### PR TITLE
[Phase 1-4] ロギング設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ target
 # Contains mutation testing data
 **/mutants.out*/
 
+# Log files
+logs/
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +480,23 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rusqlite"
@@ -733,10 +768,14 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ argon2 = "0.5"
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 thiserror = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod config;
 pub mod error;
+pub mod logging;
 
 pub use config::Config;
 pub use error::{HobbsError, Result};

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,122 @@
+//! Logging configuration and initialization for HOBBS.
+
+use std::fs::{self, File};
+use std::path::Path;
+use std::sync::Arc;
+
+use tracing::Level;
+use tracing_subscriber::fmt::writer::MakeWriterExt;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
+
+use crate::config::LoggingConfig;
+use crate::Result;
+
+/// Parse log level string to tracing Level.
+fn parse_level(level: &str) -> Level {
+    match level.to_lowercase().as_str() {
+        "trace" => Level::TRACE,
+        "debug" => Level::DEBUG,
+        "info" => Level::INFO,
+        "warn" | "warning" => Level::WARN,
+        "error" => Level::ERROR,
+        _ => Level::INFO,
+    }
+}
+
+/// Initialize the logging system with the given configuration.
+///
+/// Sets up both console output and optional file logging based on the config.
+pub fn init(config: &LoggingConfig) -> Result<()> {
+    let level = parse_level(&config.level);
+    let filter = EnvFilter::from_default_env().add_directive(level.into());
+
+    // Ensure log directory exists
+    if let Some(parent) = Path::new(&config.file).parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    // Create log file
+    let log_file = File::create(&config.file)?;
+    let log_file = Arc::new(log_file);
+
+    // Create writer that writes to both stdout and file
+    let writer = std::io::stdout.and(log_file);
+
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(writer)
+                .with_ansi(false)
+                .with_target(true)
+                .with_thread_ids(false)
+                .with_file(false)
+                .with_line_number(false),
+        )
+        .with(filter)
+        .init();
+
+    Ok(())
+}
+
+/// Initialize console-only logging (for development/testing).
+///
+/// This is a simpler initialization that only outputs to the console.
+pub fn init_console_only(level: &str) {
+    let level = parse_level(level);
+    let filter = EnvFilter::from_default_env().add_directive(level.into());
+
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stdout)
+                .with_ansi(true)
+                .with_target(true),
+        )
+        .with(filter)
+        .init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_level_trace() {
+        assert_eq!(parse_level("trace"), Level::TRACE);
+        assert_eq!(parse_level("TRACE"), Level::TRACE);
+    }
+
+    #[test]
+    fn test_parse_level_debug() {
+        assert_eq!(parse_level("debug"), Level::DEBUG);
+        assert_eq!(parse_level("DEBUG"), Level::DEBUG);
+    }
+
+    #[test]
+    fn test_parse_level_info() {
+        assert_eq!(parse_level("info"), Level::INFO);
+        assert_eq!(parse_level("INFO"), Level::INFO);
+    }
+
+    #[test]
+    fn test_parse_level_warn() {
+        assert_eq!(parse_level("warn"), Level::WARN);
+        assert_eq!(parse_level("WARN"), Level::WARN);
+        assert_eq!(parse_level("warning"), Level::WARN);
+    }
+
+    #[test]
+    fn test_parse_level_error() {
+        assert_eq!(parse_level("error"), Level::ERROR);
+        assert_eq!(parse_level("ERROR"), Level::ERROR);
+    }
+
+    #[test]
+    fn test_parse_level_default() {
+        assert_eq!(parse_level("invalid"), Level::INFO);
+        assert_eq!(parse_level(""), Level::INFO);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,28 @@
 use tracing::info;
 
+use hobbs::Config;
+
 fn main() {
-    tracing_subscriber::fmt::init();
+    // Load configuration
+    let config = match Config::load("config.toml") {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("Failed to load config.toml: {e}");
+            eprintln!("Using default configuration.");
+            Config::default()
+        }
+    };
+
+    // Initialize logging
+    if let Err(e) = hobbs::logging::init(&config.logging) {
+        eprintln!("Failed to initialize logging: {e}");
+        // Fall back to console-only logging
+        hobbs::logging::init_console_only(&config.logging.level);
+    }
+
     info!("HOBBS - Hobbyist Bulletin Board System");
+    info!(
+        "Server configured on {}:{}",
+        config.server.host, config.server.port
+    );
 }


### PR DESCRIPTION
## Summary

- `src/logging.rs` を作成し、ロギング初期化機能を実装
- tracing-subscriber を使用した設定:
  - コンソール出力（常に有効）
  - ファイル出力（config.toml で指定されたパスに出力）
  - ログレベル設定（trace, debug, info, warn, error）
  - ログディレクトリの自動作成
- `main.rs` で config.toml からロギングを初期化
- フォールバック機能（ファイル出力に失敗した場合はコンソールのみ）
- `.gitignore` に `logs/` を追加

## 動作確認

```
$ cargo run
2025-12-31T02:40:04.390594Z  INFO hobbs: HOBBS - Hobbyist Bulletin Board System
2025-12-31T02:40:04.390871Z  INFO hobbs: Server configured on 0.0.0.0:2323

$ cat logs/hobbs.log
2025-12-31T02:40:04.390594Z  INFO hobbs: HOBBS - Hobbyist Bulletin Board System
2025-12-31T02:40:04.390871Z  INFO hobbs: Server configured on 0.0.0.0:2323
```

## Test plan

- [x] `cargo test` - 18テスト成功（logging: 6, config: 6, error: 6）
- [x] `cargo clippy` - 警告なし
- [x] `cargo run` - コンソールとファイルに正しくログ出力される

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)