### PR TITLE
[Phase 3.5-1] CharacterEncoding基盤

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@ pub use config::Config;
 pub use db::{Database, NewUser, Role, User, UserRepository, UserUpdate};
 pub use error::{HobbsError, Result};
 pub use server::{
-    decode_shiftjis, decode_shiftjis_strict, encode_shiftjis, encode_shiftjis_strict,
-    initial_negotiation, DecodeResult, EchoMode, EncodeResult, InputResult, LineBuffer,
-    MultiLineBuffer, NegotiationState, TelnetCommand, TelnetParser, TelnetServer,
+    decode_from_client, decode_shiftjis, decode_shiftjis_strict, encode_for_client, encode_shiftjis,
+    encode_shiftjis_strict, initial_negotiation, CharacterEncoding, DecodeResult, EchoMode,
+    EncodeResult, InputResult, LineBuffer, MultiLineBuffer, NegotiationState, TelnetCommand,
+    TelnetParser, TelnetServer,
 };
 pub use terminal::TerminalProfile;

--- a/src/server/encoding.rs
+++ b/src/server/encoding.rs
@@ -1,9 +1,184 @@
 //! Character encoding conversion for Telnet communication.
 //!
 //! This module handles conversion between UTF-8 (internal representation)
-//! and ShiftJIS (Telnet wire format).
+//! and various wire formats (ShiftJIS for legacy terminals, UTF-8 for modern terminals).
+
+use std::fmt;
+use std::str::FromStr;
 
 use encoding_rs::SHIFT_JIS;
+
+/// Character encoding for client communication.
+///
+/// HOBBS supports two encodings:
+/// - ShiftJIS: For legacy Japanese terminals and retro computing enthusiasts
+/// - UTF-8: For modern terminals and international users
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub enum CharacterEncoding {
+    /// ShiftJIS encoding (default for retro compatibility).
+    #[default]
+    ShiftJIS,
+    /// UTF-8 encoding for modern terminals.
+    Utf8,
+}
+
+impl CharacterEncoding {
+    /// Get the encoding name as a string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CharacterEncoding::ShiftJIS => "shiftjis",
+            CharacterEncoding::Utf8 => "utf8",
+        }
+    }
+
+    /// Get the display name for the encoding.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            CharacterEncoding::ShiftJIS => "ShiftJIS",
+            CharacterEncoding::Utf8 => "UTF-8",
+        }
+    }
+
+    /// Get all available encodings.
+    pub fn all() -> &'static [CharacterEncoding] {
+        &[CharacterEncoding::ShiftJIS, CharacterEncoding::Utf8]
+    }
+}
+
+impl fmt::Display for CharacterEncoding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.display_name())
+    }
+}
+
+impl FromStr for CharacterEncoding {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "shiftjis" | "shift_jis" | "shift-jis" | "sjis" => Ok(CharacterEncoding::ShiftJIS),
+            "utf8" | "utf-8" => Ok(CharacterEncoding::Utf8),
+            _ => Err(format!("unknown encoding: {s}")),
+        }
+    }
+}
+
+/// Encode a UTF-8 string for sending to a client with the specified encoding.
+///
+/// # Arguments
+///
+/// * `text` - The UTF-8 string to encode
+/// * `encoding` - The target encoding for the client
+///
+/// # Returns
+///
+/// The encoded bytes ready to send to the client.
+///
+/// # Examples
+///
+/// ```
+/// use hobbs::server::encoding::{encode_for_client, CharacterEncoding};
+///
+/// let text = "Hello, 世界!";
+///
+/// // UTF-8 encoding (pass-through)
+/// let utf8_bytes = encode_for_client(text, CharacterEncoding::Utf8);
+/// assert_eq!(utf8_bytes, text.as_bytes());
+///
+/// // ShiftJIS encoding
+/// let sjis_bytes = encode_for_client(text, CharacterEncoding::ShiftJIS);
+/// assert_ne!(sjis_bytes, text.as_bytes());
+/// ```
+pub fn encode_for_client(text: &str, encoding: CharacterEncoding) -> Vec<u8> {
+    match encoding {
+        CharacterEncoding::Utf8 => text.as_bytes().to_vec(),
+        CharacterEncoding::ShiftJIS => encode_shiftjis(text).bytes,
+    }
+}
+
+/// Decode bytes received from a client with the specified encoding.
+///
+/// # Arguments
+///
+/// * `bytes` - The bytes received from the client
+/// * `encoding` - The encoding used by the client
+///
+/// # Returns
+///
+/// The decoded UTF-8 string. Invalid sequences are replaced with the
+/// Unicode replacement character (U+FFFD).
+///
+/// # Examples
+///
+/// ```
+/// use hobbs::server::encoding::{decode_from_client, CharacterEncoding};
+///
+/// // UTF-8 decoding
+/// let utf8_bytes = "Hello, 世界!".as_bytes();
+/// let text = decode_from_client(utf8_bytes, CharacterEncoding::Utf8);
+/// assert_eq!(text, "Hello, 世界!");
+///
+/// // ShiftJIS decoding
+/// let sjis_bytes = vec![0x83, 0x65, 0x83, 0x58, 0x83, 0x67]; // "テスト"
+/// let text = decode_from_client(&sjis_bytes, CharacterEncoding::ShiftJIS);
+/// assert_eq!(text, "テスト");
+/// ```
+pub fn decode_from_client(bytes: &[u8], encoding: CharacterEncoding) -> String {
+    match encoding {
+        CharacterEncoding::Utf8 => String::from_utf8_lossy(bytes).into_owned(),
+        CharacterEncoding::ShiftJIS => decode_shiftjis(bytes).text,
+    }
+}
+
+/// Encode a UTF-8 string for a client, with error information.
+///
+/// Like `encode_for_client`, but returns detailed information about
+/// whether any characters could not be represented in the target encoding.
+///
+/// # Arguments
+///
+/// * `text` - The UTF-8 string to encode
+/// * `encoding` - The target encoding for the client
+///
+/// # Returns
+///
+/// An `EncodeResult` with the encoded bytes and error flag.
+pub fn encode_for_client_detailed(text: &str, encoding: CharacterEncoding) -> EncodeResult {
+    match encoding {
+        CharacterEncoding::Utf8 => EncodeResult {
+            bytes: text.as_bytes().to_vec(),
+            had_errors: false,
+        },
+        CharacterEncoding::ShiftJIS => encode_shiftjis(text),
+    }
+}
+
+/// Decode bytes from a client, with error information.
+///
+/// Like `decode_from_client`, but returns detailed information about
+/// whether any bytes could not be decoded.
+///
+/// # Arguments
+///
+/// * `bytes` - The bytes received from the client
+/// * `encoding` - The encoding used by the client
+///
+/// # Returns
+///
+/// A `DecodeResult` with the decoded string and error flag.
+pub fn decode_from_client_detailed(bytes: &[u8], encoding: CharacterEncoding) -> DecodeResult {
+    match encoding {
+        CharacterEncoding::Utf8 => {
+            let text = String::from_utf8_lossy(bytes);
+            let had_errors = text.contains('\u{FFFD}');
+            DecodeResult {
+                text: text.into_owned(),
+                had_errors,
+            }
+        }
+        CharacterEncoding::ShiftJIS => decode_shiftjis(bytes),
+    }
+}
 
 /// Result of a decoding operation.
 #[derive(Debug, Clone)]
@@ -327,5 +502,246 @@ mod tests {
         let result = encode_shiftjis("漢字");
         assert_eq!(result.bytes, vec![0x8A, 0xBF, 0x8E, 0x9A]);
         assert!(!result.had_errors);
+    }
+
+    // CharacterEncoding tests
+    #[test]
+    fn test_character_encoding_default() {
+        let encoding = CharacterEncoding::default();
+        assert_eq!(encoding, CharacterEncoding::ShiftJIS);
+    }
+
+    #[test]
+    fn test_character_encoding_as_str() {
+        assert_eq!(CharacterEncoding::ShiftJIS.as_str(), "shiftjis");
+        assert_eq!(CharacterEncoding::Utf8.as_str(), "utf8");
+    }
+
+    #[test]
+    fn test_character_encoding_display_name() {
+        assert_eq!(CharacterEncoding::ShiftJIS.display_name(), "ShiftJIS");
+        assert_eq!(CharacterEncoding::Utf8.display_name(), "UTF-8");
+    }
+
+    #[test]
+    fn test_character_encoding_display() {
+        assert_eq!(format!("{}", CharacterEncoding::ShiftJIS), "ShiftJIS");
+        assert_eq!(format!("{}", CharacterEncoding::Utf8), "UTF-8");
+    }
+
+    #[test]
+    fn test_character_encoding_from_str() {
+        assert_eq!(
+            "shiftjis".parse::<CharacterEncoding>().unwrap(),
+            CharacterEncoding::ShiftJIS
+        );
+        assert_eq!(
+            "shift_jis".parse::<CharacterEncoding>().unwrap(),
+            CharacterEncoding::ShiftJIS
+        );
+        assert_eq!(
+            "shift-jis".parse::<CharacterEncoding>().unwrap(),
+            CharacterEncoding::ShiftJIS
+        );
+        assert_eq!(
+            "sjis".parse::<CharacterEncoding>().unwrap(),
+            CharacterEncoding::ShiftJIS
+        );
+        assert_eq!(
+            "SHIFTJIS".parse::<CharacterEncoding>().unwrap(),
+            CharacterEncoding::ShiftJIS
+        );
+        assert_eq!(
+            "utf8".parse::<CharacterEncoding>().unwrap(),
+            CharacterEncoding::Utf8
+        );
+        assert_eq!(
+            "utf-8".parse::<CharacterEncoding>().unwrap(),
+            CharacterEncoding::Utf8
+        );
+        assert_eq!(
+            "UTF-8".parse::<CharacterEncoding>().unwrap(),
+            CharacterEncoding::Utf8
+        );
+        assert!("invalid".parse::<CharacterEncoding>().is_err());
+    }
+
+    #[test]
+    fn test_character_encoding_all() {
+        let all = CharacterEncoding::all();
+        assert_eq!(all.len(), 2);
+        assert!(all.contains(&CharacterEncoding::ShiftJIS));
+        assert!(all.contains(&CharacterEncoding::Utf8));
+    }
+
+    // encode_for_client tests
+    #[test]
+    fn test_encode_for_client_utf8_ascii() {
+        let text = "Hello, World!";
+        let bytes = encode_for_client(text, CharacterEncoding::Utf8);
+        assert_eq!(bytes, text.as_bytes());
+    }
+
+    #[test]
+    fn test_encode_for_client_utf8_japanese() {
+        let text = "こんにちは世界";
+        let bytes = encode_for_client(text, CharacterEncoding::Utf8);
+        assert_eq!(bytes, text.as_bytes());
+    }
+
+    #[test]
+    fn test_encode_for_client_shiftjis_ascii() {
+        let text = "Hello, World!";
+        let bytes = encode_for_client(text, CharacterEncoding::ShiftJIS);
+        assert_eq!(bytes, text.as_bytes()); // ASCII is same in both encodings
+    }
+
+    #[test]
+    fn test_encode_for_client_shiftjis_japanese() {
+        let text = "テスト";
+        let bytes = encode_for_client(text, CharacterEncoding::ShiftJIS);
+        assert_eq!(bytes, vec![0x83, 0x65, 0x83, 0x58, 0x83, 0x67]);
+    }
+
+    #[test]
+    fn test_encode_for_client_utf8_preserves_special_chars() {
+        // UTF-8 can encode characters that ShiftJIS cannot
+        let text = "€£¥";
+        let bytes = encode_for_client(text, CharacterEncoding::Utf8);
+        assert_eq!(bytes, text.as_bytes());
+    }
+
+    // decode_from_client tests
+    #[test]
+    fn test_decode_from_client_utf8_ascii() {
+        let bytes = b"Hello, World!";
+        let text = decode_from_client(bytes, CharacterEncoding::Utf8);
+        assert_eq!(text, "Hello, World!");
+    }
+
+    #[test]
+    fn test_decode_from_client_utf8_japanese() {
+        let original = "こんにちは世界";
+        let bytes = original.as_bytes();
+        let text = decode_from_client(bytes, CharacterEncoding::Utf8);
+        assert_eq!(text, original);
+    }
+
+    #[test]
+    fn test_decode_from_client_shiftjis_ascii() {
+        let bytes = b"Hello, World!";
+        let text = decode_from_client(bytes, CharacterEncoding::ShiftJIS);
+        assert_eq!(text, "Hello, World!");
+    }
+
+    #[test]
+    fn test_decode_from_client_shiftjis_japanese() {
+        // "テスト" in ShiftJIS
+        let bytes = vec![0x83, 0x65, 0x83, 0x58, 0x83, 0x67];
+        let text = decode_from_client(&bytes, CharacterEncoding::ShiftJIS);
+        assert_eq!(text, "テスト");
+    }
+
+    #[test]
+    fn test_decode_from_client_utf8_invalid() {
+        // Invalid UTF-8 sequence
+        let bytes = vec![0xFF, 0xFE];
+        let text = decode_from_client(&bytes, CharacterEncoding::Utf8);
+        // Should contain replacement character
+        assert!(text.contains('\u{FFFD}'));
+    }
+
+    // encode_for_client_detailed tests
+    #[test]
+    fn test_encode_for_client_detailed_utf8() {
+        let text = "Hello, €世界!";
+        let result = encode_for_client_detailed(text, CharacterEncoding::Utf8);
+        assert_eq!(result.bytes, text.as_bytes());
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_encode_for_client_detailed_shiftjis_success() {
+        let text = "Hello, 世界!";
+        let result = encode_for_client_detailed(text, CharacterEncoding::ShiftJIS);
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_encode_for_client_detailed_shiftjis_error() {
+        // Euro sign is not in ShiftJIS
+        let text = "€";
+        let result = encode_for_client_detailed(text, CharacterEncoding::ShiftJIS);
+        assert!(result.had_errors);
+    }
+
+    // decode_from_client_detailed tests
+    #[test]
+    fn test_decode_from_client_detailed_utf8_valid() {
+        let bytes = "Hello, 世界!".as_bytes();
+        let result = decode_from_client_detailed(bytes, CharacterEncoding::Utf8);
+        assert_eq!(result.text, "Hello, 世界!");
+        assert!(!result.had_errors);
+    }
+
+    #[test]
+    fn test_decode_from_client_detailed_utf8_invalid() {
+        let bytes = vec![0xFF, 0xFE];
+        let result = decode_from_client_detailed(&bytes, CharacterEncoding::Utf8);
+        assert!(result.had_errors);
+        assert!(result.text.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn test_decode_from_client_detailed_shiftjis_valid() {
+        let bytes = vec![0x83, 0x65, 0x83, 0x58, 0x83, 0x67]; // "テスト"
+        let result = decode_from_client_detailed(&bytes, CharacterEncoding::ShiftJIS);
+        assert_eq!(result.text, "テスト");
+        assert!(!result.had_errors);
+    }
+
+    // Roundtrip tests
+    #[test]
+    fn test_roundtrip_utf8() {
+        let original = "Hello, 世界! €123";
+        let encoded = encode_for_client(original, CharacterEncoding::Utf8);
+        let decoded = decode_from_client(&encoded, CharacterEncoding::Utf8);
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn test_roundtrip_shiftjis() {
+        let original = "Hello, 世界!"; // No characters outside ShiftJIS
+        let encoded = encode_for_client(original, CharacterEncoding::ShiftJIS);
+        let decoded = decode_from_client(&encoded, CharacterEncoding::ShiftJIS);
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn test_character_encoding_equality() {
+        assert_eq!(CharacterEncoding::ShiftJIS, CharacterEncoding::ShiftJIS);
+        assert_eq!(CharacterEncoding::Utf8, CharacterEncoding::Utf8);
+        assert_ne!(CharacterEncoding::ShiftJIS, CharacterEncoding::Utf8);
+    }
+
+    #[test]
+    fn test_character_encoding_clone() {
+        let enc = CharacterEncoding::Utf8;
+        let cloned = enc;
+        assert_eq!(enc, cloned);
+    }
+
+    #[test]
+    fn test_encode_empty_string() {
+        let empty = "";
+        assert!(encode_for_client(empty, CharacterEncoding::Utf8).is_empty());
+        assert!(encode_for_client(empty, CharacterEncoding::ShiftJIS).is_empty());
+    }
+
+    #[test]
+    fn test_decode_empty_bytes() {
+        let empty: &[u8] = &[];
+        assert_eq!(decode_from_client(empty, CharacterEncoding::Utf8), "");
+        assert_eq!(decode_from_client(empty, CharacterEncoding::ShiftJIS), "");
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,8 +10,9 @@ mod session;
 pub mod telnet;
 
 pub use encoding::{
-    decode_shiftjis, decode_shiftjis_strict, encode_shiftjis, encode_shiftjis_strict, DecodeResult,
-    EncodeResult,
+    decode_from_client, decode_from_client_detailed, decode_shiftjis, decode_shiftjis_strict,
+    encode_for_client, encode_for_client_detailed, encode_shiftjis, encode_shiftjis_strict,
+    CharacterEncoding, DecodeResult, EncodeResult,
 };
 pub use input::{EchoMode, InputResult, LineBuffer, MultiLineBuffer};
 pub use listener::{ConnectionPermit, TelnetServer};


### PR DESCRIPTION
## Summary

- `CharacterEncoding` enum を追加（ShiftJIS, UTF-8）
  - デフォルトは ShiftJIS（レトロ端末との互換性）
  - `as_str()`, `display_name()`, `all()` メソッド
  - `FromStr`, `Display` トレイト実装
- `encode_for_client(text, encoding)` - エンコーディングに応じた文字列→バイト変換
- `decode_from_client(bytes, encoding)` - エンコーディングに応じたバイト→文字列変換
- `encode_for_client_detailed()` / `decode_from_client_detailed()` - エラー情報付き版
- 28個の単体テストを追加（全て通過）

## Test plan

- [x] `cargo test` で全テスト通過確認
- [x] CharacterEncoding enum のテスト
  - default, as_str, display_name, Display, FromStr, all
- [x] encode_for_client テスト
  - UTF-8 ASCII/日本語、ShiftJIS ASCII/日本語、特殊文字
- [x] decode_from_client テスト
  - UTF-8 ASCII/日本語/無効シーケンス、ShiftJIS ASCII/日本語
- [x] ラウンドトリップテスト（UTF-8, ShiftJIS）
- [x] 空文字列/空バイトのテスト

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)