### PR TITLE
feat: ユーザーリポジトリを実装

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,9 +2,13 @@
 //!
 //! This module provides SQLite database connectivity and migration management.
 
+mod repository;
 mod schema;
+mod user;
 
+pub use repository::UserRepository;
 pub use schema::MIGRATIONS;
+pub use user::{NewUser, Role, User, UserUpdate};
 
 use std::path::Path;
 

--- a/src/db/repository.rs
+++ b/src/db/repository.rs
@@ -1,0 +1,526 @@
+//! User repository for HOBBS.
+//!
+//! This module provides CRUD operations for users in the database.
+
+use rusqlite::{params, Row};
+
+use super::user::{NewUser, Role, User, UserUpdate};
+use super::Database;
+use crate::{HobbsError, Result};
+
+/// Repository for user CRUD operations.
+pub struct UserRepository<'a> {
+    db: &'a Database,
+}
+
+impl<'a> UserRepository<'a> {
+    /// Create a new UserRepository with the given database reference.
+    pub fn new(db: &'a Database) -> Self {
+        Self { db }
+    }
+
+    /// Create a new user in the database.
+    ///
+    /// Returns the created user with the assigned ID.
+    pub fn create(&self, new_user: &NewUser) -> Result<User> {
+        self.db.conn().execute(
+            "INSERT INTO users (username, password, nickname, email, role, terminal)
+             VALUES (?, ?, ?, ?, ?, ?)",
+            params![
+                &new_user.username,
+                &new_user.password,
+                &new_user.nickname,
+                &new_user.email,
+                new_user.role.as_str(),
+                &new_user.terminal,
+            ],
+        )?;
+
+        let id = self.db.conn().last_insert_rowid();
+        self.get_by_id(id)?
+            .ok_or_else(|| HobbsError::NotFound("user".to_string()))
+    }
+
+    /// Get a user by ID.
+    pub fn get_by_id(&self, id: i64) -> Result<Option<User>> {
+        let result = self.db.conn().query_row(
+            "SELECT id, username, password, nickname, email, role, profile, terminal,
+                    created_at, last_login, is_active
+             FROM users WHERE id = ?",
+            [id],
+            Self::row_to_user,
+        );
+
+        match result {
+            Ok(user) => Ok(Some(user)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Get a user by username.
+    pub fn get_by_username(&self, username: &str) -> Result<Option<User>> {
+        let result = self.db.conn().query_row(
+            "SELECT id, username, password, nickname, email, role, profile, terminal,
+                    created_at, last_login, is_active
+             FROM users WHERE username = ?",
+            [username],
+            Self::row_to_user,
+        );
+
+        match result {
+            Ok(user) => Ok(Some(user)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Update a user by ID.
+    ///
+    /// Only fields that are set in the update will be modified.
+    /// Returns the updated user, or None if not found.
+    pub fn update(&self, id: i64, update: &UserUpdate) -> Result<Option<User>> {
+        if update.is_empty() {
+            return self.get_by_id(id);
+        }
+
+        let mut fields = Vec::new();
+        let mut values: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+        if let Some(ref password) = update.password {
+            fields.push("password = ?");
+            values.push(Box::new(password.clone()));
+        }
+        if let Some(ref nickname) = update.nickname {
+            fields.push("nickname = ?");
+            values.push(Box::new(nickname.clone()));
+        }
+        if let Some(ref email) = update.email {
+            fields.push("email = ?");
+            values.push(Box::new(email.clone()));
+        }
+        if let Some(role) = update.role {
+            fields.push("role = ?");
+            values.push(Box::new(role.as_str().to_string()));
+        }
+        if let Some(ref profile) = update.profile {
+            fields.push("profile = ?");
+            values.push(Box::new(profile.clone()));
+        }
+        if let Some(ref terminal) = update.terminal {
+            fields.push("terminal = ?");
+            values.push(Box::new(terminal.clone()));
+        }
+        if let Some(is_active) = update.is_active {
+            fields.push("is_active = ?");
+            values.push(Box::new(if is_active { 1i64 } else { 0i64 }));
+        }
+
+        let sql = format!("UPDATE users SET {} WHERE id = ?", fields.join(", "));
+        values.push(Box::new(id));
+
+        let params: Vec<&dyn rusqlite::ToSql> = values.iter().map(|v| v.as_ref()).collect();
+        let affected = self.db.conn().execute(&sql, params.as_slice())?;
+
+        if affected == 0 {
+            return Ok(None);
+        }
+
+        self.get_by_id(id)
+    }
+
+    /// Update the last login timestamp for a user.
+    pub fn update_last_login(&self, id: i64) -> Result<()> {
+        self.db.conn().execute(
+            "UPDATE users SET last_login = datetime('now') WHERE id = ?",
+            [id],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a user by ID.
+    ///
+    /// Returns true if a user was deleted, false if not found.
+    pub fn delete(&self, id: i64) -> Result<bool> {
+        let affected = self.db.conn().execute("DELETE FROM users WHERE id = ?", [id])?;
+        Ok(affected > 0)
+    }
+
+    /// List all active users.
+    pub fn list_active(&self) -> Result<Vec<User>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, username, password, nickname, email, role, profile, terminal,
+                    created_at, last_login, is_active
+             FROM users WHERE is_active = 1 ORDER BY username",
+        )?;
+
+        let users = stmt
+            .query_map([], Self::row_to_user)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(users)
+    }
+
+    /// List all users (including inactive).
+    pub fn list_all(&self) -> Result<Vec<User>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, username, password, nickname, email, role, profile, terminal,
+                    created_at, last_login, is_active
+             FROM users ORDER BY username",
+        )?;
+
+        let users = stmt
+            .query_map([], Self::row_to_user)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(users)
+    }
+
+    /// List users by role.
+    pub fn list_by_role(&self, role: Role) -> Result<Vec<User>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, username, password, nickname, email, role, profile, terminal,
+                    created_at, last_login, is_active
+             FROM users WHERE role = ? AND is_active = 1 ORDER BY username",
+        )?;
+
+        let users = stmt
+            .query_map([role.as_str()], Self::row_to_user)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(users)
+    }
+
+    /// Count all users.
+    pub fn count(&self) -> Result<i64> {
+        let count: i64 = self
+            .db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM users", [], |row| row.get(0))?;
+        Ok(count)
+    }
+
+    /// Count active users.
+    pub fn count_active(&self) -> Result<i64> {
+        let count: i64 = self
+            .db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM users WHERE is_active = 1", [], |row| {
+                row.get(0)
+            })?;
+        Ok(count)
+    }
+
+    /// Check if a username is already taken.
+    pub fn username_exists(&self, username: &str) -> Result<bool> {
+        let exists: bool = self.db.conn().query_row(
+            "SELECT EXISTS(SELECT 1 FROM users WHERE username = ?)",
+            [username],
+            |row| row.get(0),
+        )?;
+        Ok(exists)
+    }
+
+    /// Convert a database row to a User struct.
+    fn row_to_user(row: &Row<'_>) -> rusqlite::Result<User> {
+        let role_str: String = row.get(5)?;
+        let role = role_str.parse().unwrap_or(Role::Member);
+        let is_active: i64 = row.get(10)?;
+
+        Ok(User {
+            id: row.get(0)?,
+            username: row.get(1)?,
+            password: row.get(2)?,
+            nickname: row.get(3)?,
+            email: row.get(4)?,
+            role,
+            profile: row.get(6)?,
+            terminal: row.get(7)?,
+            created_at: row.get(8)?,
+            last_login: row.get(9)?,
+            is_active: is_active != 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    #[test]
+    fn test_create_user() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let new_user = NewUser::new("testuser", "hashedpw", "Test User");
+        let user = repo.create(&new_user).unwrap();
+
+        assert_eq!(user.id, 1);
+        assert_eq!(user.username, "testuser");
+        assert_eq!(user.nickname, "Test User");
+        assert_eq!(user.role, Role::Member);
+        assert!(user.is_active);
+    }
+
+    #[test]
+    fn test_create_user_with_options() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let new_user = NewUser::new("admin", "hashedpw", "Administrator")
+            .with_email("admin@example.com")
+            .with_role(Role::SysOp)
+            .with_terminal("c64");
+
+        let user = repo.create(&new_user).unwrap();
+
+        assert_eq!(user.username, "admin");
+        assert_eq!(user.email, Some("admin@example.com".to_string()));
+        assert_eq!(user.role, Role::SysOp);
+        assert_eq!(user.terminal, "c64");
+    }
+
+    #[test]
+    fn test_create_duplicate_username() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let new_user = NewUser::new("testuser", "hashedpw", "Test User");
+        repo.create(&new_user).unwrap();
+
+        let duplicate = NewUser::new("testuser", "otherpw", "Other User");
+        let result = repo.create(&duplicate);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_by_id() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let new_user = NewUser::new("testuser", "hashedpw", "Test User");
+        let created = repo.create(&new_user).unwrap();
+
+        let found = repo.get_by_id(created.id).unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().username, "testuser");
+
+        let not_found = repo.get_by_id(999).unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn test_get_by_username() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let new_user = NewUser::new("testuser", "hashedpw", "Test User");
+        repo.create(&new_user).unwrap();
+
+        let found = repo.get_by_username("testuser").unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().nickname, "Test User");
+
+        let not_found = repo.get_by_username("nonexistent").unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn test_update_user() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let new_user = NewUser::new("testuser", "hashedpw", "Test User");
+        let user = repo.create(&new_user).unwrap();
+
+        let update = UserUpdate::new()
+            .nickname("Updated Name")
+            .email(Some("new@example.com".to_string()))
+            .role(Role::SubOp);
+
+        let updated = repo.update(user.id, &update).unwrap().unwrap();
+
+        assert_eq!(updated.nickname, "Updated Name");
+        assert_eq!(updated.email, Some("new@example.com".to_string()));
+        assert_eq!(updated.role, Role::SubOp);
+        // Unchanged fields
+        assert_eq!(updated.username, "testuser");
+        assert_eq!(updated.password, "hashedpw");
+    }
+
+    #[test]
+    fn test_update_nonexistent_user() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let update = UserUpdate::new().nickname("New Name");
+        let result = repo.update(999, &update).unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_update_empty() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let new_user = NewUser::new("testuser", "hashedpw", "Test User");
+        let user = repo.create(&new_user).unwrap();
+
+        let update = UserUpdate::new();
+        let result = repo.update(user.id, &update).unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().nickname, "Test User");
+    }
+
+    #[test]
+    fn test_update_is_active() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let new_user = NewUser::new("testuser", "hashedpw", "Test User");
+        let user = repo.create(&new_user).unwrap();
+        assert!(user.is_active);
+
+        let update = UserUpdate::new().is_active(false);
+        let updated = repo.update(user.id, &update).unwrap().unwrap();
+
+        assert!(!updated.is_active);
+    }
+
+    #[test]
+    fn test_update_last_login() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let new_user = NewUser::new("testuser", "hashedpw", "Test User");
+        let user = repo.create(&new_user).unwrap();
+        assert!(user.last_login.is_none());
+
+        repo.update_last_login(user.id).unwrap();
+
+        let updated = repo.get_by_id(user.id).unwrap().unwrap();
+        assert!(updated.last_login.is_some());
+    }
+
+    #[test]
+    fn test_delete_user() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        let new_user = NewUser::new("testuser", "hashedpw", "Test User");
+        let user = repo.create(&new_user).unwrap();
+
+        let deleted = repo.delete(user.id).unwrap();
+        assert!(deleted);
+
+        let found = repo.get_by_id(user.id).unwrap();
+        assert!(found.is_none());
+
+        // Deleting again should return false
+        let deleted_again = repo.delete(user.id).unwrap();
+        assert!(!deleted_again);
+    }
+
+    #[test]
+    fn test_list_active() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        // Create some users
+        repo.create(&NewUser::new("user1", "pw", "User 1")).unwrap();
+        let user2 = repo.create(&NewUser::new("user2", "pw", "User 2")).unwrap();
+        repo.create(&NewUser::new("user3", "pw", "User 3")).unwrap();
+
+        // Deactivate user2
+        repo.update(user2.id, &UserUpdate::new().is_active(false))
+            .unwrap();
+
+        let active = repo.list_active().unwrap();
+        assert_eq!(active.len(), 2);
+        assert!(active.iter().all(|u| u.username != "user2"));
+    }
+
+    #[test]
+    fn test_list_all() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        repo.create(&NewUser::new("user1", "pw", "User 1")).unwrap();
+        let user2 = repo.create(&NewUser::new("user2", "pw", "User 2")).unwrap();
+        repo.create(&NewUser::new("user3", "pw", "User 3")).unwrap();
+
+        // Deactivate user2
+        repo.update(user2.id, &UserUpdate::new().is_active(false))
+            .unwrap();
+
+        let all = repo.list_all().unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn test_list_by_role() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        repo.create(&NewUser::new("member1", "pw", "Member 1")).unwrap();
+        repo.create(&NewUser::new("member2", "pw", "Member 2")).unwrap();
+        repo.create(
+            &NewUser::new("subop", "pw", "SubOp").with_role(Role::SubOp),
+        )
+        .unwrap();
+        repo.create(
+            &NewUser::new("sysop", "pw", "SysOp").with_role(Role::SysOp),
+        )
+        .unwrap();
+
+        let members = repo.list_by_role(Role::Member).unwrap();
+        assert_eq!(members.len(), 2);
+
+        let subops = repo.list_by_role(Role::SubOp).unwrap();
+        assert_eq!(subops.len(), 1);
+
+        let sysops = repo.list_by_role(Role::SysOp).unwrap();
+        assert_eq!(sysops.len(), 1);
+    }
+
+    #[test]
+    fn test_count() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        assert_eq!(repo.count().unwrap(), 0);
+        assert_eq!(repo.count_active().unwrap(), 0);
+
+        repo.create(&NewUser::new("user1", "pw", "User 1")).unwrap();
+        let user2 = repo.create(&NewUser::new("user2", "pw", "User 2")).unwrap();
+
+        assert_eq!(repo.count().unwrap(), 2);
+        assert_eq!(repo.count_active().unwrap(), 2);
+
+        repo.update(user2.id, &UserUpdate::new().is_active(false))
+            .unwrap();
+
+        assert_eq!(repo.count().unwrap(), 2);
+        assert_eq!(repo.count_active().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_username_exists() {
+        let db = setup_db();
+        let repo = UserRepository::new(&db);
+
+        assert!(!repo.username_exists("testuser").unwrap());
+
+        repo.create(&NewUser::new("testuser", "pw", "Test")).unwrap();
+
+        assert!(repo.username_exists("testuser").unwrap());
+        assert!(!repo.username_exists("other").unwrap());
+    }
+}

--- a/src/db/user.rs
+++ b/src/db/user.rs
@@ -1,0 +1,354 @@
+//! User model for HOBBS.
+//!
+//! This module defines the User struct and Role enum for user management.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// User role for permission management.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum Role {
+    /// Guest user (not registered).
+    Guest = 0,
+    /// Regular member.
+    #[default]
+    Member = 1,
+    /// Sub-operator (moderator).
+    SubOp = 2,
+    /// System operator (administrator).
+    SysOp = 3,
+}
+
+impl Role {
+    /// Convert role to database string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Role::Guest => "guest",
+            Role::Member => "member",
+            Role::SubOp => "subop",
+            Role::SysOp => "sysop",
+        }
+    }
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for Role {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "guest" => Ok(Role::Guest),
+            "member" => Ok(Role::Member),
+            "subop" => Ok(Role::SubOp),
+            "sysop" => Ok(Role::SysOp),
+            _ => Err(format!("unknown role: {s}")),
+        }
+    }
+}
+
+/// User entity representing a registered user.
+#[derive(Debug, Clone)]
+pub struct User {
+    /// Unique user ID.
+    pub id: i64,
+    /// Login username (unique).
+    pub username: String,
+    /// Password hash (Argon2).
+    pub password: String,
+    /// Display name / handle.
+    pub nickname: String,
+    /// Email address (optional).
+    pub email: Option<String>,
+    /// User role for permissions.
+    pub role: Role,
+    /// Self-introduction text (optional).
+    pub profile: Option<String>,
+    /// Terminal profile preference.
+    pub terminal: String,
+    /// Account creation timestamp.
+    pub created_at: String,
+    /// Last login timestamp (optional).
+    pub last_login: Option<String>,
+    /// Whether the account is active.
+    pub is_active: bool,
+}
+
+impl User {
+    /// Check if this user has at least the required role level.
+    pub fn has_role(&self, required: Role) -> bool {
+        self.role >= required
+    }
+
+    /// Check if this user is a system operator.
+    pub fn is_sysop(&self) -> bool {
+        self.role == Role::SysOp
+    }
+
+    /// Check if this user is a sub-operator or higher.
+    pub fn is_operator(&self) -> bool {
+        self.role >= Role::SubOp
+    }
+}
+
+/// Data for creating a new user.
+#[derive(Debug, Clone)]
+pub struct NewUser {
+    /// Login username.
+    pub username: String,
+    /// Password hash (should be pre-hashed with Argon2).
+    pub password: String,
+    /// Display name / handle.
+    pub nickname: String,
+    /// Email address (optional).
+    pub email: Option<String>,
+    /// User role (defaults to Member).
+    pub role: Role,
+    /// Terminal profile preference (defaults to "standard").
+    pub terminal: String,
+}
+
+impl NewUser {
+    /// Create a new user with minimal required fields.
+    pub fn new(username: impl Into<String>, password: impl Into<String>, nickname: impl Into<String>) -> Self {
+        Self {
+            username: username.into(),
+            password: password.into(),
+            nickname: nickname.into(),
+            email: None,
+            role: Role::Member,
+            terminal: "standard".to_string(),
+        }
+    }
+
+    /// Set the email address.
+    pub fn with_email(mut self, email: impl Into<String>) -> Self {
+        self.email = Some(email.into());
+        self
+    }
+
+    /// Set the role.
+    pub fn with_role(mut self, role: Role) -> Self {
+        self.role = role;
+        self
+    }
+
+    /// Set the terminal profile.
+    pub fn with_terminal(mut self, terminal: impl Into<String>) -> Self {
+        self.terminal = terminal.into();
+        self
+    }
+}
+
+/// Data for updating an existing user.
+#[derive(Debug, Clone, Default)]
+pub struct UserUpdate {
+    /// New password hash (if changing password).
+    pub password: Option<String>,
+    /// New nickname.
+    pub nickname: Option<String>,
+    /// New email address.
+    pub email: Option<Option<String>>,
+    /// New role.
+    pub role: Option<Role>,
+    /// New profile text.
+    pub profile: Option<Option<String>>,
+    /// New terminal preference.
+    pub terminal: Option<String>,
+    /// New active status.
+    pub is_active: Option<bool>,
+}
+
+impl UserUpdate {
+    /// Create an empty update.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set new password.
+    pub fn password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
+        self
+    }
+
+    /// Set new nickname.
+    pub fn nickname(mut self, nickname: impl Into<String>) -> Self {
+        self.nickname = Some(nickname.into());
+        self
+    }
+
+    /// Set new email.
+    pub fn email(mut self, email: Option<String>) -> Self {
+        self.email = Some(email);
+        self
+    }
+
+    /// Set new role.
+    pub fn role(mut self, role: Role) -> Self {
+        self.role = Some(role);
+        self
+    }
+
+    /// Set new profile.
+    pub fn profile(mut self, profile: Option<String>) -> Self {
+        self.profile = Some(profile);
+        self
+    }
+
+    /// Set new terminal preference.
+    pub fn terminal(mut self, terminal: impl Into<String>) -> Self {
+        self.terminal = Some(terminal.into());
+        self
+    }
+
+    /// Set active status.
+    pub fn is_active(mut self, is_active: bool) -> Self {
+        self.is_active = Some(is_active);
+        self
+    }
+
+    /// Check if any fields are set.
+    pub fn is_empty(&self) -> bool {
+        self.password.is_none()
+            && self.nickname.is_none()
+            && self.email.is_none()
+            && self.role.is_none()
+            && self.profile.is_none()
+            && self.terminal.is_none()
+            && self.is_active.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_role_ordering() {
+        assert!(Role::Guest < Role::Member);
+        assert!(Role::Member < Role::SubOp);
+        assert!(Role::SubOp < Role::SysOp);
+    }
+
+    #[test]
+    fn test_role_from_str() {
+        assert_eq!(Role::from_str("guest").unwrap(), Role::Guest);
+        assert_eq!(Role::from_str("member").unwrap(), Role::Member);
+        assert_eq!(Role::from_str("subop").unwrap(), Role::SubOp);
+        assert_eq!(Role::from_str("sysop").unwrap(), Role::SysOp);
+        assert_eq!(Role::from_str("SYSOP").unwrap(), Role::SysOp);
+        assert!(Role::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_role_as_str() {
+        assert_eq!(Role::Guest.as_str(), "guest");
+        assert_eq!(Role::Member.as_str(), "member");
+        assert_eq!(Role::SubOp.as_str(), "subop");
+        assert_eq!(Role::SysOp.as_str(), "sysop");
+    }
+
+    #[test]
+    fn test_role_display() {
+        assert_eq!(format!("{}", Role::SysOp), "sysop");
+    }
+
+    #[test]
+    fn test_role_default() {
+        assert_eq!(Role::default(), Role::Member);
+    }
+
+    #[test]
+    fn test_new_user_builder() {
+        let user = NewUser::new("testuser", "hash", "Test User")
+            .with_email("test@example.com")
+            .with_role(Role::SubOp)
+            .with_terminal("c64");
+
+        assert_eq!(user.username, "testuser");
+        assert_eq!(user.password, "hash");
+        assert_eq!(user.nickname, "Test User");
+        assert_eq!(user.email, Some("test@example.com".to_string()));
+        assert_eq!(user.role, Role::SubOp);
+        assert_eq!(user.terminal, "c64");
+    }
+
+    #[test]
+    fn test_user_update_builder() {
+        let update = UserUpdate::new()
+            .nickname("New Name")
+            .role(Role::SubOp)
+            .is_active(false);
+
+        assert!(update.nickname.is_some());
+        assert!(update.role.is_some());
+        assert!(update.is_active.is_some());
+        assert!(update.password.is_none());
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_user_update_empty() {
+        let update = UserUpdate::new();
+        assert!(update.is_empty());
+    }
+
+    #[test]
+    fn test_user_has_role() {
+        let user = User {
+            id: 1,
+            username: "test".to_string(),
+            password: "hash".to_string(),
+            nickname: "Test".to_string(),
+            email: None,
+            role: Role::SubOp,
+            profile: None,
+            terminal: "standard".to_string(),
+            created_at: "2024-01-01".to_string(),
+            last_login: None,
+            is_active: true,
+        };
+
+        assert!(user.has_role(Role::Guest));
+        assert!(user.has_role(Role::Member));
+        assert!(user.has_role(Role::SubOp));
+        assert!(!user.has_role(Role::SysOp));
+    }
+
+    #[test]
+    fn test_user_is_operator() {
+        let member = User {
+            id: 1,
+            username: "member".to_string(),
+            password: "hash".to_string(),
+            nickname: "Member".to_string(),
+            email: None,
+            role: Role::Member,
+            profile: None,
+            terminal: "standard".to_string(),
+            created_at: "2024-01-01".to_string(),
+            last_login: None,
+            is_active: true,
+        };
+
+        let subop = User {
+            role: Role::SubOp,
+            ..member.clone()
+        };
+
+        let sysop = User {
+            role: Role::SysOp,
+            ..member.clone()
+        };
+
+        assert!(!member.is_operator());
+        assert!(subop.is_operator());
+        assert!(sysop.is_operator());
+        assert!(!subop.is_sysop());
+        assert!(sysop.is_sysop());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod server;
 pub mod terminal;
 
 pub use config::Config;
-pub use db::Database;
+pub use db::{Database, NewUser, Role, User, UserRepository, UserUpdate};
 pub use error::{HobbsError, Result};
 pub use server::{
     decode_shiftjis, decode_shiftjis_strict, encode_shiftjis, encode_shiftjis_strict,


### PR DESCRIPTION
## Summary

- ユーザーの CRUD 操作を提供する UserRepository を実装
- Role 列挙型とUser/NewUser/UserUpdate 構造体を追加

## Changes

### 新規ファイル
- `src/db/user.rs` - ユーザーモデル定義
- `src/db/repository.rs` - UserRepository（CRUD操作）

### Role 列挙型
| 値 | 説明 |
|----|------|
| Guest (0) | ゲスト（未登録） |
| Member (1) | 一般会員（デフォルト） |
| SubOp (2) | 副管理者 |
| SysOp (3) | システム管理者 |

### UserRepository メソッド
| メソッド | 機能 |
|----------|------|
| `create()` | ユーザー作成 |
| `get_by_id()` | ID でユーザー取得 |
| `get_by_username()` | ユーザー名でユーザー取得 |
| `update()` | ユーザー更新（部分更新対応） |
| `update_last_login()` | 最終ログイン日時更新 |
| `delete()` | ユーザー削除 |
| `list_active()` | アクティブユーザー一覧 |
| `list_all()` | 全ユーザー一覧 |
| `list_by_role()` | ロール別ユーザー一覧 |
| `count()`, `count_active()` | ユーザー数取得 |
| `username_exists()` | ユーザー名重複チェック |

## Test plan

- [x] `cargo test` - 143件の全テストがパス（うち新規26件）
- [x] `cargo clippy` - 警告なし
- [x] CRUD操作の単体テスト
- [x] 重複ユーザー名の検出テスト
- [x] 部分更新テスト

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)