### PR TITLE
feat: スレッド・投稿の作成と削除を実装

### DIFF
--- a/src/board/service.rs
+++ b/src/board/service.rs
@@ -267,6 +267,184 @@ impl<'a> BoardService<'a> {
         let board = self.get_board(board_id, user_role)?;
         Ok(board.can_write(user_role))
     }
+
+    // ========== Create Operations ==========
+
+    /// Create a new thread in a thread-type board.
+    ///
+    /// Returns the created thread.
+    pub fn create_thread(
+        &self,
+        board_id: i64,
+        title: impl Into<String>,
+        author_id: i64,
+        user_role: Role,
+    ) -> Result<Thread> {
+        // Check board access and write permission
+        let board = self.get_board(board_id, user_role)?;
+
+        if board.board_type != BoardType::Thread {
+            return Err(HobbsError::Validation(
+                "この掲示板はスレッド形式ではありません".to_string(),
+            ));
+        }
+
+        if !board.can_write(user_role) {
+            return Err(HobbsError::Permission(
+                "この掲示板に書き込む権限がありません".to_string(),
+            ));
+        }
+
+        let thread_repo = ThreadRepository::new(self.db);
+        let new_thread = super::NewThread::new(board_id, title, author_id);
+        thread_repo.create(&new_thread)
+    }
+
+    /// Create a new post in a thread.
+    ///
+    /// This automatically updates the thread's `updated_at` and `post_count`.
+    pub fn create_thread_post(
+        &self,
+        thread_id: i64,
+        author_id: i64,
+        body: impl Into<String>,
+        user_role: Role,
+    ) -> Result<Post> {
+        // Get thread to check permissions and get board_id
+        let thread = self.get_thread(thread_id, user_role)?;
+
+        // Check write permission on the board
+        let board = self.get_board(thread.board_id, user_role)?;
+        if !board.can_write(user_role) {
+            return Err(HobbsError::Permission(
+                "この掲示板に書き込む権限がありません".to_string(),
+            ));
+        }
+
+        // Create the post
+        let post_repo = PostRepository::new(self.db);
+        let new_post = super::NewThreadPost::new(thread.board_id, thread_id, author_id, body);
+        let post = post_repo.create_thread_post(&new_post)?;
+
+        // Update thread's updated_at and post_count
+        let thread_repo = ThreadRepository::new(self.db);
+        thread_repo.touch_and_increment(thread_id)?;
+
+        Ok(post)
+    }
+
+    /// Create a new post in a flat board.
+    pub fn create_flat_post(
+        &self,
+        board_id: i64,
+        author_id: i64,
+        title: impl Into<String>,
+        body: impl Into<String>,
+        user_role: Role,
+    ) -> Result<Post> {
+        // Check board access and write permission
+        let board = self.get_board(board_id, user_role)?;
+
+        if board.board_type != BoardType::Flat {
+            return Err(HobbsError::Validation(
+                "この掲示板はフラット形式ではありません".to_string(),
+            ));
+        }
+
+        if !board.can_write(user_role) {
+            return Err(HobbsError::Permission(
+                "この掲示板に書き込む権限がありません".to_string(),
+            ));
+        }
+
+        let post_repo = PostRepository::new(self.db);
+        let new_post = super::NewFlatPost::new(board_id, author_id, title, body);
+        post_repo.create_flat_post(&new_post)
+    }
+
+    // ========== Delete Operations ==========
+
+    /// Delete a post by ID.
+    ///
+    /// Permission rules:
+    /// - The post author can delete their own post
+    /// - SubOp or higher can delete any post
+    ///
+    /// If the post is in a thread, this automatically decrements the thread's `post_count`.
+    pub fn delete_post(&self, post_id: i64, user_id: Option<i64>, user_role: Role) -> Result<bool> {
+        let post_repo = PostRepository::new(self.db);
+        let post = post_repo
+            .get_by_id(post_id)?
+            .ok_or_else(|| HobbsError::NotFound("post".to_string()))?;
+
+        // Check board access
+        self.get_board(post.board_id, user_role)?;
+
+        // Check delete permission
+        let is_owner = user_id.is_some() && user_id == Some(post.author_id);
+        let is_operator = user_role >= Role::SubOp;
+
+        if !is_owner && !is_operator {
+            return Err(HobbsError::Permission(
+                "この投稿を削除する権限がありません".to_string(),
+            ));
+        }
+
+        // If this is a thread post, decrement the thread's post count
+        if let Some(thread_id) = post.thread_id {
+            let thread_repo = ThreadRepository::new(self.db);
+            thread_repo.decrement_post_count(thread_id)?;
+        }
+
+        post_repo.delete(post_id)
+    }
+
+    /// Delete a thread by ID.
+    ///
+    /// Permission rules:
+    /// - The thread author can delete their own thread
+    /// - SubOp or higher can delete any thread
+    ///
+    /// Note: This cascades to delete all posts in the thread.
+    pub fn delete_thread(
+        &self,
+        thread_id: i64,
+        user_id: Option<i64>,
+        user_role: Role,
+    ) -> Result<bool> {
+        let thread_repo = ThreadRepository::new(self.db);
+        let thread = thread_repo
+            .get_by_id(thread_id)?
+            .ok_or_else(|| HobbsError::NotFound("thread".to_string()))?;
+
+        // Check board access
+        self.get_board(thread.board_id, user_role)?;
+
+        // Check delete permission
+        let is_owner = user_id.is_some() && user_id == Some(thread.author_id);
+        let is_operator = user_role >= Role::SubOp;
+
+        if !is_owner && !is_operator {
+            return Err(HobbsError::Permission(
+                "このスレッドを削除する権限がありません".to_string(),
+            ));
+        }
+
+        thread_repo.delete(thread_id)
+    }
+
+    /// Get a post by ID with permission check.
+    pub fn get_post(&self, post_id: i64, user_role: Role) -> Result<Post> {
+        let post_repo = PostRepository::new(self.db);
+        let post = post_repo
+            .get_by_id(post_id)?
+            .ok_or_else(|| HobbsError::NotFound("post".to_string()))?;
+
+        // Check board access
+        self.get_board(post.board_id, user_role)?;
+
+        Ok(post)
+    }
 }
 
 #[cfg(test)]
@@ -761,5 +939,455 @@ mod tests {
         };
 
         assert!(result.next_page().is_none());
+    }
+
+    // ========== create_thread tests ==========
+
+    #[test]
+    fn test_create_thread_success() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("test").with_board_type(BoardType::Thread))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let thread = service
+            .create_thread(board.id, "Test Thread", author_id, Role::Member)
+            .unwrap();
+
+        assert_eq!(thread.title, "Test Thread");
+        assert_eq!(thread.board_id, board.id);
+        assert_eq!(thread.author_id, author_id);
+        assert_eq!(thread.post_count, 0);
+    }
+
+    #[test]
+    fn test_create_thread_flat_board_error() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("flat").with_board_type(BoardType::Flat))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let result = service.create_thread(board.id, "Test Thread", author_id, Role::Member);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_thread_permission_denied() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(
+                &NewBoard::new("members")
+                    .with_board_type(BoardType::Thread)
+                    .with_min_write_role(Role::Member),
+            )
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let result = service.create_thread(board.id, "Test Thread", author_id, Role::Guest);
+
+        assert!(result.is_err());
+    }
+
+    // ========== create_thread_post tests ==========
+
+    #[test]
+    fn test_create_thread_post_success() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("test").with_board_type(BoardType::Thread))
+            .unwrap();
+
+        let thread_repo = ThreadRepository::new(&db);
+        let thread = thread_repo
+            .create(&NewThread::new(board.id, "Test Thread", author_id))
+            .unwrap();
+        assert_eq!(thread.post_count, 0);
+
+        let service = BoardService::new(&db);
+        let post = service
+            .create_thread_post(thread.id, author_id, "Test Body", Role::Member)
+            .unwrap();
+
+        assert_eq!(post.body, "Test Body");
+        assert_eq!(post.thread_id, Some(thread.id));
+        assert_eq!(post.board_id, board.id);
+
+        // Check thread post_count was incremented
+        let updated_thread = thread_repo.get_by_id(thread.id).unwrap().unwrap();
+        assert_eq!(updated_thread.post_count, 1);
+    }
+
+    #[test]
+    fn test_create_thread_post_permission_denied() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(
+                &NewBoard::new("subop")
+                    .with_board_type(BoardType::Thread)
+                    .with_min_write_role(Role::SubOp),
+            )
+            .unwrap();
+
+        let thread_repo = ThreadRepository::new(&db);
+        let thread = thread_repo
+            .create(&NewThread::new(board.id, "Test Thread", author_id))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let result = service.create_thread_post(thread.id, author_id, "Test Body", Role::Member);
+
+        assert!(result.is_err());
+    }
+
+    // ========== create_flat_post tests ==========
+
+    #[test]
+    fn test_create_flat_post_success() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("flat").with_board_type(BoardType::Flat))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let post = service
+            .create_flat_post(board.id, author_id, "Test Title", "Test Body", Role::Member)
+            .unwrap();
+
+        assert_eq!(post.title, Some("Test Title".to_string()));
+        assert_eq!(post.body, "Test Body");
+        assert_eq!(post.board_id, board.id);
+        assert!(post.thread_id.is_none());
+    }
+
+    #[test]
+    fn test_create_flat_post_thread_board_error() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("thread").with_board_type(BoardType::Thread))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let result =
+            service.create_flat_post(board.id, author_id, "Test Title", "Test Body", Role::Member);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_flat_post_permission_denied() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(
+                &NewBoard::new("subop")
+                    .with_board_type(BoardType::Flat)
+                    .with_min_write_role(Role::SubOp),
+            )
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let result =
+            service.create_flat_post(board.id, author_id, "Test Title", "Test Body", Role::Member);
+
+        assert!(result.is_err());
+    }
+
+    // ========== delete_post tests ==========
+
+    #[test]
+    fn test_delete_post_by_owner() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("flat").with_board_type(BoardType::Flat))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let post = service
+            .create_flat_post(board.id, author_id, "Test Title", "Test Body", Role::Member)
+            .unwrap();
+
+        let deleted = service
+            .delete_post(post.id, Some(author_id), Role::Member)
+            .unwrap();
+
+        assert!(deleted);
+
+        // Verify post is gone
+        let result = service.get_post(post.id, Role::Member);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_post_by_subop() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("flat").with_board_type(BoardType::Flat))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let post = service
+            .create_flat_post(board.id, author_id, "Test Title", "Test Body", Role::Member)
+            .unwrap();
+
+        // SubOp (not owner) can delete
+        let deleted = service
+            .delete_post(post.id, Some(999), Role::SubOp)
+            .unwrap();
+
+        assert!(deleted);
+    }
+
+    #[test]
+    fn test_delete_post_permission_denied() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("flat").with_board_type(BoardType::Flat))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let post = service
+            .create_flat_post(board.id, author_id, "Test Title", "Test Body", Role::Member)
+            .unwrap();
+
+        // Other user (not owner, not SubOp) cannot delete
+        let result = service.delete_post(post.id, Some(999), Role::Member);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_post_guest_cannot_delete_others_post() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("flat").with_board_type(BoardType::Flat))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let post = service
+            .create_flat_post(board.id, author_id, "Test Title", "Test Body", Role::Member)
+            .unwrap();
+
+        // Guest with no user_id cannot delete
+        let result = service.delete_post(post.id, None, Role::Guest);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_thread_post_decrements_count() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("test").with_board_type(BoardType::Thread))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let thread = service
+            .create_thread(board.id, "Test Thread", author_id, Role::Member)
+            .unwrap();
+
+        // Create two posts
+        service
+            .create_thread_post(thread.id, author_id, "Post 1", Role::Member)
+            .unwrap();
+        let post2 = service
+            .create_thread_post(thread.id, author_id, "Post 2", Role::Member)
+            .unwrap();
+
+        let thread_repo = ThreadRepository::new(&db);
+        let thread_before = thread_repo.get_by_id(thread.id).unwrap().unwrap();
+        assert_eq!(thread_before.post_count, 2);
+
+        // Delete one post
+        service
+            .delete_post(post2.id, Some(author_id), Role::Member)
+            .unwrap();
+
+        let thread_after = thread_repo.get_by_id(thread.id).unwrap().unwrap();
+        assert_eq!(thread_after.post_count, 1);
+    }
+
+    // ========== delete_thread tests ==========
+
+    #[test]
+    fn test_delete_thread_by_owner() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("test").with_board_type(BoardType::Thread))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let thread = service
+            .create_thread(board.id, "Test Thread", author_id, Role::Member)
+            .unwrap();
+
+        let deleted = service
+            .delete_thread(thread.id, Some(author_id), Role::Member)
+            .unwrap();
+
+        assert!(deleted);
+
+        // Verify thread is gone
+        let result = service.get_thread(thread.id, Role::Member);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_thread_by_subop() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("test").with_board_type(BoardType::Thread))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let thread = service
+            .create_thread(board.id, "Test Thread", author_id, Role::Member)
+            .unwrap();
+
+        // SubOp (not owner) can delete
+        let deleted = service
+            .delete_thread(thread.id, Some(999), Role::SubOp)
+            .unwrap();
+
+        assert!(deleted);
+    }
+
+    #[test]
+    fn test_delete_thread_permission_denied() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("test").with_board_type(BoardType::Thread))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let thread = service
+            .create_thread(board.id, "Test Thread", author_id, Role::Member)
+            .unwrap();
+
+        // Other user (not owner, not SubOp) cannot delete
+        let result = service.delete_thread(thread.id, Some(999), Role::Member);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_thread_cascades_posts() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("test").with_board_type(BoardType::Thread))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let thread = service
+            .create_thread(board.id, "Test Thread", author_id, Role::Member)
+            .unwrap();
+
+        // Create posts in the thread
+        let post1 = service
+            .create_thread_post(thread.id, author_id, "Post 1", Role::Member)
+            .unwrap();
+        let post2 = service
+            .create_thread_post(thread.id, author_id, "Post 2", Role::Member)
+            .unwrap();
+
+        // Delete thread
+        service
+            .delete_thread(thread.id, Some(author_id), Role::Member)
+            .unwrap();
+
+        // Verify posts are also gone
+        let post_repo = PostRepository::new(&db);
+        assert!(post_repo.get_by_id(post1.id).unwrap().is_none());
+        assert!(post_repo.get_by_id(post2.id).unwrap().is_none());
+    }
+
+    // ========== get_post tests ==========
+
+    #[test]
+    fn test_get_post_success() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(&NewBoard::new("flat").with_board_type(BoardType::Flat))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let post = service
+            .create_flat_post(board.id, author_id, "Test Title", "Test Body", Role::Member)
+            .unwrap();
+
+        let result = service.get_post(post.id, Role::Guest).unwrap();
+
+        assert_eq!(result.id, post.id);
+        assert_eq!(result.body, "Test Body");
+    }
+
+    #[test]
+    fn test_get_post_not_found() {
+        let db = setup_db();
+        let service = BoardService::new(&db);
+        let result = service.get_post(999, Role::Guest);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_post_permission_denied() {
+        let db = setup_db();
+        let author_id = create_test_user(&db);
+        let board_repo = BoardRepository::new(&db);
+        let board = board_repo
+            .create(
+                &NewBoard::new("members")
+                    .with_board_type(BoardType::Flat)
+                    .with_min_read_role(Role::Member),
+            )
+            .unwrap();
+
+        let post_repo = PostRepository::new(&db);
+        let post = post_repo
+            .create_flat_post(&NewFlatPost::new(board.id, author_id, "Title", "Body"))
+            .unwrap();
+
+        let service = BoardService::new(&db);
+        let result = service.get_post(post.id, Role::Guest);
+
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

- BoardServiceにスレッド・投稿の作成・削除メソッドを追加
- 権限チェック機能を実装（書き込み権限、削除権限）
- スレッドのpost_count自動更新機能を実装

### 追加メソッド

| メソッド | 機能 |
|---------|------|
| `create_thread()` | スレッド形式掲示板でスレッド作成 |
| `create_thread_post()` | スレッド内に投稿作成 |
| `create_flat_post()` | フラット形式掲示板に投稿作成 |
| `delete_thread()` | スレッド削除（投稿も連鎖削除） |
| `delete_post()` | 投稿削除 |
| `get_post()` | 投稿詳細取得 |

### 権限チェック

- 書き込み: `min_write_role` 以上の権限が必要
- 削除: 投稿者本人 または SubOp以上

### 自動更新

- `create_thread_post()`: スレッドの `updated_at` と `post_count` を自動更新
- `delete_post()`: スレッド投稿削除時に `post_count` を自動デクリメント

## Test plan

- [x] `cargo test` - 全426テスト成功（20件追加）
- [x] `cargo clippy` - 警告なし
- [x] `cargo fmt` - フォーマット済み

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)