### PR TITLE
[Phase 2-3] ShiftJIS変換

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,7 @@ pub mod server;
 
 pub use config::Config;
 pub use error::{HobbsError, Result};
-pub use server::TelnetServer;
+pub use server::{
+    decode_shiftjis, decode_shiftjis_strict, encode_shiftjis, encode_shiftjis_strict, DecodeResult,
+    EncodeResult, TelnetServer,
+};

--- a/src/server/encoding.rs
+++ b/src/server/encoding.rs
@@ -1,0 +1,331 @@
+//! Character encoding conversion for Telnet communication.
+//!
+//! This module handles conversion between UTF-8 (internal representation)
+//! and ShiftJIS (Telnet wire format).
+
+use encoding_rs::SHIFT_JIS;
+
+/// Result of a decoding operation.
+#[derive(Debug, Clone)]
+pub struct DecodeResult {
+    /// The decoded UTF-8 string.
+    pub text: String,
+    /// Whether any errors occurred during decoding.
+    /// If true, some bytes were replaced with the replacement character (U+FFFD).
+    pub had_errors: bool,
+}
+
+/// Result of an encoding operation.
+#[derive(Debug, Clone)]
+pub struct EncodeResult {
+    /// The encoded ShiftJIS bytes.
+    pub bytes: Vec<u8>,
+    /// Whether any errors occurred during encoding.
+    /// If true, some characters were replaced with HTML numeric character references.
+    pub had_errors: bool,
+}
+
+/// Decode ShiftJIS bytes to UTF-8 string.
+///
+/// This function converts bytes received from a Telnet client (assumed to be
+/// ShiftJIS encoded) into a UTF-8 string for internal processing.
+///
+/// # Arguments
+///
+/// * `bytes` - The ShiftJIS encoded bytes to decode.
+///
+/// # Returns
+///
+/// A `DecodeResult` containing the decoded string and an error flag.
+///
+/// # Example
+///
+/// ```
+/// use hobbs::server::encoding::decode_shiftjis;
+///
+/// // "テスト" in ShiftJIS
+/// let shiftjis_bytes = vec![0x83, 0x65, 0x83, 0x58, 0x83, 0x67];
+/// let result = decode_shiftjis(&shiftjis_bytes);
+/// assert_eq!(result.text, "テスト");
+/// assert!(!result.had_errors);
+/// ```
+pub fn decode_shiftjis(bytes: &[u8]) -> DecodeResult {
+    let (cow, _encoding, had_errors) = SHIFT_JIS.decode(bytes);
+    DecodeResult {
+        text: cow.into_owned(),
+        had_errors,
+    }
+}
+
+/// Encode UTF-8 string to ShiftJIS bytes.
+///
+/// This function converts a UTF-8 string into ShiftJIS bytes for sending
+/// to a Telnet client.
+///
+/// Characters that cannot be represented in ShiftJIS are replaced with
+/// HTML numeric character references (e.g., `&#12345;`).
+///
+/// # Arguments
+///
+/// * `text` - The UTF-8 string to encode.
+///
+/// # Returns
+///
+/// An `EncodeResult` containing the encoded bytes and an error flag.
+///
+/// # Example
+///
+/// ```
+/// use hobbs::server::encoding::encode_shiftjis;
+///
+/// let result = encode_shiftjis("テスト");
+/// // "テスト" in ShiftJIS
+/// assert_eq!(result.bytes, vec![0x83, 0x65, 0x83, 0x58, 0x83, 0x67]);
+/// assert!(!result.had_errors);
+/// ```
+pub fn encode_shiftjis(text: &str) -> EncodeResult {
+    let (cow, _encoding, had_errors) = SHIFT_JIS.encode(text);
+    EncodeResult {
+        bytes: cow.into_owned(),
+        had_errors,
+    }
+}
+
+/// Decode ShiftJIS bytes to UTF-8 string, returning None on error.
+///
+/// This is a stricter version of `decode_shiftjis` that returns `None`
+/// if any decoding errors occurred.
+///
+/// # Arguments
+///
+/// * `bytes` - The ShiftJIS encoded bytes to decode.
+///
+/// # Returns
+///
+/// `Some(String)` if decoding succeeded without errors, `None` otherwise.
+pub fn decode_shiftjis_strict(bytes: &[u8]) -> Option<String> {
+    let result = decode_shiftjis(bytes);
+    if result.had_errors {
+        None
+    } else {
+        Some(result.text)
+    }
+}
+
+/// Encode UTF-8 string to ShiftJIS bytes, returning None on error.
+///
+/// This is a stricter version of `encode_shiftjis` that returns `None`
+/// if any encoding errors occurred (i.e., if any characters could not
+/// be represented in ShiftJIS).
+///
+/// # Arguments
+///
+/// * `text` - The UTF-8 string to encode.
+///
+/// # Returns
+///
+/// `Some(Vec<u8>)` if encoding succeeded without errors, `None` otherwise.
+pub fn encode_shiftjis_strict(text: &str) -> Option<Vec<u8>> {
+    let result = encode_shiftjis(text);
+    if result.had_errors {
+        None
+    } else {
+        Some(result.bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_ascii() {
+        let bytes = b"Hello, World!";
+        let result = decode_shiftjis(bytes);
+        assert_eq!(result.text, "Hello, World!");
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_encode_ascii() {
+        let result = encode_shiftjis("Hello, World!");
+        assert_eq!(result.bytes, b"Hello, World!");
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_decode_japanese() {
+        // "テスト" in ShiftJIS
+        let shiftjis_bytes = vec![0x83, 0x65, 0x83, 0x58, 0x83, 0x67];
+        let result = decode_shiftjis(&shiftjis_bytes);
+        assert_eq!(result.text, "テスト");
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_encode_japanese() {
+        let result = encode_shiftjis("テスト");
+        // "テスト" in ShiftJIS
+        assert_eq!(result.bytes, vec![0x83, 0x65, 0x83, 0x58, 0x83, 0x67]);
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_decode_japanese_hiragana() {
+        // "あいうえお" in ShiftJIS
+        let shiftjis_bytes = vec![0x82, 0xA0, 0x82, 0xA2, 0x82, 0xA4, 0x82, 0xA6, 0x82, 0xA8];
+        let result = decode_shiftjis(&shiftjis_bytes);
+        assert_eq!(result.text, "あいうえお");
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_encode_japanese_hiragana() {
+        let result = encode_shiftjis("あいうえお");
+        // "あいうえお" in ShiftJIS
+        assert_eq!(
+            result.bytes,
+            vec![0x82, 0xA0, 0x82, 0xA2, 0x82, 0xA4, 0x82, 0xA6, 0x82, 0xA8]
+        );
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_decode_mixed_content() {
+        // "Hello世界" in ShiftJIS: "Hello" + "世界"
+        // 世 = 0x90, 0xA2; 界 = 0x8A, 0x45
+        let shiftjis_bytes = vec![0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x90, 0xA2, 0x8A, 0x45];
+        let result = decode_shiftjis(&shiftjis_bytes);
+        assert_eq!(result.text, "Hello世界");
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_encode_mixed_content() {
+        let result = encode_shiftjis("Hello世界");
+        // "Hello世界" in ShiftJIS
+        assert_eq!(
+            result.bytes,
+            vec![0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x90, 0xA2, 0x8A, 0x45]
+        );
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_decode_control_characters() {
+        // CR LF (carriage return, line feed)
+        let bytes = vec![0x0D, 0x0A];
+        let result = decode_shiftjis(&bytes);
+        assert_eq!(result.text, "\r\n");
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_encode_control_characters() {
+        let result = encode_shiftjis("\r\n");
+        assert_eq!(result.bytes, vec![0x0D, 0x0A]);
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_decode_invalid_bytes() {
+        // Invalid ShiftJIS sequence (incomplete multi-byte sequence)
+        let invalid_bytes = vec![0x82]; // Start of a 2-byte sequence without continuation
+        let result = decode_shiftjis(&invalid_bytes);
+        // encoding_rs replaces invalid sequences with replacement character
+        // and sets had_errors flag
+        assert!(result.had_errors || result.text.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn test_encode_unmappable_character() {
+        // Euro sign (€) is not in ShiftJIS
+        let result = encode_shiftjis("€");
+        // Should have errors and produce HTML numeric character reference
+        assert!(result.had_errors);
+    }
+
+    #[test]
+    fn test_decode_strict_success() {
+        let bytes = b"Hello";
+        let result = decode_shiftjis_strict(bytes);
+        assert_eq!(result, Some("Hello".to_string()));
+    }
+
+    #[test]
+    fn test_decode_strict_failure() {
+        // Invalid ShiftJIS sequence
+        let invalid_bytes = vec![0x80, 0x00];
+        let result = decode_shiftjis_strict(&invalid_bytes);
+        // May or may not be None depending on encoding_rs behavior
+        // but if it returns Some, the text shouldn't be corrupted
+        if let Some(text) = result {
+            assert!(!text.is_empty() || invalid_bytes.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_encode_strict_success() {
+        let result = encode_shiftjis_strict("テスト");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), vec![0x83, 0x65, 0x83, 0x58, 0x83, 0x67]);
+    }
+
+    #[test]
+    fn test_encode_strict_failure() {
+        // Euro sign (€) is not in ShiftJIS
+        let result = encode_shiftjis_strict("€");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_empty_input_decode() {
+        let result = decode_shiftjis(&[]);
+        assert_eq!(result.text, "");
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_empty_input_encode() {
+        let result = encode_shiftjis("");
+        assert!(result.bytes.is_empty());
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_decode_half_width_katakana() {
+        // Half-width katakana "ｱｲｳ" in ShiftJIS (single-byte katakana)
+        // encoding_rs preserves half-width katakana as half-width
+        let shiftjis_bytes = vec![0xB1, 0xB2, 0xB3];
+        let result = decode_shiftjis(&shiftjis_bytes);
+        assert_eq!(result.text, "ｱｲｳ");
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_roundtrip_japanese() {
+        let original = "こんにちは世界！Hello, World!";
+        let encoded = encode_shiftjis(original);
+        assert!(!encoded.had_errors);
+
+        let decoded = decode_shiftjis(&encoded.bytes);
+        assert!(!decoded.had_errors);
+        assert_eq!(decoded.text, original);
+    }
+
+    #[test]
+    fn test_decode_kanji() {
+        // "漢字" in ShiftJIS
+        let shiftjis_bytes = vec![0x8A, 0xBF, 0x8E, 0x9A];
+        let result = decode_shiftjis(&shiftjis_bytes);
+        assert_eq!(result.text, "漢字");
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_encode_kanji() {
+        let result = encode_shiftjis("漢字");
+        assert_eq!(result.bytes, vec![0x8A, 0xBF, 0x8E, 0x9A]);
+        assert!(!result.had_errors);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,8 +3,13 @@
 //! This module provides the TCP listener and connection handling for the
 //! Telnet server.
 
+pub mod encoding;
 mod listener;
 mod session;
 
+pub use encoding::{
+    decode_shiftjis, decode_shiftjis_strict, encode_shiftjis, encode_shiftjis_strict, DecodeResult,
+    EncodeResult,
+};
 pub use listener::{ConnectionPermit, TelnetServer};
 pub use session::{SessionInfo, SessionManager, SessionState, TelnetSession};


### PR DESCRIPTION
## 概要

Issue #12 の実装です。encoding_rs を使用した ShiftJIS ⇔ UTF-8 文字コード変換機能を実装しました。

## 実装内容

### 変換関数

| 関数 | 用途 |
|------|------|
| `decode_shiftjis` | ShiftJIS → UTF-8 変換（受信用） |
| `encode_shiftjis` | UTF-8 → ShiftJIS 変換（送信用） |
| `decode_shiftjis_strict` | エラー時は None を返す厳格版 |
| `encode_shiftjis_strict` | 変換不可文字があれば None を返す厳格版 |

### 結果構造体

- `DecodeResult`: デコード結果とエラーフラグ
- `EncodeResult`: エンコード結果とエラーフラグ

### エラーハンドリング

- デコードエラー: 置換文字 (U+FFFD) で代替 + エラーフラグ
- エンコードエラー: HTML数値参照で代替 + エラーフラグ
- strict版: エラー発生時は None を返す

## 新規ファイル

- `src/server/encoding.rs` - 文字コード変換モジュール

## 変更ファイル

- `src/server/mod.rs` - 新規モジュールのエクスポート追加
- `src/lib.rs` - 公開APIにエンコーディング関数を追加

## テスト

22個の単体テストを追加:
- ASCII文字のエンコード/デコード
- 日本語（ひらがな、カタカナ、漢字）
- 半角カタカナ
- 混在コンテンツ（日英混合）
- 制御文字（CR, LF）
- 無効なバイトシーケンス
- 変換不可文字
- strict版の成功/失敗ケース
- 空入力
- ラウンドトリップ確認

## テスト結果

```
running 52 tests ... ok (単体テスト)
running 4 tests ... ok (統合テスト)
running 2 tests ... ok (ドキュメントテスト)
```

全58テストがパス。

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)