### PR TITLE
feat: ユーザーエンコーディング設定を実装

### DIFF
--- a/src/auth/permission.rs
+++ b/src/auth/permission.rs
@@ -195,6 +195,7 @@ pub fn can_modify_resource(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::CharacterEncoding;
 
     fn create_test_user(role: Role, is_active: bool) -> User {
         User {
@@ -206,6 +207,7 @@ mod tests {
             role,
             profile: None,
             terminal: "standard".to_string(),
+            encoding: CharacterEncoding::default(),
             created_at: "2024-01-01".to_string(),
             last_login: None,
             is_active,

--- a/src/auth/profile.rs
+++ b/src/auth/profile.rs
@@ -668,6 +668,8 @@ mod tests {
 
     #[test]
     fn test_user_profile_from_user() {
+        use crate::server::CharacterEncoding;
+
         let user = User {
             id: 1,
             username: "testuser".to_string(),
@@ -677,6 +679,7 @@ mod tests {
             role: Role::Member,
             profile: Some("Hello!".to_string()),
             terminal: "standard".to_string(),
+            encoding: CharacterEncoding::default(),
             created_at: "2024-01-01".to_string(),
             last_login: Some("2024-01-02".to_string()),
             is_active: true,

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -28,6 +28,10 @@ CREATE TABLE users (
 CREATE INDEX idx_users_username ON users(username);
 CREATE INDEX idx_users_role ON users(role);
 "#,
+    // v2: Add encoding column for character encoding preference
+    r#"
+ALTER TABLE users ADD COLUMN encoding TEXT NOT NULL DEFAULT 'shiftjis';
+"#,
 ];
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- v2 マイグレーション追加：users テーブルに `encoding` カラム（デフォルト 'shiftjis'）
- `User`, `NewUser`, `UserUpdate` 構造体に `encoding: CharacterEncoding` フィールド追加
- `UserRepository` の CRUD 操作を encoding 対応に更新
- 単体テスト6件追加

## Test plan

- [x] ユーザー作成時のデフォルトエンコーディングテスト
- [x] ユーザー作成時のエンコーディング指定テスト
- [x] ユーザー更新時のエンコーディング変更テスト
- [x] 全306単体テスト + 14統合テスト + 4サーバー統合テスト通過

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)