### PR TITLE
[Phase 3-5] 新規登録

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,14 +1,18 @@
 //! Authentication module for HOBBS.
 //!
 //! This module provides password hashing, session management,
-//! and authentication utilities.
+//! user registration, and authentication utilities.
 
 mod password;
+mod registration;
 mod session;
+pub mod validation;
 
 pub use password::{hash_password, validate_password, verify_password, PasswordError};
+pub use registration::{register, register_with_role, RegistrationError, RegistrationRequest};
 pub use session::{
     AuthSession, LimitResult, LoginLimiter, SessionError, SessionManager,
     DEFAULT_IDLE_TIMEOUT_SECS, DEFAULT_SESSION_DURATION_SECS, LOCKOUT_DURATION_SECS,
     MAX_LOGIN_ATTEMPTS,
 };
+pub use validation::ValidationError;

--- a/src/auth/registration.rs
+++ b/src/auth/registration.rs
@@ -1,0 +1,380 @@
+//! User registration for HOBBS.
+//!
+//! This module provides the user registration functionality.
+
+use thiserror::Error;
+use tracing::info;
+
+use crate::auth::validation::{validate_registration, ValidationError};
+use crate::auth::{hash_password, PasswordError};
+use crate::db::{NewUser, Role, User, UserRepository};
+
+/// Registration-specific errors.
+#[derive(Error, Debug)]
+pub enum RegistrationError {
+    /// Validation failed.
+    #[error("validation error: {0}")]
+    Validation(#[from] ValidationError),
+
+    /// Username already exists.
+    #[error("username already exists")]
+    UsernameExists,
+
+    /// Password hashing failed.
+    #[error("password error: {0}")]
+    Password(#[from] PasswordError),
+
+    /// Database error.
+    #[error("database error: {0}")]
+    Database(String),
+}
+
+/// Registration request data.
+#[derive(Debug, Clone)]
+pub struct RegistrationRequest {
+    /// Desired username (4-16 alphanumeric + underscore).
+    pub username: String,
+    /// Password (8-128 characters).
+    pub password: String,
+    /// Display nickname (1-20 characters).
+    pub nickname: String,
+    /// Optional email address.
+    pub email: Option<String>,
+    /// Optional terminal profile.
+    pub terminal: Option<String>,
+}
+
+impl RegistrationRequest {
+    /// Create a new registration request.
+    pub fn new(
+        username: impl Into<String>,
+        password: impl Into<String>,
+        nickname: impl Into<String>,
+    ) -> Self {
+        Self {
+            username: username.into(),
+            password: password.into(),
+            nickname: nickname.into(),
+            email: None,
+            terminal: None,
+        }
+    }
+
+    /// Set the email address.
+    pub fn with_email(mut self, email: impl Into<String>) -> Self {
+        self.email = Some(email.into());
+        self
+    }
+
+    /// Set the terminal profile.
+    pub fn with_terminal(mut self, terminal: impl Into<String>) -> Self {
+        self.terminal = Some(terminal.into());
+        self
+    }
+}
+
+/// Register a new user.
+///
+/// This function:
+/// 1. Validates all input fields
+/// 2. Checks if the username already exists
+/// 3. Hashes the password
+/// 4. Creates the user in the database
+///
+/// # Arguments
+///
+/// * `repo` - The user repository
+/// * `request` - Registration request data
+///
+/// # Returns
+///
+/// The newly created user on success, or a `RegistrationError` on failure.
+///
+/// # Examples
+///
+/// ```ignore
+/// use hobbs::auth::registration::{register, RegistrationRequest};
+/// use hobbs::db::{Database, UserRepository};
+///
+/// let db = Database::open_in_memory()?;
+/// let repo = UserRepository::new(db.conn());
+///
+/// let request = RegistrationRequest::new("john_doe", "password123", "John Doe")
+///     .with_email("john@example.com");
+///
+/// let user = register(&repo, request)?;
+/// println!("Registered user: {}", user.username);
+/// ```
+pub fn register(
+    repo: &UserRepository,
+    request: RegistrationRequest,
+) -> std::result::Result<User, RegistrationError> {
+    // 1. Validate all fields
+    validate_registration(
+        &request.username,
+        &request.password,
+        &request.nickname,
+        request.email.as_deref(),
+    )?;
+
+    // 2. Check if username already exists
+    if repo
+        .username_exists(&request.username)
+        .map_err(|e| RegistrationError::Database(e.to_string()))?
+    {
+        return Err(RegistrationError::UsernameExists);
+    }
+
+    // 3. Hash the password
+    let password_hash = hash_password(&request.password)?;
+
+    // 4. Create the user
+    let mut new_user = NewUser::new(&request.username, &password_hash, &request.nickname);
+
+    if let Some(ref email) = request.email {
+        new_user = new_user.with_email(email);
+    }
+
+    if let Some(ref terminal) = request.terminal {
+        new_user = new_user.with_terminal(terminal);
+    }
+
+    let user = repo
+        .create(&new_user)
+        .map_err(|e| RegistrationError::Database(e.to_string()))?;
+
+    info!(
+        username = %user.username,
+        user_id = user.id,
+        "New user registered"
+    );
+
+    Ok(user)
+}
+
+/// Register a new user with a specific role.
+///
+/// This is typically used for creating the initial SysOp account.
+///
+/// # Arguments
+///
+/// * `repo` - The user repository
+/// * `request` - Registration request data
+/// * `role` - The role to assign to the new user
+pub fn register_with_role(
+    repo: &UserRepository,
+    request: RegistrationRequest,
+    role: Role,
+) -> std::result::Result<User, RegistrationError> {
+    // 1. Validate all fields
+    validate_registration(
+        &request.username,
+        &request.password,
+        &request.nickname,
+        request.email.as_deref(),
+    )?;
+
+    // 2. Check if username already exists
+    if repo
+        .username_exists(&request.username)
+        .map_err(|e| RegistrationError::Database(e.to_string()))?
+    {
+        return Err(RegistrationError::UsernameExists);
+    }
+
+    // 3. Hash the password
+    let password_hash = hash_password(&request.password)?;
+
+    // 4. Create the user with specified role
+    let mut new_user =
+        NewUser::new(&request.username, &password_hash, &request.nickname).with_role(role);
+
+    if let Some(ref email) = request.email {
+        new_user = new_user.with_email(email);
+    }
+
+    if let Some(ref terminal) = request.terminal {
+        new_user = new_user.with_terminal(terminal);
+    }
+
+    let user = repo
+        .create(&new_user)
+        .map_err(|e| RegistrationError::Database(e.to_string()))?;
+
+    info!(
+        username = %user.username,
+        user_id = user.id,
+        role = %role,
+        "New user registered with role"
+    );
+
+    Ok(user)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    #[test]
+    fn test_register_success() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = UserRepository::new(&db);
+
+        let request = RegistrationRequest::new("testuser", "password123", "Test User");
+        let result = register(&repo, request);
+
+        assert!(result.is_ok());
+        let user = result.unwrap();
+        assert_eq!(user.username, "testuser");
+        assert_eq!(user.nickname, "Test User");
+        assert_eq!(user.role, Role::Member);
+        assert!(user.is_active);
+    }
+
+    #[test]
+    fn test_register_with_email() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = UserRepository::new(&db);
+
+        let request = RegistrationRequest::new("testuser", "password123", "Test User")
+            .with_email("test@example.com");
+        let result = register(&repo, request);
+
+        assert!(result.is_ok());
+        let user = result.unwrap();
+        assert_eq!(user.email, Some("test@example.com".to_string()));
+    }
+
+    #[test]
+    fn test_register_with_terminal() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = UserRepository::new(&db);
+
+        let request =
+            RegistrationRequest::new("testuser", "password123", "Test User").with_terminal("c64");
+        let result = register(&repo, request);
+
+        assert!(result.is_ok());
+        let user = result.unwrap();
+        assert_eq!(user.terminal, "c64");
+    }
+
+    #[test]
+    fn test_register_duplicate_username() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = UserRepository::new(&db);
+
+        // Register first user
+        let request1 = RegistrationRequest::new("testuser", "password123", "Test User 1");
+        register(&repo, request1).unwrap();
+
+        // Try to register with same username
+        let request2 = RegistrationRequest::new("testuser", "password456", "Test User 2");
+        let result = register(&repo, request2);
+
+        assert!(matches!(result, Err(RegistrationError::UsernameExists)));
+    }
+
+    #[test]
+    fn test_register_invalid_username() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = UserRepository::new(&db);
+
+        // Too short
+        let request = RegistrationRequest::new("abc", "password123", "Test");
+        let result = register(&repo, request);
+        assert!(matches!(result, Err(RegistrationError::Validation(_))));
+
+        // Reserved
+        let request = RegistrationRequest::new("admin", "password123", "Admin");
+        let result = register(&repo, request);
+        assert!(matches!(result, Err(RegistrationError::Validation(_))));
+    }
+
+    #[test]
+    fn test_register_invalid_password() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = UserRepository::new(&db);
+
+        // Too short
+        let request = RegistrationRequest::new("testuser", "short", "Test User");
+        let result = register(&repo, request);
+        assert!(matches!(result, Err(RegistrationError::Validation(_))));
+
+        // Same as username
+        let request = RegistrationRequest::new("testuser", "testuser", "Test User");
+        let result = register(&repo, request);
+        assert!(matches!(result, Err(RegistrationError::Validation(_))));
+    }
+
+    #[test]
+    fn test_register_invalid_nickname() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = UserRepository::new(&db);
+
+        // Empty
+        let request = RegistrationRequest::new("testuser", "password123", "");
+        let result = register(&repo, request);
+        assert!(matches!(result, Err(RegistrationError::Validation(_))));
+    }
+
+    #[test]
+    fn test_register_invalid_email() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = UserRepository::new(&db);
+
+        let request = RegistrationRequest::new("testuser", "password123", "Test User")
+            .with_email("invalid-email");
+        let result = register(&repo, request);
+        assert!(matches!(result, Err(RegistrationError::Validation(_))));
+    }
+
+    #[test]
+    fn test_register_with_role() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = UserRepository::new(&db);
+
+        let request = RegistrationRequest::new("sysop_user", "password123", "System Operator");
+        let result = register_with_role(&repo, request, Role::SysOp);
+
+        assert!(result.is_ok());
+        let user = result.unwrap();
+        assert_eq!(user.role, Role::SysOp);
+    }
+
+    #[test]
+    fn test_registration_request_builder() {
+        let request = RegistrationRequest::new("user", "pass", "nick")
+            .with_email("a@b.com")
+            .with_terminal("c64");
+
+        assert_eq!(request.username, "user");
+        assert_eq!(request.password, "pass");
+        assert_eq!(request.nickname, "nick");
+        assert_eq!(request.email, Some("a@b.com".to_string()));
+        assert_eq!(request.terminal, Some("c64".to_string()));
+    }
+
+    #[test]
+    fn test_registration_error_display() {
+        let err = RegistrationError::UsernameExists;
+        assert!(err.to_string().contains("already exists"));
+
+        let err = RegistrationError::Validation(ValidationError::UsernameTooShort);
+        assert!(err.to_string().contains("validation"));
+    }
+
+    #[test]
+    fn test_password_is_hashed() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = UserRepository::new(&db);
+
+        let request = RegistrationRequest::new("testuser", "password123", "Test User");
+        let user = register(&repo, request).unwrap();
+
+        // Password should be hashed, not plain text
+        assert_ne!(user.password, "password123");
+        assert!(user.password.starts_with("$argon2id$"));
+    }
+}

--- a/src/auth/validation.rs
+++ b/src/auth/validation.rs
@@ -1,0 +1,575 @@
+//! Input validation for HOBBS user registration.
+//!
+//! This module provides validation functions for usernames, passwords,
+//! nicknames, and email addresses.
+
+use thiserror::Error;
+
+/// Minimum username length.
+pub const MIN_USERNAME_LENGTH: usize = 4;
+
+/// Maximum username length.
+pub const MAX_USERNAME_LENGTH: usize = 16;
+
+/// Minimum password length.
+pub const MIN_PASSWORD_LENGTH: usize = 8;
+
+/// Maximum password length.
+pub const MAX_PASSWORD_LENGTH: usize = 128;
+
+/// Maximum nickname length.
+pub const MAX_NICKNAME_LENGTH: usize = 20;
+
+/// Maximum email length.
+pub const MAX_EMAIL_LENGTH: usize = 254;
+
+/// Validation errors.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum ValidationError {
+    /// Username is too short.
+    #[error("username must be at least {MIN_USERNAME_LENGTH} characters")]
+    UsernameTooShort,
+
+    /// Username is too long.
+    #[error("username must be at most {MAX_USERNAME_LENGTH} characters")]
+    UsernameTooLong,
+
+    /// Username contains invalid characters.
+    #[error("username can only contain alphanumeric characters and underscores")]
+    UsernameInvalidChars,
+
+    /// Username is reserved.
+    #[error("this username is reserved")]
+    UsernameReserved,
+
+    /// Password is too short.
+    #[error("password must be at least {MIN_PASSWORD_LENGTH} characters")]
+    PasswordTooShort,
+
+    /// Password is too long.
+    #[error("password must be at most {MAX_PASSWORD_LENGTH} characters")]
+    PasswordTooLong,
+
+    /// Password is the same as username.
+    #[error("password cannot be the same as username")]
+    PasswordSameAsUsername,
+
+    /// Nickname is empty.
+    #[error("nickname cannot be empty")]
+    NicknameEmpty,
+
+    /// Nickname is too long.
+    #[error("nickname must be at most {MAX_NICKNAME_LENGTH} characters")]
+    NicknameTooLong,
+
+    /// Nickname contains invalid characters.
+    #[error("nickname contains invalid characters")]
+    NicknameInvalidChars,
+
+    /// Email is too long.
+    #[error("email must be at most {MAX_EMAIL_LENGTH} characters")]
+    EmailTooLong,
+
+    /// Email format is invalid.
+    #[error("invalid email format")]
+    EmailInvalidFormat,
+}
+
+/// Reserved usernames that cannot be registered.
+const RESERVED_USERNAMES: &[&str] = &[
+    "guest",
+    "admin",
+    "sysop",
+    "subop",
+    "root",
+    "system",
+    "anonymous",
+    "administrator",
+    "moderator",
+    "operator",
+    "support",
+    "help",
+    "info",
+    "test",
+    "demo",
+    "null",
+    "undefined",
+    "hobbs",
+];
+
+/// Check if a username is reserved.
+pub fn is_reserved_username(username: &str) -> bool {
+    let lower = username.to_lowercase();
+    RESERVED_USERNAMES.iter().any(|&r| r == lower)
+}
+
+/// Validate a username.
+///
+/// Requirements:
+/// - Length: 4-16 characters
+/// - Characters: alphanumeric (a-z, A-Z, 0-9) and underscore (_)
+/// - Not a reserved username
+///
+/// # Examples
+///
+/// ```
+/// use hobbs::auth::validation::validate_username;
+///
+/// assert!(validate_username("john_doe").is_ok());
+/// assert!(validate_username("ab").is_err()); // too short
+/// assert!(validate_username("guest").is_err()); // reserved
+/// ```
+pub fn validate_username(username: &str) -> Result<(), ValidationError> {
+    // Check length
+    if username.len() < MIN_USERNAME_LENGTH {
+        return Err(ValidationError::UsernameTooShort);
+    }
+    if username.len() > MAX_USERNAME_LENGTH {
+        return Err(ValidationError::UsernameTooLong);
+    }
+
+    // Check characters: must be alphanumeric or underscore
+    if !username
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return Err(ValidationError::UsernameInvalidChars);
+    }
+
+    // Check reserved usernames
+    if is_reserved_username(username) {
+        return Err(ValidationError::UsernameReserved);
+    }
+
+    Ok(())
+}
+
+/// Validate a password.
+///
+/// Requirements:
+/// - Length: 8-128 characters
+/// - Must not be the same as the username (if provided)
+///
+/// # Examples
+///
+/// ```
+/// use hobbs::auth::validation::validate_registration_password;
+///
+/// assert!(validate_registration_password("secure_pass123", Some("john")).is_ok());
+/// assert!(validate_registration_password("short", None).is_err()); // too short
+/// assert!(validate_registration_password("john", Some("john")).is_err()); // same as username
+/// ```
+pub fn validate_registration_password(
+    password: &str,
+    username: Option<&str>,
+) -> Result<(), ValidationError> {
+    // Check length
+    if password.len() < MIN_PASSWORD_LENGTH {
+        return Err(ValidationError::PasswordTooShort);
+    }
+    if password.len() > MAX_PASSWORD_LENGTH {
+        return Err(ValidationError::PasswordTooLong);
+    }
+
+    // Check if same as username
+    if let Some(user) = username {
+        if password.eq_ignore_ascii_case(user) {
+            return Err(ValidationError::PasswordSameAsUsername);
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate a nickname.
+///
+/// Requirements:
+/// - Not empty
+/// - Length: at most 20 characters
+/// - No control characters
+///
+/// # Examples
+///
+/// ```
+/// use hobbs::auth::validation::validate_nickname;
+///
+/// assert!(validate_nickname("John Doe").is_ok());
+/// assert!(validate_nickname("").is_err()); // empty
+/// ```
+pub fn validate_nickname(nickname: &str) -> Result<(), ValidationError> {
+    // Check empty
+    if nickname.is_empty() {
+        return Err(ValidationError::NicknameEmpty);
+    }
+
+    // Check length (in characters, not bytes)
+    if nickname.chars().count() > MAX_NICKNAME_LENGTH {
+        return Err(ValidationError::NicknameTooLong);
+    }
+
+    // Check for control characters (except space)
+    if nickname.chars().any(|c| c.is_control()) {
+        return Err(ValidationError::NicknameInvalidChars);
+    }
+
+    Ok(())
+}
+
+/// Validate an email address (optional field).
+///
+/// If empty, returns Ok (email is optional).
+/// If provided, performs basic format validation.
+///
+/// # Examples
+///
+/// ```
+/// use hobbs::auth::validation::validate_email;
+///
+/// assert!(validate_email("").is_ok()); // optional
+/// assert!(validate_email("user@example.com").is_ok());
+/// assert!(validate_email("invalid").is_err());
+/// ```
+pub fn validate_email(email: &str) -> Result<(), ValidationError> {
+    // Empty is OK (email is optional)
+    if email.is_empty() {
+        return Ok(());
+    }
+
+    // Check length
+    if email.len() > MAX_EMAIL_LENGTH {
+        return Err(ValidationError::EmailTooLong);
+    }
+
+    // Basic format check: must contain @ and have text before and after
+    // This is intentionally simple - we don't try to fully validate email format
+    let parts: Vec<&str> = email.split('@').collect();
+    if parts.len() != 2 {
+        return Err(ValidationError::EmailInvalidFormat);
+    }
+
+    let (local, domain) = (parts[0], parts[1]);
+
+    // Local part must not be empty
+    if local.is_empty() {
+        return Err(ValidationError::EmailInvalidFormat);
+    }
+
+    // Domain must contain at least one dot and not be empty on either side
+    if !domain.contains('.') {
+        return Err(ValidationError::EmailInvalidFormat);
+    }
+
+    let domain_parts: Vec<&str> = domain.split('.').collect();
+    if domain_parts.iter().any(|p| p.is_empty()) {
+        return Err(ValidationError::EmailInvalidFormat);
+    }
+
+    // No whitespace allowed
+    if email.chars().any(|c| c.is_whitespace()) {
+        return Err(ValidationError::EmailInvalidFormat);
+    }
+
+    Ok(())
+}
+
+/// Validate all registration fields at once.
+///
+/// Returns the first validation error encountered, or Ok if all fields are valid.
+pub fn validate_registration(
+    username: &str,
+    password: &str,
+    nickname: &str,
+    email: Option<&str>,
+) -> Result<(), ValidationError> {
+    validate_username(username)?;
+    validate_registration_password(password, Some(username))?;
+    validate_nickname(nickname)?;
+    if let Some(e) = email {
+        validate_email(e)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Username validation tests
+    #[test]
+    fn test_validate_username_valid() {
+        assert!(validate_username("john").is_ok());
+        assert!(validate_username("john_doe").is_ok());
+        assert!(validate_username("JohnDoe123").is_ok());
+        assert!(validate_username("user_name_123").is_ok());
+        assert!(validate_username("a_b_").is_ok());
+    }
+
+    #[test]
+    fn test_validate_username_too_short() {
+        assert_eq!(
+            validate_username("abc"),
+            Err(ValidationError::UsernameTooShort)
+        );
+        assert_eq!(
+            validate_username("ab"),
+            Err(ValidationError::UsernameTooShort)
+        );
+        assert_eq!(
+            validate_username("a"),
+            Err(ValidationError::UsernameTooShort)
+        );
+        assert_eq!(
+            validate_username(""),
+            Err(ValidationError::UsernameTooShort)
+        );
+    }
+
+    #[test]
+    fn test_validate_username_too_long() {
+        let long_name = "a".repeat(17);
+        assert_eq!(
+            validate_username(&long_name),
+            Err(ValidationError::UsernameTooLong)
+        );
+    }
+
+    #[test]
+    fn test_validate_username_exact_lengths() {
+        // Exactly 4 characters - minimum
+        assert!(validate_username("abcd").is_ok());
+        // Exactly 16 characters - maximum
+        assert!(validate_username("abcdefghijklmnop").is_ok());
+    }
+
+    #[test]
+    fn test_validate_username_invalid_chars() {
+        assert_eq!(
+            validate_username("john-doe"),
+            Err(ValidationError::UsernameInvalidChars)
+        );
+        assert_eq!(
+            validate_username("john.doe"),
+            Err(ValidationError::UsernameInvalidChars)
+        );
+        assert_eq!(
+            validate_username("john doe"),
+            Err(ValidationError::UsernameInvalidChars)
+        );
+        assert_eq!(
+            validate_username("john@doe"),
+            Err(ValidationError::UsernameInvalidChars)
+        );
+        assert_eq!(
+            validate_username("ユーザー"),
+            Err(ValidationError::UsernameInvalidChars)
+        );
+    }
+
+    #[test]
+    fn test_validate_username_reserved() {
+        assert_eq!(
+            validate_username("guest"),
+            Err(ValidationError::UsernameReserved)
+        );
+        assert_eq!(
+            validate_username("GUEST"),
+            Err(ValidationError::UsernameReserved)
+        );
+        assert_eq!(
+            validate_username("Guest"),
+            Err(ValidationError::UsernameReserved)
+        );
+        assert_eq!(
+            validate_username("admin"),
+            Err(ValidationError::UsernameReserved)
+        );
+        assert_eq!(
+            validate_username("sysop"),
+            Err(ValidationError::UsernameReserved)
+        );
+        assert_eq!(
+            validate_username("root"),
+            Err(ValidationError::UsernameReserved)
+        );
+    }
+
+    #[test]
+    fn test_is_reserved_username() {
+        assert!(is_reserved_username("guest"));
+        assert!(is_reserved_username("ADMIN"));
+        assert!(is_reserved_username("SysOp"));
+        assert!(!is_reserved_username("john"));
+        assert!(!is_reserved_username("guestuser")); // contains but not exact
+    }
+
+    // Password validation tests
+    #[test]
+    fn test_validate_password_valid() {
+        assert!(validate_registration_password("password123", None).is_ok());
+        assert!(validate_registration_password("12345678", None).is_ok());
+        assert!(validate_registration_password("a".repeat(128).as_str(), None).is_ok());
+    }
+
+    #[test]
+    fn test_validate_password_too_short() {
+        assert_eq!(
+            validate_registration_password("short", None),
+            Err(ValidationError::PasswordTooShort)
+        );
+        assert_eq!(
+            validate_registration_password("1234567", None),
+            Err(ValidationError::PasswordTooShort)
+        );
+    }
+
+    #[test]
+    fn test_validate_password_too_long() {
+        let long_pass = "a".repeat(129);
+        assert_eq!(
+            validate_registration_password(&long_pass, None),
+            Err(ValidationError::PasswordTooLong)
+        );
+    }
+
+    #[test]
+    fn test_validate_password_same_as_username() {
+        // Use 8+ character username to avoid triggering PasswordTooShort
+        assert_eq!(
+            validate_registration_password("john_doe", Some("john_doe")),
+            Err(ValidationError::PasswordSameAsUsername)
+        );
+        // Case insensitive
+        assert_eq!(
+            validate_registration_password("John_Doe", Some("john_doe")),
+            Err(ValidationError::PasswordSameAsUsername)
+        );
+    }
+
+    // Nickname validation tests
+    #[test]
+    fn test_validate_nickname_valid() {
+        assert!(validate_nickname("John").is_ok());
+        assert!(validate_nickname("John Doe").is_ok());
+        assert!(validate_nickname("太郎").is_ok());
+        assert!(validate_nickname("User 123").is_ok());
+    }
+
+    #[test]
+    fn test_validate_nickname_empty() {
+        assert_eq!(validate_nickname(""), Err(ValidationError::NicknameEmpty));
+    }
+
+    #[test]
+    fn test_validate_nickname_too_long() {
+        // 21 ASCII characters
+        assert_eq!(
+            validate_nickname("a".repeat(21).as_str()),
+            Err(ValidationError::NicknameTooLong)
+        );
+        // 21 Japanese characters (multi-byte but still 21 chars)
+        assert_eq!(
+            validate_nickname("あ".repeat(21).as_str()),
+            Err(ValidationError::NicknameTooLong)
+        );
+    }
+
+    #[test]
+    fn test_validate_nickname_exact_length() {
+        // Exactly 20 characters - maximum
+        assert!(validate_nickname("a".repeat(20).as_str()).is_ok());
+        assert!(validate_nickname("あ".repeat(20).as_str()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_nickname_control_chars() {
+        assert_eq!(
+            validate_nickname("John\x00Doe"),
+            Err(ValidationError::NicknameInvalidChars)
+        );
+        assert_eq!(
+            validate_nickname("John\nDoe"),
+            Err(ValidationError::NicknameInvalidChars)
+        );
+    }
+
+    // Email validation tests
+    #[test]
+    fn test_validate_email_valid() {
+        assert!(validate_email("").is_ok()); // optional
+        assert!(validate_email("user@example.com").is_ok());
+        assert!(validate_email("user.name@example.co.jp").is_ok());
+        assert!(validate_email("user+tag@example.com").is_ok());
+    }
+
+    #[test]
+    fn test_validate_email_invalid_format() {
+        assert_eq!(
+            validate_email("invalid"),
+            Err(ValidationError::EmailInvalidFormat)
+        );
+        assert_eq!(
+            validate_email("@example.com"),
+            Err(ValidationError::EmailInvalidFormat)
+        );
+        assert_eq!(
+            validate_email("user@"),
+            Err(ValidationError::EmailInvalidFormat)
+        );
+        assert_eq!(
+            validate_email("user@example"),
+            Err(ValidationError::EmailInvalidFormat)
+        );
+        assert_eq!(
+            validate_email("user@@example.com"),
+            Err(ValidationError::EmailInvalidFormat)
+        );
+        assert_eq!(
+            validate_email("user @example.com"),
+            Err(ValidationError::EmailInvalidFormat)
+        );
+    }
+
+    #[test]
+    fn test_validate_email_too_long() {
+        let long_email = format!("{}@example.com", "a".repeat(250));
+        assert_eq!(
+            validate_email(&long_email),
+            Err(ValidationError::EmailTooLong)
+        );
+    }
+
+    // Combined validation tests
+    #[test]
+    fn test_validate_registration_all_valid() {
+        assert!(validate_registration("john_doe", "password123", "John Doe", None).is_ok());
+        assert!(validate_registration(
+            "john_doe",
+            "password123",
+            "John Doe",
+            Some("john@example.com")
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_registration_fails_on_first_error() {
+        // Should fail on username
+        assert_eq!(
+            validate_registration("ab", "password123", "John", None),
+            Err(ValidationError::UsernameTooShort)
+        );
+    }
+
+    #[test]
+    fn test_validation_error_display() {
+        assert!(ValidationError::UsernameTooShort
+            .to_string()
+            .contains("at least"));
+        assert!(ValidationError::UsernameReserved
+            .to_string()
+            .contains("reserved"));
+        assert!(ValidationError::PasswordTooShort
+            .to_string()
+            .contains("at least"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,9 @@ pub mod server;
 pub mod terminal;
 
 pub use auth::{
-    hash_password, validate_password, verify_password, AuthSession, LimitResult, LoginLimiter,
-    PasswordError, SessionError, SessionManager,
+    hash_password, register, register_with_role, validate_password, verify_password, AuthSession,
+    LimitResult, LoginLimiter, PasswordError, RegistrationError, RegistrationRequest, SessionError,
+    SessionManager, ValidationError,
 };
 pub use config::Config;
 pub use db::{Database, NewUser, Role, User, UserRepository, UserUpdate};


### PR DESCRIPTION
## Summary

- `src/auth/validation.rs` を作成し、入力バリデーション機能を実装
  - ユーザー名: 4-16文字、英数字とアンダースコアのみ、予約語チェック
  - パスワード: 8-128文字、ユーザー名との一致チェック
  - ニックネーム: 1-20文字、制御文字禁止
  - メールアドレス: 基本的なフォーマットチェック
- `src/auth/registration.rs` を作成し、ユーザー登録機能を実装
  - `RegistrationRequest` ビルダーパターン
  - `register()` 関数（一般ユーザー登録）
  - `register_with_role()` 関数（ロール指定登録、SysOp用）
  - パスワードはArgon2idでハッシュ化
- 35個の単体テストを追加（全て通過）

## Test plan

- [x] `cargo test` で全テスト通過確認
- [x] 正常系: ユーザー登録成功
- [x] 正常系: メール付き登録成功
- [x] 正常系: ターミナル設定付き登録成功
- [x] 異常系: ユーザー名重複エラー
- [x] 異常系: ユーザー名バリデーション（短すぎ/長すぎ/無効文字/予約語）
- [x] 異常系: パスワードバリデーション（短すぎ/長すぎ/ユーザー名と同じ）
- [x] 異常系: ニックネームバリデーション（空/長すぎ/制御文字）
- [x] 異常系: メールバリデーション（無効フォーマット）
- [x] パスワードがArgon2idでハッシュ化されていることを確認

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)