### PR TITLE
[Phase 1-2] エラー型の定義

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,85 @@
+//! Error types for HOBBS.
+
+use thiserror::Error;
+
+/// Common error type for HOBBS.
+#[derive(Error, Debug)]
+pub enum HobbsError {
+    /// Database error from rusqlite.
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
+
+    /// I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Authentication error.
+    #[error("authentication error: {0}")]
+    Auth(String),
+
+    /// Permission denied error.
+    #[error("permission denied: {0}")]
+    Permission(String),
+
+    /// Validation error for user input.
+    #[error("validation error: {0}")]
+    Validation(String),
+
+    /// Resource not found.
+    #[error("{0} not found")]
+    NotFound(String),
+}
+
+/// Result type alias for HOBBS operations.
+pub type Result<T> = std::result::Result<T, HobbsError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_error_display() {
+        let err = HobbsError::Auth("invalid password".to_string());
+        assert_eq!(err.to_string(), "authentication error: invalid password");
+    }
+
+    #[test]
+    fn test_permission_error_display() {
+        let err = HobbsError::Permission("admin access required".to_string());
+        assert_eq!(err.to_string(), "permission denied: admin access required");
+    }
+
+    #[test]
+    fn test_validation_error_display() {
+        let err = HobbsError::Validation("username too long".to_string());
+        assert_eq!(err.to_string(), "validation error: username too long");
+    }
+
+    #[test]
+    fn test_not_found_error_display() {
+        let err = HobbsError::NotFound("user".to_string());
+        assert_eq!(err.to_string(), "user not found");
+    }
+
+    #[test]
+    fn test_io_error_conversion() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let err: HobbsError = io_err.into();
+        assert!(matches!(err, HobbsError::Io(_)));
+        assert!(err.to_string().contains("file not found"));
+    }
+
+    #[test]
+    fn test_result_alias() {
+        fn sample_ok() -> Result<i32> {
+            Ok(42)
+        }
+
+        fn sample_err() -> Result<i32> {
+            Err(HobbsError::Auth("test".to_string()))
+        }
+
+        assert_eq!(sample_ok().unwrap(), 42);
+        assert!(sample_err().is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,6 @@
 //!
 //! A retro BBS host program accessible via Telnet, implemented in Rust.
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+pub mod error;
+
+pub use error::{HobbsError, Result};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use tracing::info;
-use tracing_subscriber;
 
 fn main() {
     tracing_subscriber::fmt::init();


### PR DESCRIPTION
## Summary

- `src/error.rs` を作成し、`HobbsError` 列挙型を定義
- thiserror クレートを使用したエラー実装
- エラーバリアント:
  - `Database` - rusqlite::Error から自動変換
  - `Io` - std::io::Error から自動変換
  - `Auth` - 認証エラー
  - `Permission` - 権限エラー
  - `Validation` - 入力バリデーションエラー
  - `NotFound` - リソース未発見
- `Result<T>` エイリアスを定義
- main.rs の冗長なimportを削除（clippy警告対応）

## Test plan

- [x] `cargo test` - 6テスト成功
- [x] `cargo clippy` - 警告なし
- [x] `cargo fmt` - フォーマット済み

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)