### PR TITLE
[Phase 4-2] スレッド・投稿テーブル実装

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -2,11 +2,21 @@
 //!
 //! This module provides bulletin board functionality including:
 //! - Board management (create, read, update, delete)
+//! - Thread management for thread-based boards
+//! - Post management for both thread and flat boards
 //! - Board types (thread-based and flat)
 //! - Role-based access control for read/write permissions
 
+mod post;
+mod post_repository;
 mod repository;
+mod thread;
+mod thread_repository;
 mod types;
 
+pub use post::{NewFlatPost, NewThreadPost, Post, PostUpdate};
+pub use post_repository::PostRepository;
 pub use repository::BoardRepository;
+pub use thread::{NewThread, Thread, ThreadUpdate};
+pub use thread_repository::ThreadRepository;
 pub use types::{Board, BoardType, BoardUpdate, NewBoard};

--- a/src/board/post.rs
+++ b/src/board/post.rs
@@ -1,0 +1,212 @@
+//! Post model for HOBBS.
+//!
+//! This module defines the Post struct for both thread-based and flat boards.
+
+/// Post entity representing a message in a board or thread.
+#[derive(Debug, Clone)]
+pub struct Post {
+    /// Unique post ID.
+    pub id: i64,
+    /// ID of the board this post belongs to.
+    pub board_id: i64,
+    /// ID of the thread this post belongs to (None for flat boards).
+    pub thread_id: Option<i64>,
+    /// ID of the user who created the post.
+    pub author_id: i64,
+    /// Post title (used for flat boards, None for thread posts).
+    pub title: Option<String>,
+    /// Post body/content.
+    pub body: String,
+    /// Post creation timestamp.
+    pub created_at: String,
+}
+
+impl Post {
+    /// Check if this post is in a thread (thread-based board).
+    pub fn is_thread_post(&self) -> bool {
+        self.thread_id.is_some()
+    }
+
+    /// Check if this post is a flat post (flat board).
+    pub fn is_flat_post(&self) -> bool {
+        self.thread_id.is_none()
+    }
+}
+
+/// Data for creating a new post in a thread.
+#[derive(Debug, Clone)]
+pub struct NewThreadPost {
+    /// ID of the board.
+    pub board_id: i64,
+    /// ID of the thread to post in.
+    pub thread_id: i64,
+    /// ID of the user creating the post.
+    pub author_id: i64,
+    /// Post body/content.
+    pub body: String,
+}
+
+impl NewThreadPost {
+    /// Create a new thread post with required fields.
+    pub fn new(board_id: i64, thread_id: i64, author_id: i64, body: impl Into<String>) -> Self {
+        Self {
+            board_id,
+            thread_id,
+            author_id,
+            body: body.into(),
+        }
+    }
+}
+
+/// Data for creating a new post in a flat board.
+#[derive(Debug, Clone)]
+pub struct NewFlatPost {
+    /// ID of the board.
+    pub board_id: i64,
+    /// ID of the user creating the post.
+    pub author_id: i64,
+    /// Post title.
+    pub title: String,
+    /// Post body/content.
+    pub body: String,
+}
+
+impl NewFlatPost {
+    /// Create a new flat post with required fields.
+    pub fn new(
+        board_id: i64,
+        author_id: i64,
+        title: impl Into<String>,
+        body: impl Into<String>,
+    ) -> Self {
+        Self {
+            board_id,
+            author_id,
+            title: title.into(),
+            body: body.into(),
+        }
+    }
+}
+
+/// Data for updating an existing post.
+#[derive(Debug, Clone, Default)]
+pub struct PostUpdate {
+    /// New title (for flat posts).
+    pub title: Option<Option<String>>,
+    /// New body.
+    pub body: Option<String>,
+}
+
+impl PostUpdate {
+    /// Create an empty update.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set new title.
+    pub fn title(mut self, title: Option<String>) -> Self {
+        self.title = Some(title);
+        self
+    }
+
+    /// Set new body.
+    pub fn body(mut self, body: impl Into<String>) -> Self {
+        self.body = Some(body.into());
+        self
+    }
+
+    /// Check if any fields are set.
+    pub fn is_empty(&self) -> bool {
+        self.title.is_none() && self.body.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_post_is_thread_post() {
+        let post = Post {
+            id: 1,
+            board_id: 1,
+            thread_id: Some(1),
+            author_id: 1,
+            title: None,
+            body: "Test".to_string(),
+            created_at: "2024-01-01".to_string(),
+        };
+        assert!(post.is_thread_post());
+        assert!(!post.is_flat_post());
+    }
+
+    #[test]
+    fn test_post_is_flat_post() {
+        let post = Post {
+            id: 1,
+            board_id: 1,
+            thread_id: None,
+            author_id: 1,
+            title: Some("Title".to_string()),
+            body: "Test".to_string(),
+            created_at: "2024-01-01".to_string(),
+        };
+        assert!(!post.is_thread_post());
+        assert!(post.is_flat_post());
+    }
+
+    #[test]
+    fn test_new_thread_post() {
+        let post = NewThreadPost::new(1, 2, 3, "Hello World");
+        assert_eq!(post.board_id, 1);
+        assert_eq!(post.thread_id, 2);
+        assert_eq!(post.author_id, 3);
+        assert_eq!(post.body, "Hello World");
+    }
+
+    #[test]
+    fn test_new_flat_post() {
+        let post = NewFlatPost::new(1, 2, "Title", "Body");
+        assert_eq!(post.board_id, 1);
+        assert_eq!(post.author_id, 2);
+        assert_eq!(post.title, "Title");
+        assert_eq!(post.body, "Body");
+    }
+
+    #[test]
+    fn test_post_update_empty() {
+        let update = PostUpdate::new();
+        assert!(update.is_empty());
+    }
+
+    #[test]
+    fn test_post_update_body() {
+        let update = PostUpdate::new().body("New Body");
+        assert_eq!(update.body, Some("New Body".to_string()));
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_post_update_title() {
+        let update = PostUpdate::new().title(Some("New Title".to_string()));
+        assert_eq!(update.title, Some(Some("New Title".to_string())));
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_post_update_clear_title() {
+        let update = PostUpdate::new().title(None);
+        assert_eq!(update.title, Some(None));
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_post_update_combined() {
+        let update = PostUpdate::new()
+            .title(Some("New Title".to_string()))
+            .body("New Body");
+        assert_eq!(update.title, Some(Some("New Title".to_string())));
+        assert_eq!(update.body, Some("New Body".to_string()));
+        assert!(!update.is_empty());
+    }
+}

--- a/src/board/post_repository.rs
+++ b/src/board/post_repository.rs
@@ -1,0 +1,634 @@
+//! Post repository for HOBBS.
+//!
+//! This module provides CRUD operations for posts in the database.
+
+use rusqlite::{params, Row};
+
+use super::post::{NewFlatPost, NewThreadPost, Post, PostUpdate};
+use crate::db::Database;
+use crate::{HobbsError, Result};
+
+/// Repository for post CRUD operations.
+pub struct PostRepository<'a> {
+    db: &'a Database,
+}
+
+impl<'a> PostRepository<'a> {
+    /// Create a new PostRepository with the given database reference.
+    pub fn new(db: &'a Database) -> Self {
+        Self { db }
+    }
+
+    /// Create a new post in a thread.
+    ///
+    /// Returns the created post with the assigned ID.
+    pub fn create_thread_post(&self, new_post: &NewThreadPost) -> Result<Post> {
+        self.db.conn().execute(
+            "INSERT INTO posts (board_id, thread_id, author_id, body) VALUES (?, ?, ?, ?)",
+            params![
+                new_post.board_id,
+                new_post.thread_id,
+                new_post.author_id,
+                &new_post.body,
+            ],
+        )?;
+
+        let id = self.db.conn().last_insert_rowid();
+        self.get_by_id(id)?
+            .ok_or_else(|| HobbsError::NotFound("post".to_string()))
+    }
+
+    /// Create a new post in a flat board.
+    ///
+    /// Returns the created post with the assigned ID.
+    pub fn create_flat_post(&self, new_post: &NewFlatPost) -> Result<Post> {
+        self.db.conn().execute(
+            "INSERT INTO posts (board_id, author_id, title, body) VALUES (?, ?, ?, ?)",
+            params![
+                new_post.board_id,
+                new_post.author_id,
+                &new_post.title,
+                &new_post.body,
+            ],
+        )?;
+
+        let id = self.db.conn().last_insert_rowid();
+        self.get_by_id(id)?
+            .ok_or_else(|| HobbsError::NotFound("post".to_string()))
+    }
+
+    /// Get a post by ID.
+    pub fn get_by_id(&self, id: i64) -> Result<Option<Post>> {
+        let result = self.db.conn().query_row(
+            "SELECT id, board_id, thread_id, author_id, title, body, created_at
+             FROM posts WHERE id = ?",
+            [id],
+            Self::row_to_post,
+        );
+
+        match result {
+            Ok(post) => Ok(Some(post)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Update a post by ID.
+    ///
+    /// Only fields that are set in the update will be modified.
+    /// Returns the updated post, or None if not found.
+    pub fn update(&self, id: i64, update: &PostUpdate) -> Result<Option<Post>> {
+        if update.is_empty() {
+            return self.get_by_id(id);
+        }
+
+        let mut fields = Vec::new();
+        let mut values: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+        if let Some(ref title) = update.title {
+            fields.push("title = ?");
+            values.push(Box::new(title.clone()));
+        }
+        if let Some(ref body) = update.body {
+            fields.push("body = ?");
+            values.push(Box::new(body.clone()));
+        }
+
+        let sql = format!("UPDATE posts SET {} WHERE id = ?", fields.join(", "));
+        values.push(Box::new(id));
+
+        let params: Vec<&dyn rusqlite::ToSql> = values.iter().map(|v| v.as_ref()).collect();
+        let affected = self.db.conn().execute(&sql, params.as_slice())?;
+
+        if affected == 0 {
+            return Ok(None);
+        }
+
+        self.get_by_id(id)
+    }
+
+    /// Delete a post by ID.
+    ///
+    /// Returns true if a post was deleted, false if not found.
+    pub fn delete(&self, id: i64) -> Result<bool> {
+        let affected = self
+            .db
+            .conn()
+            .execute("DELETE FROM posts WHERE id = ?", [id])?;
+        Ok(affected > 0)
+    }
+
+    /// List posts in a thread, ordered by created_at ascending.
+    pub fn list_by_thread(&self, thread_id: i64) -> Result<Vec<Post>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, board_id, thread_id, author_id, title, body, created_at
+             FROM posts WHERE thread_id = ? ORDER BY created_at ASC",
+        )?;
+
+        let posts = stmt
+            .query_map([thread_id], Self::row_to_post)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(posts)
+    }
+
+    /// List posts in a thread with pagination.
+    pub fn list_by_thread_paginated(
+        &self,
+        thread_id: i64,
+        offset: i64,
+        limit: i64,
+    ) -> Result<Vec<Post>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, board_id, thread_id, author_id, title, body, created_at
+             FROM posts WHERE thread_id = ? ORDER BY created_at ASC LIMIT ? OFFSET ?",
+        )?;
+
+        let posts = stmt
+            .query_map([thread_id, limit, offset], Self::row_to_post)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(posts)
+    }
+
+    /// List posts in a flat board (posts without thread_id), ordered by created_at descending.
+    pub fn list_by_flat_board(&self, board_id: i64) -> Result<Vec<Post>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, board_id, thread_id, author_id, title, body, created_at
+             FROM posts WHERE board_id = ? AND thread_id IS NULL ORDER BY created_at DESC, id DESC",
+        )?;
+
+        let posts = stmt
+            .query_map([board_id], Self::row_to_post)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(posts)
+    }
+
+    /// List posts in a flat board with pagination.
+    pub fn list_by_flat_board_paginated(
+        &self,
+        board_id: i64,
+        offset: i64,
+        limit: i64,
+    ) -> Result<Vec<Post>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, board_id, thread_id, author_id, title, body, created_at
+             FROM posts WHERE board_id = ? AND thread_id IS NULL
+             ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?",
+        )?;
+
+        let posts = stmt
+            .query_map([board_id, limit, offset], Self::row_to_post)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(posts)
+    }
+
+    /// List posts by author.
+    pub fn list_by_author(&self, author_id: i64) -> Result<Vec<Post>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, board_id, thread_id, author_id, title, body, created_at
+             FROM posts WHERE author_id = ? ORDER BY created_at DESC",
+        )?;
+
+        let posts = stmt
+            .query_map([author_id], Self::row_to_post)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(posts)
+    }
+
+    /// Count posts in a thread.
+    pub fn count_by_thread(&self, thread_id: i64) -> Result<i64> {
+        let count: i64 = self.db.conn().query_row(
+            "SELECT COUNT(*) FROM posts WHERE thread_id = ?",
+            [thread_id],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
+    /// Count posts in a flat board.
+    pub fn count_by_flat_board(&self, board_id: i64) -> Result<i64> {
+        let count: i64 = self.db.conn().query_row(
+            "SELECT COUNT(*) FROM posts WHERE board_id = ? AND thread_id IS NULL",
+            [board_id],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
+    /// Get the latest post in a thread.
+    pub fn get_latest_in_thread(&self, thread_id: i64) -> Result<Option<Post>> {
+        let result = self.db.conn().query_row(
+            "SELECT id, board_id, thread_id, author_id, title, body, created_at
+             FROM posts WHERE thread_id = ? ORDER BY created_at DESC, id DESC LIMIT 1",
+            [thread_id],
+            Self::row_to_post,
+        );
+
+        match result {
+            Ok(post) => Ok(Some(post)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Convert a database row to a Post struct.
+    fn row_to_post(row: &Row<'_>) -> rusqlite::Result<Post> {
+        Ok(Post {
+            id: row.get(0)?,
+            board_id: row.get(1)?,
+            thread_id: row.get(2)?,
+            author_id: row.get(3)?,
+            title: row.get(4)?,
+            body: row.get(5)?,
+            created_at: row.get(6)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::board::{BoardRepository, BoardType, NewBoard, NewThread, ThreadRepository};
+    use crate::db::{NewUser, UserRepository};
+
+    fn setup_db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    fn create_test_board(db: &Database, board_type: BoardType) -> i64 {
+        let repo = BoardRepository::new(db);
+        let board = repo
+            .create(&NewBoard::new("test-board").with_board_type(board_type))
+            .unwrap();
+        board.id
+    }
+
+    fn create_test_user(db: &Database) -> i64 {
+        let repo = UserRepository::new(db);
+        let user = repo
+            .create(&NewUser::new("testuser", "hash", "Test User"))
+            .unwrap();
+        user.id
+    }
+
+    fn create_test_thread(db: &Database, board_id: i64, author_id: i64) -> i64 {
+        let repo = ThreadRepository::new(db);
+        let thread = repo
+            .create(&NewThread::new(board_id, "Test Thread", author_id))
+            .unwrap();
+        thread.id
+    }
+
+    // Thread post tests
+    #[test]
+    fn test_create_thread_post() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Thread);
+        let author_id = create_test_user(&db);
+        let thread_id = create_test_thread(&db, board_id, author_id);
+        let repo = PostRepository::new(&db);
+
+        let new_post = NewThreadPost::new(board_id, thread_id, author_id, "Hello World");
+        let post = repo.create_thread_post(&new_post).unwrap();
+
+        assert_eq!(post.board_id, board_id);
+        assert_eq!(post.thread_id, Some(thread_id));
+        assert_eq!(post.author_id, author_id);
+        assert_eq!(post.body, "Hello World");
+        assert!(post.title.is_none());
+        assert!(post.is_thread_post());
+    }
+
+    #[test]
+    fn test_create_flat_post() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Flat);
+        let author_id = create_test_user(&db);
+        let repo = PostRepository::new(&db);
+
+        let new_post = NewFlatPost::new(board_id, author_id, "Test Title", "Hello World");
+        let post = repo.create_flat_post(&new_post).unwrap();
+
+        assert_eq!(post.board_id, board_id);
+        assert!(post.thread_id.is_none());
+        assert_eq!(post.author_id, author_id);
+        assert_eq!(post.title, Some("Test Title".to_string()));
+        assert_eq!(post.body, "Hello World");
+        assert!(post.is_flat_post());
+    }
+
+    #[test]
+    fn test_get_by_id() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Thread);
+        let author_id = create_test_user(&db);
+        let thread_id = create_test_thread(&db, board_id, author_id);
+        let repo = PostRepository::new(&db);
+
+        let new_post = NewThreadPost::new(board_id, thread_id, author_id, "Hello");
+        let created = repo.create_thread_post(&new_post).unwrap();
+
+        let found = repo.get_by_id(created.id).unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().body, "Hello");
+
+        let not_found = repo.get_by_id(999).unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn test_update_post_body() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Thread);
+        let author_id = create_test_user(&db);
+        let thread_id = create_test_thread(&db, board_id, author_id);
+        let repo = PostRepository::new(&db);
+
+        let new_post = NewThreadPost::new(board_id, thread_id, author_id, "Original Body");
+        let post = repo.create_thread_post(&new_post).unwrap();
+
+        let update = PostUpdate::new().body("Updated Body");
+        let updated = repo.update(post.id, &update).unwrap().unwrap();
+
+        assert_eq!(updated.body, "Updated Body");
+    }
+
+    #[test]
+    fn test_update_post_title() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Flat);
+        let author_id = create_test_user(&db);
+        let repo = PostRepository::new(&db);
+
+        let new_post = NewFlatPost::new(board_id, author_id, "Original Title", "Body");
+        let post = repo.create_flat_post(&new_post).unwrap();
+
+        let update = PostUpdate::new().title(Some("Updated Title".to_string()));
+        let updated = repo.update(post.id, &update).unwrap().unwrap();
+
+        assert_eq!(updated.title, Some("Updated Title".to_string()));
+    }
+
+    #[test]
+    fn test_update_empty() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Thread);
+        let author_id = create_test_user(&db);
+        let thread_id = create_test_thread(&db, board_id, author_id);
+        let repo = PostRepository::new(&db);
+
+        let new_post = NewThreadPost::new(board_id, thread_id, author_id, "Hello");
+        let post = repo.create_thread_post(&new_post).unwrap();
+
+        let update = PostUpdate::new();
+        let result = repo.update(post.id, &update).unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().body, "Hello");
+    }
+
+    #[test]
+    fn test_update_nonexistent_post() {
+        let db = setup_db();
+        let repo = PostRepository::new(&db);
+
+        let update = PostUpdate::new().body("New Body");
+        let result = repo.update(999, &update).unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_delete_post() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Thread);
+        let author_id = create_test_user(&db);
+        let thread_id = create_test_thread(&db, board_id, author_id);
+        let repo = PostRepository::new(&db);
+
+        let new_post = NewThreadPost::new(board_id, thread_id, author_id, "Hello");
+        let post = repo.create_thread_post(&new_post).unwrap();
+
+        let deleted = repo.delete(post.id).unwrap();
+        assert!(deleted);
+
+        let found = repo.get_by_id(post.id).unwrap();
+        assert!(found.is_none());
+
+        // Deleting again should return false
+        let deleted_again = repo.delete(post.id).unwrap();
+        assert!(!deleted_again);
+    }
+
+    #[test]
+    fn test_list_by_thread() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Thread);
+        let author_id = create_test_user(&db);
+        let thread_id = create_test_thread(&db, board_id, author_id);
+        let repo = PostRepository::new(&db);
+
+        // Create some posts
+        repo.create_thread_post(&NewThreadPost::new(
+            board_id, thread_id, author_id, "Post 1",
+        ))
+        .unwrap();
+        repo.create_thread_post(&NewThreadPost::new(
+            board_id, thread_id, author_id, "Post 2",
+        ))
+        .unwrap();
+        repo.create_thread_post(&NewThreadPost::new(
+            board_id, thread_id, author_id, "Post 3",
+        ))
+        .unwrap();
+
+        let posts = repo.list_by_thread(thread_id).unwrap();
+        assert_eq!(posts.len(), 3);
+        // Should be ordered by created_at ASC
+        assert_eq!(posts[0].body, "Post 1");
+        assert_eq!(posts[2].body, "Post 3");
+    }
+
+    #[test]
+    fn test_list_by_thread_paginated() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Thread);
+        let author_id = create_test_user(&db);
+        let thread_id = create_test_thread(&db, board_id, author_id);
+        let repo = PostRepository::new(&db);
+
+        // Create some posts
+        for i in 1..=5 {
+            repo.create_thread_post(&NewThreadPost::new(
+                board_id,
+                thread_id,
+                author_id,
+                format!("Post {i}"),
+            ))
+            .unwrap();
+        }
+
+        // Get first page
+        let page1 = repo.list_by_thread_paginated(thread_id, 0, 2).unwrap();
+        assert_eq!(page1.len(), 2);
+        assert_eq!(page1[0].body, "Post 1");
+        assert_eq!(page1[1].body, "Post 2");
+
+        // Get second page
+        let page2 = repo.list_by_thread_paginated(thread_id, 2, 2).unwrap();
+        assert_eq!(page2.len(), 2);
+        assert_eq!(page2[0].body, "Post 3");
+        assert_eq!(page2[1].body, "Post 4");
+    }
+
+    #[test]
+    fn test_list_by_flat_board() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Flat);
+        let author_id = create_test_user(&db);
+        let repo = PostRepository::new(&db);
+
+        // Create some flat posts
+        repo.create_flat_post(&NewFlatPost::new(board_id, author_id, "Title 1", "Body 1"))
+            .unwrap();
+        repo.create_flat_post(&NewFlatPost::new(board_id, author_id, "Title 2", "Body 2"))
+            .unwrap();
+        repo.create_flat_post(&NewFlatPost::new(board_id, author_id, "Title 3", "Body 3"))
+            .unwrap();
+
+        let posts = repo.list_by_flat_board(board_id).unwrap();
+        assert_eq!(posts.len(), 3);
+        // Should be ordered by created_at DESC
+        assert_eq!(posts[0].title, Some("Title 3".to_string()));
+    }
+
+    #[test]
+    fn test_list_by_flat_board_paginated() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Flat);
+        let author_id = create_test_user(&db);
+        let repo = PostRepository::new(&db);
+
+        // Create some flat posts
+        for i in 1..=5 {
+            repo.create_flat_post(&NewFlatPost::new(
+                board_id,
+                author_id,
+                format!("Title {i}"),
+                format!("Body {i}"),
+            ))
+            .unwrap();
+        }
+
+        // Get first page
+        let page1 = repo.list_by_flat_board_paginated(board_id, 0, 2).unwrap();
+        assert_eq!(page1.len(), 2);
+        assert_eq!(page1[0].title, Some("Title 5".to_string()));
+        assert_eq!(page1[1].title, Some("Title 4".to_string()));
+    }
+
+    #[test]
+    fn test_list_by_author() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Flat);
+        let author_id = create_test_user(&db);
+
+        // Create another user
+        let user_repo = UserRepository::new(&db);
+        let other_author = user_repo
+            .create(&NewUser::new("other", "hash", "Other"))
+            .unwrap();
+
+        let repo = PostRepository::new(&db);
+
+        // Create posts by different authors
+        repo.create_flat_post(&NewFlatPost::new(board_id, author_id, "Title 1", "Body 1"))
+            .unwrap();
+        repo.create_flat_post(&NewFlatPost::new(
+            board_id,
+            other_author.id,
+            "Title 2",
+            "Body 2",
+        ))
+        .unwrap();
+        repo.create_flat_post(&NewFlatPost::new(board_id, author_id, "Title 3", "Body 3"))
+            .unwrap();
+
+        let posts = repo.list_by_author(author_id).unwrap();
+        assert_eq!(posts.len(), 2);
+    }
+
+    #[test]
+    fn test_count_by_thread() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Thread);
+        let author_id = create_test_user(&db);
+        let thread_id = create_test_thread(&db, board_id, author_id);
+        let repo = PostRepository::new(&db);
+
+        assert_eq!(repo.count_by_thread(thread_id).unwrap(), 0);
+
+        repo.create_thread_post(&NewThreadPost::new(
+            board_id, thread_id, author_id, "Post 1",
+        ))
+        .unwrap();
+        repo.create_thread_post(&NewThreadPost::new(
+            board_id, thread_id, author_id, "Post 2",
+        ))
+        .unwrap();
+
+        assert_eq!(repo.count_by_thread(thread_id).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_count_by_flat_board() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Flat);
+        let author_id = create_test_user(&db);
+        let repo = PostRepository::new(&db);
+
+        assert_eq!(repo.count_by_flat_board(board_id).unwrap(), 0);
+
+        repo.create_flat_post(&NewFlatPost::new(board_id, author_id, "Title 1", "Body 1"))
+            .unwrap();
+        repo.create_flat_post(&NewFlatPost::new(board_id, author_id, "Title 2", "Body 2"))
+            .unwrap();
+
+        assert_eq!(repo.count_by_flat_board(board_id).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_get_latest_in_thread() {
+        let db = setup_db();
+        let board_id = create_test_board(&db, BoardType::Thread);
+        let author_id = create_test_user(&db);
+        let thread_id = create_test_thread(&db, board_id, author_id);
+        let repo = PostRepository::new(&db);
+
+        // No posts yet
+        let latest = repo.get_latest_in_thread(thread_id).unwrap();
+        assert!(latest.is_none());
+
+        // Add some posts
+        repo.create_thread_post(&NewThreadPost::new(
+            board_id, thread_id, author_id, "Post 1",
+        ))
+        .unwrap();
+        repo.create_thread_post(&NewThreadPost::new(
+            board_id, thread_id, author_id, "Post 2",
+        ))
+        .unwrap();
+        repo.create_thread_post(&NewThreadPost::new(
+            board_id, thread_id, author_id, "Post 3",
+        ))
+        .unwrap();
+
+        let latest = repo.get_latest_in_thread(thread_id).unwrap();
+        assert!(latest.is_some());
+        assert_eq!(latest.unwrap().body, "Post 3");
+    }
+}

--- a/src/board/thread.rs
+++ b/src/board/thread.rs
@@ -1,0 +1,150 @@
+//! Thread model for HOBBS.
+//!
+//! This module defines the Thread struct for thread-based boards.
+
+/// Thread entity representing a discussion thread in a board.
+#[derive(Debug, Clone)]
+pub struct Thread {
+    /// Unique thread ID.
+    pub id: i64,
+    /// ID of the board this thread belongs to.
+    pub board_id: i64,
+    /// Thread title.
+    pub title: String,
+    /// ID of the user who created the thread.
+    pub author_id: i64,
+    /// Number of posts in this thread.
+    pub post_count: i32,
+    /// Thread creation timestamp.
+    pub created_at: String,
+    /// Last update timestamp (when a new post was added).
+    pub updated_at: String,
+}
+
+/// Data for creating a new thread.
+#[derive(Debug, Clone)]
+pub struct NewThread {
+    /// ID of the board to create the thread in.
+    pub board_id: i64,
+    /// Thread title.
+    pub title: String,
+    /// ID of the user creating the thread.
+    pub author_id: i64,
+}
+
+impl NewThread {
+    /// Create a new thread with required fields.
+    pub fn new(board_id: i64, title: impl Into<String>, author_id: i64) -> Self {
+        Self {
+            board_id,
+            title: title.into(),
+            author_id,
+        }
+    }
+}
+
+/// Data for updating an existing thread.
+#[derive(Debug, Clone, Default)]
+pub struct ThreadUpdate {
+    /// New title.
+    pub title: Option<String>,
+    /// Increment post count by this amount.
+    pub post_count_delta: Option<i32>,
+    /// Update the updated_at timestamp to now.
+    pub touch: bool,
+}
+
+impl ThreadUpdate {
+    /// Create an empty update.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set new title.
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Increment post count.
+    pub fn increment_post_count(mut self) -> Self {
+        self.post_count_delta = Some(1);
+        self
+    }
+
+    /// Decrement post count.
+    pub fn decrement_post_count(mut self) -> Self {
+        self.post_count_delta = Some(-1);
+        self
+    }
+
+    /// Update the updated_at timestamp.
+    pub fn touch(mut self) -> Self {
+        self.touch = true;
+        self
+    }
+
+    /// Check if any fields are set.
+    pub fn is_empty(&self) -> bool {
+        self.title.is_none() && self.post_count_delta.is_none() && !self.touch
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_thread() {
+        let thread = NewThread::new(1, "Test Thread", 42);
+        assert_eq!(thread.board_id, 1);
+        assert_eq!(thread.title, "Test Thread");
+        assert_eq!(thread.author_id, 42);
+    }
+
+    #[test]
+    fn test_thread_update_empty() {
+        let update = ThreadUpdate::new();
+        assert!(update.is_empty());
+    }
+
+    #[test]
+    fn test_thread_update_title() {
+        let update = ThreadUpdate::new().title("New Title");
+        assert_eq!(update.title, Some("New Title".to_string()));
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_thread_update_increment_post_count() {
+        let update = ThreadUpdate::new().increment_post_count();
+        assert_eq!(update.post_count_delta, Some(1));
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_thread_update_decrement_post_count() {
+        let update = ThreadUpdate::new().decrement_post_count();
+        assert_eq!(update.post_count_delta, Some(-1));
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_thread_update_touch() {
+        let update = ThreadUpdate::new().touch();
+        assert!(update.touch);
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_thread_update_combined() {
+        let update = ThreadUpdate::new()
+            .title("Updated Title")
+            .increment_post_count()
+            .touch();
+        assert_eq!(update.title, Some("Updated Title".to_string()));
+        assert_eq!(update.post_count_delta, Some(1));
+        assert!(update.touch);
+        assert!(!update.is_empty());
+    }
+}

--- a/src/board/thread_repository.rs
+++ b/src/board/thread_repository.rs
@@ -1,0 +1,439 @@
+//! Thread repository for HOBBS.
+//!
+//! This module provides CRUD operations for threads in the database.
+
+use rusqlite::{params, Row};
+
+use super::thread::{NewThread, Thread, ThreadUpdate};
+use crate::db::Database;
+use crate::{HobbsError, Result};
+
+/// Repository for thread CRUD operations.
+pub struct ThreadRepository<'a> {
+    db: &'a Database,
+}
+
+impl<'a> ThreadRepository<'a> {
+    /// Create a new ThreadRepository with the given database reference.
+    pub fn new(db: &'a Database) -> Self {
+        Self { db }
+    }
+
+    /// Create a new thread in the database.
+    ///
+    /// Returns the created thread with the assigned ID.
+    pub fn create(&self, new_thread: &NewThread) -> Result<Thread> {
+        self.db.conn().execute(
+            "INSERT INTO threads (board_id, title, author_id) VALUES (?, ?, ?)",
+            params![new_thread.board_id, &new_thread.title, new_thread.author_id,],
+        )?;
+
+        let id = self.db.conn().last_insert_rowid();
+        self.get_by_id(id)?
+            .ok_or_else(|| HobbsError::NotFound("thread".to_string()))
+    }
+
+    /// Get a thread by ID.
+    pub fn get_by_id(&self, id: i64) -> Result<Option<Thread>> {
+        let result = self.db.conn().query_row(
+            "SELECT id, board_id, title, author_id, post_count, created_at, updated_at
+             FROM threads WHERE id = ?",
+            [id],
+            Self::row_to_thread,
+        );
+
+        match result {
+            Ok(thread) => Ok(Some(thread)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Update a thread by ID.
+    ///
+    /// Only fields that are set in the update will be modified.
+    /// Returns the updated thread, or None if not found.
+    pub fn update(&self, id: i64, update: &ThreadUpdate) -> Result<Option<Thread>> {
+        if update.is_empty() {
+            return self.get_by_id(id);
+        }
+
+        let mut fields = Vec::new();
+        let mut values: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+        if let Some(ref title) = update.title {
+            fields.push("title = ?");
+            values.push(Box::new(title.clone()));
+        }
+        if let Some(delta) = update.post_count_delta {
+            fields.push("post_count = post_count + ?");
+            values.push(Box::new(delta));
+        }
+        if update.touch {
+            fields.push("updated_at = datetime('now')");
+        }
+
+        let sql = format!("UPDATE threads SET {} WHERE id = ?", fields.join(", "));
+        values.push(Box::new(id));
+
+        let params: Vec<&dyn rusqlite::ToSql> = values.iter().map(|v| v.as_ref()).collect();
+        let affected = self.db.conn().execute(&sql, params.as_slice())?;
+
+        if affected == 0 {
+            return Ok(None);
+        }
+
+        self.get_by_id(id)
+    }
+
+    /// Delete a thread by ID.
+    ///
+    /// Returns true if a thread was deleted, false if not found.
+    /// Note: This will cascade delete all posts in the thread.
+    pub fn delete(&self, id: i64) -> Result<bool> {
+        let affected = self
+            .db
+            .conn()
+            .execute("DELETE FROM threads WHERE id = ?", [id])?;
+        Ok(affected > 0)
+    }
+
+    /// List threads in a board, ordered by updated_at descending.
+    pub fn list_by_board(&self, board_id: i64) -> Result<Vec<Thread>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, board_id, title, author_id, post_count, created_at, updated_at
+             FROM threads WHERE board_id = ? ORDER BY updated_at DESC, id DESC",
+        )?;
+
+        let threads = stmt
+            .query_map([board_id], Self::row_to_thread)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(threads)
+    }
+
+    /// List threads in a board with pagination.
+    pub fn list_by_board_paginated(
+        &self,
+        board_id: i64,
+        offset: i64,
+        limit: i64,
+    ) -> Result<Vec<Thread>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, board_id, title, author_id, post_count, created_at, updated_at
+             FROM threads WHERE board_id = ? ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?",
+        )?;
+
+        let threads = stmt
+            .query_map([board_id, limit, offset], Self::row_to_thread)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(threads)
+    }
+
+    /// List threads by author.
+    pub fn list_by_author(&self, author_id: i64) -> Result<Vec<Thread>> {
+        let mut stmt = self.db.conn().prepare(
+            "SELECT id, board_id, title, author_id, post_count, created_at, updated_at
+             FROM threads WHERE author_id = ? ORDER BY updated_at DESC",
+        )?;
+
+        let threads = stmt
+            .query_map([author_id], Self::row_to_thread)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(threads)
+    }
+
+    /// Count threads in a board.
+    pub fn count_by_board(&self, board_id: i64) -> Result<i64> {
+        let count: i64 = self.db.conn().query_row(
+            "SELECT COUNT(*) FROM threads WHERE board_id = ?",
+            [board_id],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
+    /// Touch a thread (update updated_at to now) and increment post count.
+    ///
+    /// This is a convenience method for when a new post is added to a thread.
+    pub fn touch_and_increment(&self, id: i64) -> Result<Option<Thread>> {
+        self.update(id, &ThreadUpdate::new().touch().increment_post_count())
+    }
+
+    /// Decrement post count when a post is deleted.
+    pub fn decrement_post_count(&self, id: i64) -> Result<Option<Thread>> {
+        self.update(id, &ThreadUpdate::new().decrement_post_count())
+    }
+
+    /// Convert a database row to a Thread struct.
+    fn row_to_thread(row: &Row<'_>) -> rusqlite::Result<Thread> {
+        Ok(Thread {
+            id: row.get(0)?,
+            board_id: row.get(1)?,
+            title: row.get(2)?,
+            author_id: row.get(3)?,
+            post_count: row.get(4)?,
+            created_at: row.get(5)?,
+            updated_at: row.get(6)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::board::{BoardRepository, NewBoard};
+    use crate::db::{NewUser, UserRepository};
+
+    fn setup_db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    fn create_test_board(db: &Database) -> i64 {
+        let repo = BoardRepository::new(db);
+        let board = repo.create(&NewBoard::new("test-board")).unwrap();
+        board.id
+    }
+
+    fn create_test_user(db: &Database) -> i64 {
+        let repo = UserRepository::new(db);
+        let user = repo
+            .create(&NewUser::new("testuser", "hash", "Test User"))
+            .unwrap();
+        user.id
+    }
+
+    #[test]
+    fn test_create_thread() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+        let repo = ThreadRepository::new(&db);
+
+        let new_thread = NewThread::new(board_id, "Test Thread", author_id);
+        let thread = repo.create(&new_thread).unwrap();
+
+        assert_eq!(thread.board_id, board_id);
+        assert_eq!(thread.title, "Test Thread");
+        assert_eq!(thread.author_id, author_id);
+        assert_eq!(thread.post_count, 0);
+    }
+
+    #[test]
+    fn test_get_by_id() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+        let repo = ThreadRepository::new(&db);
+
+        let new_thread = NewThread::new(board_id, "Test Thread", author_id);
+        let created = repo.create(&new_thread).unwrap();
+
+        let found = repo.get_by_id(created.id).unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().title, "Test Thread");
+
+        let not_found = repo.get_by_id(999).unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn test_update_thread_title() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+        let repo = ThreadRepository::new(&db);
+
+        let new_thread = NewThread::new(board_id, "Original Title", author_id);
+        let thread = repo.create(&new_thread).unwrap();
+
+        let update = ThreadUpdate::new().title("Updated Title");
+        let updated = repo.update(thread.id, &update).unwrap().unwrap();
+
+        assert_eq!(updated.title, "Updated Title");
+    }
+
+    #[test]
+    fn test_update_empty() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+        let repo = ThreadRepository::new(&db);
+
+        let new_thread = NewThread::new(board_id, "Test Thread", author_id);
+        let thread = repo.create(&new_thread).unwrap();
+
+        let update = ThreadUpdate::new();
+        let result = repo.update(thread.id, &update).unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().title, "Test Thread");
+    }
+
+    #[test]
+    fn test_update_nonexistent_thread() {
+        let db = setup_db();
+        let repo = ThreadRepository::new(&db);
+
+        let update = ThreadUpdate::new().title("New Title");
+        let result = repo.update(999, &update).unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_touch_and_increment() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+        let repo = ThreadRepository::new(&db);
+
+        let new_thread = NewThread::new(board_id, "Test Thread", author_id);
+        let thread = repo.create(&new_thread).unwrap();
+        let original_updated_at = thread.updated_at.clone();
+        assert_eq!(thread.post_count, 0);
+
+        // Wait a tiny bit to ensure timestamp changes
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        let updated = repo.touch_and_increment(thread.id).unwrap().unwrap();
+        assert_eq!(updated.post_count, 1);
+        // updated_at should be different (or at least not less than original)
+        assert!(updated.updated_at >= original_updated_at);
+    }
+
+    #[test]
+    fn test_decrement_post_count() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+        let repo = ThreadRepository::new(&db);
+
+        let new_thread = NewThread::new(board_id, "Test Thread", author_id);
+        let thread = repo.create(&new_thread).unwrap();
+
+        // First increment
+        repo.touch_and_increment(thread.id).unwrap();
+        repo.touch_and_increment(thread.id).unwrap();
+
+        let thread = repo.get_by_id(thread.id).unwrap().unwrap();
+        assert_eq!(thread.post_count, 2);
+
+        // Then decrement
+        let updated = repo.decrement_post_count(thread.id).unwrap().unwrap();
+        assert_eq!(updated.post_count, 1);
+    }
+
+    #[test]
+    fn test_delete_thread() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+        let repo = ThreadRepository::new(&db);
+
+        let new_thread = NewThread::new(board_id, "Test Thread", author_id);
+        let thread = repo.create(&new_thread).unwrap();
+
+        let deleted = repo.delete(thread.id).unwrap();
+        assert!(deleted);
+
+        let found = repo.get_by_id(thread.id).unwrap();
+        assert!(found.is_none());
+
+        // Deleting again should return false
+        let deleted_again = repo.delete(thread.id).unwrap();
+        assert!(!deleted_again);
+    }
+
+    #[test]
+    fn test_list_by_board() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+        let repo = ThreadRepository::new(&db);
+
+        // Create some threads
+        repo.create(&NewThread::new(board_id, "Thread 1", author_id))
+            .unwrap();
+        repo.create(&NewThread::new(board_id, "Thread 2", author_id))
+            .unwrap();
+        repo.create(&NewThread::new(board_id, "Thread 3", author_id))
+            .unwrap();
+
+        let threads = repo.list_by_board(board_id).unwrap();
+        assert_eq!(threads.len(), 3);
+        // Should be ordered by updated_at DESC, so newest first
+        assert_eq!(threads[0].title, "Thread 3");
+    }
+
+    #[test]
+    fn test_list_by_board_paginated() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+        let repo = ThreadRepository::new(&db);
+
+        // Create some threads
+        for i in 1..=5 {
+            repo.create(&NewThread::new(board_id, format!("Thread {i}"), author_id))
+                .unwrap();
+        }
+
+        // Get first page
+        let page1 = repo.list_by_board_paginated(board_id, 0, 2).unwrap();
+        assert_eq!(page1.len(), 2);
+        assert_eq!(page1[0].title, "Thread 5");
+        assert_eq!(page1[1].title, "Thread 4");
+
+        // Get second page
+        let page2 = repo.list_by_board_paginated(board_id, 2, 2).unwrap();
+        assert_eq!(page2.len(), 2);
+        assert_eq!(page2[0].title, "Thread 3");
+        assert_eq!(page2[1].title, "Thread 2");
+    }
+
+    #[test]
+    fn test_list_by_author() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+
+        // Create another user
+        let user_repo = UserRepository::new(&db);
+        let other_author = user_repo
+            .create(&NewUser::new("other", "hash", "Other"))
+            .unwrap();
+
+        let repo = ThreadRepository::new(&db);
+
+        // Create threads by different authors
+        repo.create(&NewThread::new(board_id, "Thread 1", author_id))
+            .unwrap();
+        repo.create(&NewThread::new(board_id, "Thread 2", other_author.id))
+            .unwrap();
+        repo.create(&NewThread::new(board_id, "Thread 3", author_id))
+            .unwrap();
+
+        let threads = repo.list_by_author(author_id).unwrap();
+        assert_eq!(threads.len(), 2);
+    }
+
+    #[test]
+    fn test_count_by_board() {
+        let db = setup_db();
+        let board_id = create_test_board(&db);
+        let author_id = create_test_user(&db);
+        let repo = ThreadRepository::new(&db);
+
+        assert_eq!(repo.count_by_board(board_id).unwrap(), 0);
+
+        repo.create(&NewThread::new(board_id, "Thread 1", author_id))
+            .unwrap();
+        repo.create(&NewThread::new(board_id, "Thread 2", author_id))
+            .unwrap();
+
+        assert_eq!(repo.count_by_board(board_id).unwrap(), 2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,10 @@ pub use auth::{
     RegistrationError, RegistrationRequest, SessionError, SessionManager, UserProfile,
     ValidationError, MAX_PROFILE_LENGTH,
 };
-pub use board::{Board, BoardRepository, BoardType, BoardUpdate, NewBoard};
+pub use board::{
+    Board, BoardRepository, BoardType, BoardUpdate, NewBoard, NewFlatPost, NewThread,
+    NewThreadPost, Post, PostRepository, PostUpdate, Thread, ThreadRepository, ThreadUpdate,
+};
 pub use config::Config;
 pub use db::{Database, NewUser, Role, User, UserRepository, UserUpdate};
 pub use error::{HobbsError, Result};


### PR DESCRIPTION
## Summary

- threads テーブルのマイグレーション (v4) を追加
- posts テーブルのマイグレーション (v5) を追加
- `Thread`, `NewThread`, `ThreadUpdate` 構造体を定義
- `ThreadRepository` で CRUD 操作を実装
- `Post`, `NewThreadPost`, `NewFlatPost`, `PostUpdate` 構造体を定義
- `PostRepository` で CRUD 操作を実装
- スレッド形式とフラット形式の両方に対応
- 46件の単体テストを追加

## テーブル構成

### threads テーブル
- スレッド形式掲示板用
- board_id で boards テーブルを参照（CASCADE DELETE）
- author_id で users テーブルを参照
- post_count で投稿数を管理
- updated_at で最終更新日時を管理

### posts テーブル
- スレッド/フラット両対応
- thread_id が NULL の場合はフラット形式
- thread_id がある場合はスレッド形式

## Test plan

- [x] `cargo test` で全382テストが通ること
- [x] `cargo clippy` で警告がないこと
- [x] 新規追加した46件のテストが通ること

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)