### PR TITLE
[Phase 4-1] 掲示板テーブル実装

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -188,19 +188,19 @@
 
 ---
 
-## Phase 3: データベース・認証
+## Phase 3: データベース・認証 ✅
 
-### 3-1. データベース基盤
+### 3-1. データベース基盤 ✅
 
 **概要**: SQLite 接続とマイグレーション機能を実装する
 
 **完了条件**:
-- [ ] `src/db/mod.rs`, `src/db/schema.rs` を作成
-- [ ] `Database` 構造体（接続プール的な管理）
-- [ ] マイグレーション機能
-- [ ] schema_version テーブル
-- [ ] 初期スキーマ（users テーブル）
-- [ ] 単体テスト
+- [x] `src/db/mod.rs`, `src/db/schema.rs` を作成
+- [x] `Database` 構造体（接続プール的な管理）
+- [x] マイグレーション機能
+- [x] schema_version テーブル
+- [x] 初期スキーマ（users テーブル）
+- [x] 単体テスト
 
 **関連ファイル**:
 - `src/db/mod.rs`
@@ -209,15 +209,15 @@
 
 ---
 
-### 3-2. ユーザーリポジトリ
+### 3-2. ユーザーリポジトリ ✅
 
 **概要**: ユーザーの CRUD 操作を実装する
 
 **完了条件**:
-- [ ] `src/db/repository.rs` または `src/auth/repository.rs` を作成
-- [ ] ユーザー作成・取得・更新・削除
-- [ ] ユーザー名による検索
-- [ ] 単体テスト
+- [x] `src/db/repository.rs` または `src/auth/repository.rs` を作成
+- [x] ユーザー作成・取得・更新・削除
+- [x] ユーザー名による検索
+- [x] 単体テスト
 
 **関連ファイル**:
 - `src/db/repository.rs`
@@ -225,33 +225,33 @@
 
 ---
 
-### 3-3. パスワードハッシュ
+### 3-3. パスワードハッシュ ✅
 
 **概要**: Argon2id によるパスワードハッシュを実装する
 
 **完了条件**:
-- [ ] `src/auth/password.rs` を作成
-- [ ] hash_password() 関数
-- [ ] verify_password() 関数
-- [ ] 単体テスト
+- [x] `src/auth/password.rs` を作成
+- [x] hash_password() 関数
+- [x] verify_password() 関数
+- [x] 単体テスト
 
 **関連ファイル**:
 - `src/auth/password.rs`
 
 ---
 
-### 3-4. ログイン・ログアウト
+### 3-4. ログイン・ログアウト ✅
 
 **概要**: ログイン認証とセッション作成を実装する
 
 **完了条件**:
-- [ ] `src/auth/mod.rs`, `src/auth/session.rs` を作成
-- [ ] `AuthSession` 構造体
-- [ ] login() 関数（認証 + セッション作成）
-- [ ] logout() 関数
-- [ ] セッション検証
-- [ ] ログイン試行制限（3回、5分ロック）
-- [ ] 単体テスト
+- [x] `src/auth/mod.rs`, `src/auth/session.rs` を作成
+- [x] `AuthSession` 構造体
+- [x] login() 関数（認証 + セッション作成）
+- [x] logout() 関数
+- [x] セッション検証
+- [x] ログイン試行制限（3回、5分ロック）
+- [x] 単体テスト
 
 **関連ファイル**:
 - `src/auth/mod.rs`
@@ -259,16 +259,16 @@
 
 ---
 
-### 3-5. 新規登録
+### 3-5. 新規登録 ✅
 
 **概要**: ユーザー登録機能を実装する
 
 **完了条件**:
-- [ ] register() 関数
-- [ ] バリデーション（ユーザーID、パスワード、ニックネーム）
-- [ ] 禁止ユーザーIDチェック
-- [ ] 重複チェック
-- [ ] 単体テスト
+- [x] register() 関数
+- [x] バリデーション（ユーザーID、パスワード、ニックネーム）
+- [x] 禁止ユーザーIDチェック
+- [x] 重複チェック
+- [x] 単体テスト
 
 **関連ファイル**:
 - `src/auth/mod.rs`（拡張）
@@ -276,63 +276,63 @@
 
 ---
 
-### 3-6. 権限チェック
+### 3-6. 権限チェック ✅
 
 **概要**: Role ベースの権限チェックを実装する
 
 **完了条件**:
-- [ ] `src/auth/permission.rs` を作成
-- [ ] `Role` 列挙型（Guest, Member, SubOp, SysOp）
-- [ ] can_access() 関数
-- [ ] check_permission() 関数
-- [ ] 単体テスト
+- [x] `src/auth/permission.rs` を作成
+- [x] `Role` 列挙型（Guest, Member, SubOp, SysOp）
+- [x] can_access() 関数
+- [x] check_permission() 関数
+- [x] 単体テスト
 
 **関連ファイル**:
 - `src/auth/permission.rs`
 
 ---
 
-### 3-7. プロフィール管理
+### 3-7. プロフィール管理 ✅
 
 **概要**: ユーザープロフィールの閲覧・編集を実装する
 
 **完了条件**:
-- [ ] get_profile() 関数
-- [ ] update_profile() 関数
-- [ ] change_password() 関数
-- [ ] 単体テスト
+- [x] get_profile() 関数
+- [x] update_profile() 関数
+- [x] change_password() 関数
+- [x] 単体テスト
 
 **関連ファイル**:
 - `src/auth/mod.rs`（拡張）
 
 ---
 
-## Phase 3.5: エンコーディング対応
+## Phase 3.5: エンコーディング対応 ✅
 
-### 3.5-1. CharacterEncoding基盤
+### 3.5-1. CharacterEncoding基盤 ✅
 
 **概要**: 文字エンコーディング選択の基盤を実装する
 
 **完了条件**:
-- [ ] `CharacterEncoding` enum定義（ShiftJIS, UTF-8）
-- [ ] `src/server/encoding.rs` にエンコーディング判定ヘルパー追加
-- [ ] `encode_for_client()`, `decode_from_client()` 関数
-- [ ] 単体テスト
+- [x] `CharacterEncoding` enum定義（ShiftJIS, UTF-8）
+- [x] `src/server/encoding.rs` にエンコーディング判定ヘルパー追加
+- [x] `encode_for_client()`, `decode_from_client()` 関数
+- [x] 単体テスト
 
 **関連ファイル**:
 - `src/server/encoding.rs`
 
 ---
 
-### 3.5-2. セッションエンコーディング対応
+### 3.5-2. セッションエンコーディング対応 ✅
 
 **概要**: Telnetセッションでエンコーディング設定を使用する
 
 **完了条件**:
-- [ ] `TelnetSession` に `encoding` フィールド追加
-- [ ] `LineBuffer` のエンコーディング対応
-- [ ] 入出力処理のエンコーディング変換
-- [ ] 統合テスト
+- [x] `TelnetSession` に `encoding` フィールド追加
+- [x] `LineBuffer` のエンコーディング対応
+- [x] 入出力処理のエンコーディング変換
+- [x] 統合テスト
 
 **関連ファイル**:
 - `src/server/session.rs`
@@ -340,17 +340,17 @@
 
 ---
 
-### 3.5-3. ユーザーエンコーディング設定
+### 3.5-3. ユーザーエンコーディング設定 ✅
 
 **概要**: ユーザー設定でエンコーディングを選択・保存する
 
 **完了条件**:
-- [ ] `users` テーブルに `encoding` カラム追加（マイグレーション）
-- [ ] `User`, `NewUser`, `UserUpdate` 構造体に `encoding` フィールド追加
-- [ ] `UserRepository` 更新
-- [ ] ログイン時のエンコーディング設定読み込み
-- [ ] ゲスト用のエンコーディング選択（セッションのみ）
-- [ ] 単体テスト
+- [x] `users` テーブルに `encoding` カラム追加（マイグレーション）
+- [x] `User`, `NewUser`, `UserUpdate` 構造体に `encoding` フィールド追加
+- [x] `UserRepository` 更新
+- [x] ログイン時のエンコーディング設定読み込み
+- [x] ゲスト用のエンコーディング選択（セッションのみ）
+- [x] 単体テスト
 
 **関連ファイル**:
 - `src/db/schema.rs` (マイグレーション追加)

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -1,0 +1,12 @@
+//! Board module for HOBBS.
+//!
+//! This module provides bulletin board functionality including:
+//! - Board management (create, read, update, delete)
+//! - Board types (thread-based and flat)
+//! - Role-based access control for read/write permissions
+
+mod repository;
+mod types;
+
+pub use repository::BoardRepository;
+pub use types::{Board, BoardType, BoardUpdate, NewBoard};

--- a/src/board/repository.rs
+++ b/src/board/repository.rs
@@ -1,0 +1,585 @@
+//! Board repository for HOBBS.
+//!
+//! This module provides CRUD operations for boards in the database.
+
+use rusqlite::{params, Row};
+
+use super::types::{Board, BoardType, BoardUpdate, NewBoard};
+use crate::db::{Database, Role};
+use crate::{HobbsError, Result};
+
+/// Repository for board CRUD operations.
+pub struct BoardRepository<'a> {
+    db: &'a Database,
+}
+
+impl<'a> BoardRepository<'a> {
+    /// Create a new BoardRepository with the given database reference.
+    pub fn new(db: &'a Database) -> Self {
+        Self { db }
+    }
+
+    /// Create a new board in the database.
+    ///
+    /// Returns the created board with the assigned ID.
+    pub fn create(&self, new_board: &NewBoard) -> Result<Board> {
+        self.db.conn().execute(
+            "INSERT INTO boards (name, description, board_type, min_read_role, min_write_role, sort_order)
+             VALUES (?, ?, ?, ?, ?, ?)",
+            params![
+                &new_board.name,
+                &new_board.description,
+                new_board.board_type.as_str(),
+                new_board.min_read_role.as_str(),
+                new_board.min_write_role.as_str(),
+                new_board.sort_order,
+            ],
+        )?;
+
+        let id = self.db.conn().last_insert_rowid();
+        self.get_by_id(id)?
+            .ok_or_else(|| HobbsError::NotFound("board".to_string()))
+    }
+
+    /// Get a board by ID.
+    pub fn get_by_id(&self, id: i64) -> Result<Option<Board>> {
+        let result = self.db.conn().query_row(
+            "SELECT id, name, description, board_type, min_read_role, min_write_role,
+                    sort_order, is_active, created_at
+             FROM boards WHERE id = ?",
+            [id],
+            Self::row_to_board,
+        );
+
+        match result {
+            Ok(board) => Ok(Some(board)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Get a board by name.
+    pub fn get_by_name(&self, name: &str) -> Result<Option<Board>> {
+        let result = self.db.conn().query_row(
+            "SELECT id, name, description, board_type, min_read_role, min_write_role,
+                    sort_order, is_active, created_at
+             FROM boards WHERE name = ?",
+            [name],
+            Self::row_to_board,
+        );
+
+        match result {
+            Ok(board) => Ok(Some(board)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Update a board by ID.
+    ///
+    /// Only fields that are set in the update will be modified.
+    /// Returns the updated board, or None if not found.
+    pub fn update(&self, id: i64, update: &BoardUpdate) -> Result<Option<Board>> {
+        if update.is_empty() {
+            return self.get_by_id(id);
+        }
+
+        let mut fields = Vec::new();
+        let mut values: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+        if let Some(ref name) = update.name {
+            fields.push("name = ?");
+            values.push(Box::new(name.clone()));
+        }
+        if let Some(ref description) = update.description {
+            fields.push("description = ?");
+            values.push(Box::new(description.clone()));
+        }
+        if let Some(board_type) = update.board_type {
+            fields.push("board_type = ?");
+            values.push(Box::new(board_type.as_str().to_string()));
+        }
+        if let Some(role) = update.min_read_role {
+            fields.push("min_read_role = ?");
+            values.push(Box::new(role.as_str().to_string()));
+        }
+        if let Some(role) = update.min_write_role {
+            fields.push("min_write_role = ?");
+            values.push(Box::new(role.as_str().to_string()));
+        }
+        if let Some(sort_order) = update.sort_order {
+            fields.push("sort_order = ?");
+            values.push(Box::new(sort_order));
+        }
+        if let Some(is_active) = update.is_active {
+            fields.push("is_active = ?");
+            values.push(Box::new(if is_active { 1i64 } else { 0i64 }));
+        }
+
+        let sql = format!("UPDATE boards SET {} WHERE id = ?", fields.join(", "));
+        values.push(Box::new(id));
+
+        let params: Vec<&dyn rusqlite::ToSql> = values.iter().map(|v| v.as_ref()).collect();
+        let affected = self.db.conn().execute(&sql, params.as_slice())?;
+
+        if affected == 0 {
+            return Ok(None);
+        }
+
+        self.get_by_id(id)
+    }
+
+    /// Delete a board by ID.
+    ///
+    /// Returns true if a board was deleted, false if not found.
+    pub fn delete(&self, id: i64) -> Result<bool> {
+        let affected = self
+            .db
+            .conn()
+            .execute("DELETE FROM boards WHERE id = ?", [id])?;
+        Ok(affected > 0)
+    }
+
+    /// List all active boards, ordered by sort_order.
+    pub fn list_active(&self) -> Result<Vec<Board>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, name, description, board_type, min_read_role, min_write_role,
+                    sort_order, is_active, created_at
+             FROM boards WHERE is_active = 1 ORDER BY sort_order, name",
+        )?;
+
+        let boards = stmt
+            .query_map([], Self::row_to_board)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(boards)
+    }
+
+    /// List all boards (including inactive), ordered by sort_order.
+    pub fn list_all(&self) -> Result<Vec<Board>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, name, description, board_type, min_read_role, min_write_role,
+                    sort_order, is_active, created_at
+             FROM boards ORDER BY sort_order, name",
+        )?;
+
+        let boards = stmt
+            .query_map([], Self::row_to_board)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(boards)
+    }
+
+    /// List boards accessible by a user with the given role.
+    ///
+    /// Only returns active boards where min_read_role <= user's role.
+    pub fn list_accessible(&self, user_role: Role) -> Result<Vec<Board>> {
+        let all_boards = self.list_active()?;
+        let accessible = all_boards
+            .into_iter()
+            .filter(|b| b.can_read(user_role))
+            .collect();
+        Ok(accessible)
+    }
+
+    /// List boards writable by a user with the given role.
+    ///
+    /// Only returns active boards where min_write_role <= user's role.
+    pub fn list_writable(&self, user_role: Role) -> Result<Vec<Board>> {
+        let all_boards = self.list_active()?;
+        let writable = all_boards
+            .into_iter()
+            .filter(|b| b.can_write(user_role))
+            .collect();
+        Ok(writable)
+    }
+
+    /// Count all boards.
+    pub fn count(&self) -> Result<i64> {
+        let count: i64 = self
+            .db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM boards", [], |row| row.get(0))?;
+        Ok(count)
+    }
+
+    /// Count active boards.
+    pub fn count_active(&self) -> Result<i64> {
+        let count: i64 = self.db.conn().query_row(
+            "SELECT COUNT(*) FROM boards WHERE is_active = 1",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
+    /// Check if a board name is already taken.
+    pub fn name_exists(&self, name: &str) -> Result<bool> {
+        let exists: bool = self.db.conn().query_row(
+            "SELECT EXISTS(SELECT 1 FROM boards WHERE name = ?)",
+            [name],
+            |row| row.get(0),
+        )?;
+        Ok(exists)
+    }
+
+    /// Convert a database row to a Board struct.
+    fn row_to_board(row: &Row<'_>) -> rusqlite::Result<Board> {
+        let board_type_str: String = row.get(3)?;
+        let board_type = board_type_str.parse().unwrap_or(BoardType::Thread);
+        let min_read_role_str: String = row.get(4)?;
+        let min_read_role = min_read_role_str.parse().unwrap_or(Role::Guest);
+        let min_write_role_str: String = row.get(5)?;
+        let min_write_role = min_write_role_str.parse().unwrap_or(Role::Member);
+        let is_active: i64 = row.get(7)?;
+
+        Ok(Board {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            description: row.get(2)?,
+            board_type,
+            min_read_role,
+            min_write_role,
+            sort_order: row.get(6)?,
+            is_active: is_active != 0,
+            created_at: row.get(8)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    #[test]
+    fn test_create_board() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let new_board = NewBoard::new("general");
+        let board = repo.create(&new_board).unwrap();
+
+        assert_eq!(board.id, 1);
+        assert_eq!(board.name, "general");
+        assert_eq!(board.board_type, BoardType::Thread);
+        assert_eq!(board.min_read_role, Role::Guest);
+        assert_eq!(board.min_write_role, Role::Member);
+        assert!(board.is_active);
+    }
+
+    #[test]
+    fn test_create_board_with_options() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let new_board = NewBoard::new("admin-board")
+            .with_description("For administrators only")
+            .with_board_type(BoardType::Flat)
+            .with_min_read_role(Role::SubOp)
+            .with_min_write_role(Role::SysOp)
+            .with_sort_order(100);
+
+        let board = repo.create(&new_board).unwrap();
+
+        assert_eq!(board.name, "admin-board");
+        assert_eq!(
+            board.description,
+            Some("For administrators only".to_string())
+        );
+        assert_eq!(board.board_type, BoardType::Flat);
+        assert_eq!(board.min_read_role, Role::SubOp);
+        assert_eq!(board.min_write_role, Role::SysOp);
+        assert_eq!(board.sort_order, 100);
+    }
+
+    #[test]
+    fn test_create_duplicate_name() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let new_board = NewBoard::new("general");
+        repo.create(&new_board).unwrap();
+
+        let duplicate = NewBoard::new("general");
+        let result = repo.create(&duplicate);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_by_id() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let new_board = NewBoard::new("general");
+        let created = repo.create(&new_board).unwrap();
+
+        let found = repo.get_by_id(created.id).unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "general");
+
+        let not_found = repo.get_by_id(999).unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn test_get_by_name() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let new_board = NewBoard::new("general").with_description("General discussion");
+        repo.create(&new_board).unwrap();
+
+        let found = repo.get_by_name("general").unwrap();
+        assert!(found.is_some());
+        assert_eq!(
+            found.unwrap().description,
+            Some("General discussion".to_string())
+        );
+
+        let not_found = repo.get_by_name("nonexistent").unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn test_update_board() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let new_board = NewBoard::new("general");
+        let board = repo.create(&new_board).unwrap();
+
+        let update = BoardUpdate::new()
+            .name("renamed")
+            .description(Some("Updated description".to_string()))
+            .board_type(BoardType::Flat)
+            .min_read_role(Role::Member);
+
+        let updated = repo.update(board.id, &update).unwrap().unwrap();
+
+        assert_eq!(updated.name, "renamed");
+        assert_eq!(updated.description, Some("Updated description".to_string()));
+        assert_eq!(updated.board_type, BoardType::Flat);
+        assert_eq!(updated.min_read_role, Role::Member);
+        // Unchanged fields
+        assert_eq!(updated.min_write_role, Role::Member);
+    }
+
+    #[test]
+    fn test_update_nonexistent_board() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let update = BoardUpdate::new().name("New Name");
+        let result = repo.update(999, &update).unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_update_empty() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let new_board = NewBoard::new("general");
+        let board = repo.create(&new_board).unwrap();
+
+        let update = BoardUpdate::new();
+        let result = repo.update(board.id, &update).unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name, "general");
+    }
+
+    #[test]
+    fn test_update_is_active() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let new_board = NewBoard::new("general");
+        let board = repo.create(&new_board).unwrap();
+        assert!(board.is_active);
+
+        let update = BoardUpdate::new().is_active(false);
+        let updated = repo.update(board.id, &update).unwrap().unwrap();
+
+        assert!(!updated.is_active);
+    }
+
+    #[test]
+    fn test_update_clear_description() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let new_board = NewBoard::new("general").with_description("Has description");
+        let board = repo.create(&new_board).unwrap();
+        assert!(board.description.is_some());
+
+        let update = BoardUpdate::new().description(None);
+        let updated = repo.update(board.id, &update).unwrap().unwrap();
+
+        assert!(updated.description.is_none());
+    }
+
+    #[test]
+    fn test_delete_board() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        let new_board = NewBoard::new("general");
+        let board = repo.create(&new_board).unwrap();
+
+        let deleted = repo.delete(board.id).unwrap();
+        assert!(deleted);
+
+        let found = repo.get_by_id(board.id).unwrap();
+        assert!(found.is_none());
+
+        // Deleting again should return false
+        let deleted_again = repo.delete(board.id).unwrap();
+        assert!(!deleted_again);
+    }
+
+    #[test]
+    fn test_list_active() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        // Create some boards with different sort orders
+        repo.create(&NewBoard::new("board3").with_sort_order(30))
+            .unwrap();
+        let board2 = repo
+            .create(&NewBoard::new("board2").with_sort_order(20))
+            .unwrap();
+        repo.create(&NewBoard::new("board1").with_sort_order(10))
+            .unwrap();
+
+        // Deactivate board2
+        repo.update(board2.id, &BoardUpdate::new().is_active(false))
+            .unwrap();
+
+        let active = repo.list_active().unwrap();
+        assert_eq!(active.len(), 2);
+        // Should be sorted by sort_order
+        assert_eq!(active[0].name, "board1");
+        assert_eq!(active[1].name, "board3");
+    }
+
+    #[test]
+    fn test_list_all() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        repo.create(&NewBoard::new("board1").with_sort_order(10))
+            .unwrap();
+        let board2 = repo
+            .create(&NewBoard::new("board2").with_sort_order(20))
+            .unwrap();
+        repo.create(&NewBoard::new("board3").with_sort_order(30))
+            .unwrap();
+
+        // Deactivate board2
+        repo.update(board2.id, &BoardUpdate::new().is_active(false))
+            .unwrap();
+
+        let all = repo.list_all().unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn test_list_accessible() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        // Create boards with different read permissions
+        repo.create(&NewBoard::new("public").with_min_read_role(Role::Guest))
+            .unwrap();
+        repo.create(&NewBoard::new("members").with_min_read_role(Role::Member))
+            .unwrap();
+        repo.create(&NewBoard::new("staff").with_min_read_role(Role::SubOp))
+            .unwrap();
+        repo.create(&NewBoard::new("admin").with_min_read_role(Role::SysOp))
+            .unwrap();
+
+        // Guest can only see public
+        let guest_boards = repo.list_accessible(Role::Guest).unwrap();
+        assert_eq!(guest_boards.len(), 1);
+        assert_eq!(guest_boards[0].name, "public");
+
+        // Member can see public and members
+        let member_boards = repo.list_accessible(Role::Member).unwrap();
+        assert_eq!(member_boards.len(), 2);
+
+        // SubOp can see public, members, staff
+        let subop_boards = repo.list_accessible(Role::SubOp).unwrap();
+        assert_eq!(subop_boards.len(), 3);
+
+        // SysOp can see all
+        let sysop_boards = repo.list_accessible(Role::SysOp).unwrap();
+        assert_eq!(sysop_boards.len(), 4);
+    }
+
+    #[test]
+    fn test_list_writable() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        // Create boards with different write permissions
+        repo.create(&NewBoard::new("public").with_min_write_role(Role::Guest))
+            .unwrap();
+        repo.create(&NewBoard::new("members").with_min_write_role(Role::Member))
+            .unwrap();
+        repo.create(&NewBoard::new("staff").with_min_write_role(Role::SubOp))
+            .unwrap();
+
+        // Guest can only write to public
+        let guest_boards = repo.list_writable(Role::Guest).unwrap();
+        assert_eq!(guest_boards.len(), 1);
+
+        // Member can write to public and members
+        let member_boards = repo.list_writable(Role::Member).unwrap();
+        assert_eq!(member_boards.len(), 2);
+
+        // SubOp can write to all
+        let subop_boards = repo.list_writable(Role::SubOp).unwrap();
+        assert_eq!(subop_boards.len(), 3);
+    }
+
+    #[test]
+    fn test_count() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        assert_eq!(repo.count().unwrap(), 0);
+        assert_eq!(repo.count_active().unwrap(), 0);
+
+        repo.create(&NewBoard::new("board1")).unwrap();
+        let board2 = repo.create(&NewBoard::new("board2")).unwrap();
+
+        assert_eq!(repo.count().unwrap(), 2);
+        assert_eq!(repo.count_active().unwrap(), 2);
+
+        repo.update(board2.id, &BoardUpdate::new().is_active(false))
+            .unwrap();
+
+        assert_eq!(repo.count().unwrap(), 2);
+        assert_eq!(repo.count_active().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_name_exists() {
+        let db = setup_db();
+        let repo = BoardRepository::new(&db);
+
+        assert!(!repo.name_exists("general").unwrap());
+
+        repo.create(&NewBoard::new("general")).unwrap();
+
+        assert!(repo.name_exists("general").unwrap());
+        assert!(!repo.name_exists("other").unwrap());
+    }
+}

--- a/src/board/types.rs
+++ b/src/board/types.rs
@@ -1,0 +1,367 @@
+//! Board model for HOBBS.
+//!
+//! This module defines the Board struct and BoardType enum for bulletin board management.
+
+use std::fmt;
+use std::str::FromStr;
+
+use crate::db::Role;
+
+/// Board type for distinguishing between thread-based and flat boards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BoardType {
+    /// Thread-based board where posts are grouped into threads.
+    #[default]
+    Thread,
+    /// Flat board where posts are displayed in chronological order.
+    Flat,
+}
+
+impl BoardType {
+    /// Convert board type to database string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BoardType::Thread => "thread",
+            BoardType::Flat => "flat",
+        }
+    }
+
+    /// Get display name for the board type.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            BoardType::Thread => "スレッド形式",
+            BoardType::Flat => "フラット形式",
+        }
+    }
+}
+
+impl fmt::Display for BoardType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for BoardType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "thread" => Ok(BoardType::Thread),
+            "flat" => Ok(BoardType::Flat),
+            _ => Err(format!("unknown board type: {s}")),
+        }
+    }
+}
+
+/// Board entity representing a bulletin board.
+#[derive(Debug, Clone)]
+pub struct Board {
+    /// Unique board ID.
+    pub id: i64,
+    /// Board name (unique).
+    pub name: String,
+    /// Board description.
+    pub description: Option<String>,
+    /// Board type (thread or flat).
+    pub board_type: BoardType,
+    /// Minimum role required to read posts.
+    pub min_read_role: Role,
+    /// Minimum role required to write posts.
+    pub min_write_role: Role,
+    /// Sort order for display.
+    pub sort_order: i32,
+    /// Whether the board is active.
+    pub is_active: bool,
+    /// Board creation timestamp.
+    pub created_at: String,
+}
+
+impl Board {
+    /// Check if a user with the given role can read this board.
+    pub fn can_read(&self, role: Role) -> bool {
+        role.can_access(self.min_read_role)
+    }
+
+    /// Check if a user with the given role can write to this board.
+    pub fn can_write(&self, role: Role) -> bool {
+        role.can_access(self.min_write_role)
+    }
+}
+
+/// Data for creating a new board.
+#[derive(Debug, Clone)]
+pub struct NewBoard {
+    /// Board name.
+    pub name: String,
+    /// Board description.
+    pub description: Option<String>,
+    /// Board type (defaults to Thread).
+    pub board_type: BoardType,
+    /// Minimum role required to read posts (defaults to Guest).
+    pub min_read_role: Role,
+    /// Minimum role required to write posts (defaults to Member).
+    pub min_write_role: Role,
+    /// Sort order for display (defaults to 0).
+    pub sort_order: i32,
+}
+
+impl NewBoard {
+    /// Create a new board with minimal required fields.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            board_type: BoardType::Thread,
+            min_read_role: Role::Guest,
+            min_write_role: Role::Member,
+            sort_order: 0,
+        }
+    }
+
+    /// Set the description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the board type.
+    pub fn with_board_type(mut self, board_type: BoardType) -> Self {
+        self.board_type = board_type;
+        self
+    }
+
+    /// Set the minimum read role.
+    pub fn with_min_read_role(mut self, role: Role) -> Self {
+        self.min_read_role = role;
+        self
+    }
+
+    /// Set the minimum write role.
+    pub fn with_min_write_role(mut self, role: Role) -> Self {
+        self.min_write_role = role;
+        self
+    }
+
+    /// Set the sort order.
+    pub fn with_sort_order(mut self, sort_order: i32) -> Self {
+        self.sort_order = sort_order;
+        self
+    }
+}
+
+/// Data for updating an existing board.
+#[derive(Debug, Clone, Default)]
+pub struct BoardUpdate {
+    /// New name.
+    pub name: Option<String>,
+    /// New description.
+    pub description: Option<Option<String>>,
+    /// New board type.
+    pub board_type: Option<BoardType>,
+    /// New minimum read role.
+    pub min_read_role: Option<Role>,
+    /// New minimum write role.
+    pub min_write_role: Option<Role>,
+    /// New sort order.
+    pub sort_order: Option<i32>,
+    /// New active status.
+    pub is_active: Option<bool>,
+}
+
+impl BoardUpdate {
+    /// Create an empty update.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set new name.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Set new description.
+    pub fn description(mut self, description: Option<String>) -> Self {
+        self.description = Some(description);
+        self
+    }
+
+    /// Set new board type.
+    pub fn board_type(mut self, board_type: BoardType) -> Self {
+        self.board_type = Some(board_type);
+        self
+    }
+
+    /// Set new minimum read role.
+    pub fn min_read_role(mut self, role: Role) -> Self {
+        self.min_read_role = Some(role);
+        self
+    }
+
+    /// Set new minimum write role.
+    pub fn min_write_role(mut self, role: Role) -> Self {
+        self.min_write_role = Some(role);
+        self
+    }
+
+    /// Set new sort order.
+    pub fn sort_order(mut self, sort_order: i32) -> Self {
+        self.sort_order = Some(sort_order);
+        self
+    }
+
+    /// Set active status.
+    pub fn is_active(mut self, is_active: bool) -> Self {
+        self.is_active = Some(is_active);
+        self
+    }
+
+    /// Check if any fields are set.
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none()
+            && self.description.is_none()
+            && self.board_type.is_none()
+            && self.min_read_role.is_none()
+            && self.min_write_role.is_none()
+            && self.sort_order.is_none()
+            && self.is_active.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_board_type_as_str() {
+        assert_eq!(BoardType::Thread.as_str(), "thread");
+        assert_eq!(BoardType::Flat.as_str(), "flat");
+    }
+
+    #[test]
+    fn test_board_type_display_name() {
+        assert_eq!(BoardType::Thread.display_name(), "スレッド形式");
+        assert_eq!(BoardType::Flat.display_name(), "フラット形式");
+    }
+
+    #[test]
+    fn test_board_type_from_str() {
+        assert_eq!(BoardType::from_str("thread").unwrap(), BoardType::Thread);
+        assert_eq!(BoardType::from_str("flat").unwrap(), BoardType::Flat);
+        assert_eq!(BoardType::from_str("THREAD").unwrap(), BoardType::Thread);
+        assert!(BoardType::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_board_type_display() {
+        assert_eq!(format!("{}", BoardType::Thread), "thread");
+        assert_eq!(format!("{}", BoardType::Flat), "flat");
+    }
+
+    #[test]
+    fn test_board_type_default() {
+        assert_eq!(BoardType::default(), BoardType::Thread);
+    }
+
+    #[test]
+    fn test_board_can_read() {
+        let board = Board {
+            id: 1,
+            name: "test".to_string(),
+            description: None,
+            board_type: BoardType::Thread,
+            min_read_role: Role::Member,
+            min_write_role: Role::Member,
+            sort_order: 0,
+            is_active: true,
+            created_at: "2024-01-01".to_string(),
+        };
+
+        assert!(!board.can_read(Role::Guest));
+        assert!(board.can_read(Role::Member));
+        assert!(board.can_read(Role::SubOp));
+        assert!(board.can_read(Role::SysOp));
+    }
+
+    #[test]
+    fn test_board_can_write() {
+        let board = Board {
+            id: 1,
+            name: "test".to_string(),
+            description: None,
+            board_type: BoardType::Thread,
+            min_read_role: Role::Guest,
+            min_write_role: Role::SubOp,
+            sort_order: 0,
+            is_active: true,
+            created_at: "2024-01-01".to_string(),
+        };
+
+        assert!(!board.can_write(Role::Guest));
+        assert!(!board.can_write(Role::Member));
+        assert!(board.can_write(Role::SubOp));
+        assert!(board.can_write(Role::SysOp));
+    }
+
+    #[test]
+    fn test_new_board_builder() {
+        let board = NewBoard::new("Test Board")
+            .with_description("Test description")
+            .with_board_type(BoardType::Flat)
+            .with_min_read_role(Role::Member)
+            .with_min_write_role(Role::SubOp)
+            .with_sort_order(10);
+
+        assert_eq!(board.name, "Test Board");
+        assert_eq!(board.description, Some("Test description".to_string()));
+        assert_eq!(board.board_type, BoardType::Flat);
+        assert_eq!(board.min_read_role, Role::Member);
+        assert_eq!(board.min_write_role, Role::SubOp);
+        assert_eq!(board.sort_order, 10);
+    }
+
+    #[test]
+    fn test_new_board_defaults() {
+        let board = NewBoard::new("Test Board");
+
+        assert_eq!(board.name, "Test Board");
+        assert_eq!(board.description, None);
+        assert_eq!(board.board_type, BoardType::Thread);
+        assert_eq!(board.min_read_role, Role::Guest);
+        assert_eq!(board.min_write_role, Role::Member);
+        assert_eq!(board.sort_order, 0);
+    }
+
+    #[test]
+    fn test_board_update_builder() {
+        let update = BoardUpdate::new()
+            .name("New Name")
+            .description(Some("New description".to_string()))
+            .board_type(BoardType::Flat)
+            .min_read_role(Role::Member)
+            .is_active(false);
+
+        assert_eq!(update.name, Some("New Name".to_string()));
+        assert_eq!(
+            update.description,
+            Some(Some("New description".to_string()))
+        );
+        assert_eq!(update.board_type, Some(BoardType::Flat));
+        assert_eq!(update.min_read_role, Some(Role::Member));
+        assert_eq!(update.is_active, Some(false));
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_board_update_empty() {
+        let update = BoardUpdate::new();
+        assert!(update.is_empty());
+    }
+
+    #[test]
+    fn test_board_update_clear_description() {
+        let update = BoardUpdate::new().description(None);
+        assert_eq!(update.description, Some(None));
+        assert!(!update.is_empty());
+    }
+}

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -32,6 +32,24 @@ CREATE INDEX idx_users_role ON users(role);
     r#"
 ALTER TABLE users ADD COLUMN encoding TEXT NOT NULL DEFAULT 'shiftjis';
 "#,
+    // v3: Boards table for bulletin board management
+    r#"
+-- Boards table for bulletin board management
+CREATE TABLE boards (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    name            TEXT NOT NULL UNIQUE,
+    description     TEXT,
+    board_type      TEXT NOT NULL DEFAULT 'thread',  -- 'thread' or 'flat'
+    min_read_role   TEXT NOT NULL DEFAULT 'guest',   -- minimum role to read
+    min_write_role  TEXT NOT NULL DEFAULT 'member',  -- minimum role to write
+    sort_order      INTEGER NOT NULL DEFAULT 0,
+    is_active       INTEGER NOT NULL DEFAULT 1,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_boards_sort_order ON boards(sort_order);
+CREATE INDEX idx_boards_is_active ON boards(is_active);
+"#,
 ];
 
 #[cfg(test)]
@@ -63,5 +81,15 @@ mod tests {
                     || migration.contains("CREATE INDEX")
             );
         }
+    }
+
+    #[test]
+    fn test_boards_migration_contains_boards_table() {
+        let boards_migration = MIGRATIONS[2];
+        assert!(boards_migration.contains("CREATE TABLE boards"));
+        assert!(boards_migration.contains("name"));
+        assert!(boards_migration.contains("board_type"));
+        assert!(boards_migration.contains("min_read_role"));
+        assert!(boards_migration.contains("min_write_role"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! A retro BBS host program accessible via Telnet, implemented in Rust.
 
 pub mod auth;
+pub mod board;
 pub mod config;
 pub mod db;
 pub mod error;
@@ -18,6 +19,7 @@ pub use auth::{
     RegistrationError, RegistrationRequest, SessionError, SessionManager, UserProfile,
     ValidationError, MAX_PROFILE_LENGTH,
 };
+pub use board::{Board, BoardRepository, BoardType, BoardUpdate, NewBoard};
 pub use config::Config;
 pub use db::{Database, NewUser, Role, User, UserRepository, UserUpdate};
 pub use error::{HobbsError, Result};


### PR DESCRIPTION
## Summary

- boards テーブルのマイグレーション (v3) を追加
- `Board`, `BoardType`, `NewBoard`, `BoardUpdate` 構造体を定義
- `BoardRepository` で CRUD 操作を実装
- 権限による絞り込み機能 (`list_accessible`, `list_writable`)
- 30件の単体テストを追加
- Phase 3, 3.5 の完了マークを `implementation_plan.md` に追加

## Test plan

- [x] `cargo test` で全336テストが通ること
- [x] `cargo clippy` で警告がないこと
- [x] 新規追加した30件のboardテストが通ること

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)