### PR TITLE
feat: 未読管理機能を実装

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -6,6 +6,7 @@
 //! - Post management for both thread and flat boards
 //! - Board types (thread-based and flat)
 //! - Role-based access control for read/write permissions
+//! - Unread management for tracking user's read positions
 
 mod post;
 mod post_repository;
@@ -14,6 +15,7 @@ mod service;
 mod thread;
 mod thread_repository;
 mod types;
+mod unread;
 
 pub use post::{NewFlatPost, NewThreadPost, Post, PostUpdate};
 pub use post_repository::PostRepository;
@@ -22,3 +24,4 @@ pub use service::{BoardService, PaginatedResult, Pagination};
 pub use thread::{NewThread, Thread, ThreadUpdate};
 pub use thread_repository::ThreadRepository;
 pub use types::{Board, BoardType, BoardUpdate, NewBoard};
+pub use unread::{ReadPosition, UnreadRepository};

--- a/src/board/unread.rs
+++ b/src/board/unread.rs
@@ -1,0 +1,584 @@
+//! Unread management for HOBBS.
+//!
+//! This module provides functionality to track and manage unread posts
+//! for each user per board.
+
+use rusqlite::{params, Row};
+
+use crate::db::Database;
+use crate::Result;
+
+use super::Post;
+
+/// Read position tracking for a user on a board.
+#[derive(Debug, Clone)]
+pub struct ReadPosition {
+    /// Unique ID.
+    pub id: i64,
+    /// User ID.
+    pub user_id: i64,
+    /// Board ID.
+    pub board_id: i64,
+    /// Last read post ID.
+    pub last_read_post_id: i64,
+    /// Last read timestamp.
+    pub last_read_at: String,
+}
+
+/// Repository for unread management operations.
+pub struct UnreadRepository<'a> {
+    db: &'a Database,
+}
+
+impl<'a> UnreadRepository<'a> {
+    /// Create a new UnreadRepository with the given database reference.
+    pub fn new(db: &'a Database) -> Self {
+        Self { db }
+    }
+
+    /// Get the read position for a user on a board.
+    pub fn get_read_position(&self, user_id: i64, board_id: i64) -> Result<Option<ReadPosition>> {
+        let result = self.db.conn().query_row(
+            "SELECT id, user_id, board_id, last_read_post_id, last_read_at
+             FROM read_positions WHERE user_id = ? AND board_id = ?",
+            params![user_id, board_id],
+            Self::row_to_read_position,
+        );
+
+        match result {
+            Ok(pos) => Ok(Some(pos)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Mark a board as read up to a specific post.
+    ///
+    /// This updates the read position for the user on the board.
+    /// If no read position exists, one is created.
+    pub fn mark_as_read(&self, user_id: i64, board_id: i64, post_id: i64) -> Result<()> {
+        self.db.conn().execute(
+            "INSERT INTO read_positions (user_id, board_id, last_read_post_id, last_read_at)
+             VALUES (?, ?, ?, datetime('now'))
+             ON CONFLICT(user_id, board_id) DO UPDATE SET
+                 last_read_post_id = excluded.last_read_post_id,
+                 last_read_at = datetime('now')",
+            params![user_id, board_id, post_id],
+        )?;
+        Ok(())
+    }
+
+    /// Get unread count for a user on a board.
+    ///
+    /// Returns the number of posts with ID greater than the last read post ID.
+    /// If the user has no read position for this board, returns the total post count.
+    pub fn get_unread_count(&self, user_id: i64, board_id: i64) -> Result<i64> {
+        let read_position = self.get_read_position(user_id, board_id)?;
+
+        let count: i64 = match read_position {
+            Some(pos) => self.db.conn().query_row(
+                "SELECT COUNT(*) FROM posts WHERE board_id = ? AND id > ?",
+                params![board_id, pos.last_read_post_id],
+                |row| row.get(0),
+            )?,
+            None => self.db.conn().query_row(
+                "SELECT COUNT(*) FROM posts WHERE board_id = ?",
+                [board_id],
+                |row| row.get(0),
+            )?,
+        };
+
+        Ok(count)
+    }
+
+    /// Get unread counts for all boards for a user.
+    ///
+    /// Returns a list of (board_id, unread_count) tuples.
+    pub fn get_all_unread_counts(&self, user_id: i64) -> Result<Vec<(i64, i64)>> {
+        // Get all active boards
+        let mut stmt = self.db.conn().prepare(
+            "SELECT b.id,
+                    (SELECT COUNT(*) FROM posts p WHERE p.board_id = b.id
+                     AND p.id > COALESCE(
+                         (SELECT last_read_post_id FROM read_positions
+                          WHERE user_id = ? AND board_id = b.id),
+                         0
+                     )) as unread_count
+             FROM boards b
+             WHERE b.is_active = 1
+             ORDER BY b.sort_order, b.id",
+        )?;
+
+        let counts = stmt
+            .query_map([user_id], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(counts)
+    }
+
+    /// Get unread posts for a user on a board.
+    ///
+    /// Returns posts with ID greater than the last read post ID.
+    /// If the user has no read position, returns all posts.
+    pub fn get_unread_posts(&self, user_id: i64, board_id: i64) -> Result<Vec<Post>> {
+        let read_position = self.get_read_position(user_id, board_id)?;
+
+        let mut stmt = match read_position {
+            Some(pos) => {
+                let mut stmt = self.db.conn().prepare(
+                    "SELECT id, board_id, thread_id, author_id, title, body, created_at
+                     FROM posts WHERE board_id = ? AND id > ?
+                     ORDER BY id ASC",
+                )?;
+                let posts = stmt
+                    .query_map(params![board_id, pos.last_read_post_id], Self::row_to_post)?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                return Ok(posts);
+            }
+            None => self.db.conn().prepare(
+                "SELECT id, board_id, thread_id, author_id, title, body, created_at
+                 FROM posts WHERE board_id = ?
+                 ORDER BY id ASC",
+            )?,
+        };
+
+        let posts = stmt
+            .query_map([board_id], Self::row_to_post)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(posts)
+    }
+
+    /// Get unread posts with pagination.
+    pub fn get_unread_posts_paginated(
+        &self,
+        user_id: i64,
+        board_id: i64,
+        offset: i64,
+        limit: i64,
+    ) -> Result<Vec<Post>> {
+        let read_position = self.get_read_position(user_id, board_id)?;
+
+        match read_position {
+            Some(pos) => {
+                let mut stmt = self.db.conn().prepare(
+                    "SELECT id, board_id, thread_id, author_id, title, body, created_at
+                     FROM posts WHERE board_id = ? AND id > ?
+                     ORDER BY id ASC LIMIT ? OFFSET ?",
+                )?;
+                let posts = stmt
+                    .query_map(
+                        params![board_id, pos.last_read_post_id, limit, offset],
+                        Self::row_to_post,
+                    )?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                Ok(posts)
+            }
+            None => {
+                let mut stmt = self.db.conn().prepare(
+                    "SELECT id, board_id, thread_id, author_id, title, body, created_at
+                     FROM posts WHERE board_id = ?
+                     ORDER BY id ASC LIMIT ? OFFSET ?",
+                )?;
+                let posts = stmt
+                    .query_map(params![board_id, limit, offset], Self::row_to_post)?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                Ok(posts)
+            }
+        }
+    }
+
+    /// Mark all posts in a board as read for a user.
+    ///
+    /// This sets the read position to the latest post ID.
+    pub fn mark_all_as_read(&self, user_id: i64, board_id: i64) -> Result<bool> {
+        // Get the latest post ID in the board
+        let latest_post_id: Option<i64> = self.db.conn().query_row(
+            "SELECT MAX(id) FROM posts WHERE board_id = ?",
+            [board_id],
+            |row| row.get(0),
+        )?;
+
+        match latest_post_id {
+            Some(post_id) => {
+                self.mark_as_read(user_id, board_id, post_id)?;
+                Ok(true)
+            }
+            None => Ok(false), // No posts in board
+        }
+    }
+
+    /// Delete read position for a user on a board.
+    ///
+    /// This effectively marks all posts as unread.
+    pub fn delete_read_position(&self, user_id: i64, board_id: i64) -> Result<bool> {
+        let affected = self.db.conn().execute(
+            "DELETE FROM read_positions WHERE user_id = ? AND board_id = ?",
+            params![user_id, board_id],
+        )?;
+        Ok(affected > 0)
+    }
+
+    /// Delete all read positions for a user.
+    pub fn delete_all_read_positions(&self, user_id: i64) -> Result<i64> {
+        let affected = self
+            .db
+            .conn()
+            .execute("DELETE FROM read_positions WHERE user_id = ?", [user_id])?;
+        Ok(affected as i64)
+    }
+
+    /// Convert a database row to a ReadPosition struct.
+    fn row_to_read_position(row: &Row<'_>) -> rusqlite::Result<ReadPosition> {
+        Ok(ReadPosition {
+            id: row.get(0)?,
+            user_id: row.get(1)?,
+            board_id: row.get(2)?,
+            last_read_post_id: row.get(3)?,
+            last_read_at: row.get(4)?,
+        })
+    }
+
+    /// Convert a database row to a Post struct.
+    fn row_to_post(row: &Row<'_>) -> rusqlite::Result<Post> {
+        Ok(Post {
+            id: row.get(0)?,
+            board_id: row.get(1)?,
+            thread_id: row.get(2)?,
+            author_id: row.get(3)?,
+            title: row.get(4)?,
+            body: row.get(5)?,
+            created_at: row.get(6)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::board::{BoardRepository, NewBoard, NewFlatPost, PostRepository};
+    use crate::db::{NewUser, UserRepository};
+
+    fn setup_db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    fn create_test_user(db: &Database) -> i64 {
+        let repo = UserRepository::new(db);
+        let user = repo
+            .create(&NewUser::new("testuser", "hash", "Test User"))
+            .unwrap();
+        user.id
+    }
+
+    fn create_test_board(db: &Database) -> i64 {
+        let repo = BoardRepository::new(db);
+        let board = repo.create(&NewBoard::new("test-board")).unwrap();
+        board.id
+    }
+
+    fn create_test_post(db: &Database, board_id: i64, author_id: i64) -> i64 {
+        let repo = PostRepository::new(db);
+        let post = repo
+            .create_flat_post(&NewFlatPost::new(board_id, author_id, "Title", "Body"))
+            .unwrap();
+        post.id
+    }
+
+    #[test]
+    fn test_mark_as_read() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+        let post_id = create_test_post(&db, board_id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+        repo.mark_as_read(user_id, board_id, post_id).unwrap();
+
+        let position = repo.get_read_position(user_id, board_id).unwrap().unwrap();
+        assert_eq!(position.user_id, user_id);
+        assert_eq!(position.board_id, board_id);
+        assert_eq!(position.last_read_post_id, post_id);
+    }
+
+    #[test]
+    fn test_mark_as_read_update() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+        let post1_id = create_test_post(&db, board_id, user_id);
+        let post2_id = create_test_post(&db, board_id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+
+        // Mark first post as read
+        repo.mark_as_read(user_id, board_id, post1_id).unwrap();
+        let pos1 = repo.get_read_position(user_id, board_id).unwrap().unwrap();
+        assert_eq!(pos1.last_read_post_id, post1_id);
+
+        // Update to second post
+        repo.mark_as_read(user_id, board_id, post2_id).unwrap();
+        let pos2 = repo.get_read_position(user_id, board_id).unwrap().unwrap();
+        assert_eq!(pos2.last_read_post_id, post2_id);
+    }
+
+    #[test]
+    fn test_get_read_position_not_found() {
+        let db = setup_db();
+        let repo = UnreadRepository::new(&db);
+
+        let position = repo.get_read_position(999, 999).unwrap();
+        assert!(position.is_none());
+    }
+
+    #[test]
+    fn test_get_unread_count_no_position() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+
+        // Create some posts
+        create_test_post(&db, board_id, user_id);
+        create_test_post(&db, board_id, user_id);
+        create_test_post(&db, board_id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+        let count = repo.get_unread_count(user_id, board_id).unwrap();
+
+        // All posts should be unread
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_get_unread_count_with_position() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+
+        // Create posts
+        let post1_id = create_test_post(&db, board_id, user_id);
+        create_test_post(&db, board_id, user_id);
+        create_test_post(&db, board_id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+
+        // Mark first post as read
+        repo.mark_as_read(user_id, board_id, post1_id).unwrap();
+
+        let count = repo.get_unread_count(user_id, board_id).unwrap();
+        assert_eq!(count, 2); // 2 posts after the read position
+    }
+
+    #[test]
+    fn test_get_unread_count_all_read() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+
+        create_test_post(&db, board_id, user_id);
+        create_test_post(&db, board_id, user_id);
+        let post3_id = create_test_post(&db, board_id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+        repo.mark_as_read(user_id, board_id, post3_id).unwrap();
+
+        let count = repo.get_unread_count(user_id, board_id).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_get_all_unread_counts() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        // Create two boards
+        let board_repo = BoardRepository::new(&db);
+        let board1 = board_repo.create(&NewBoard::new("board1")).unwrap();
+        let board2 = board_repo.create(&NewBoard::new("board2")).unwrap();
+
+        // Create posts in each board
+        create_test_post(&db, board1.id, user_id);
+        create_test_post(&db, board1.id, user_id);
+        create_test_post(&db, board2.id, user_id);
+        create_test_post(&db, board2.id, user_id);
+        create_test_post(&db, board2.id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+        let counts = repo.get_all_unread_counts(user_id).unwrap();
+
+        assert_eq!(counts.len(), 2);
+        // Find the counts for each board
+        let board1_count = counts.iter().find(|(id, _)| *id == board1.id).unwrap().1;
+        let board2_count = counts.iter().find(|(id, _)| *id == board2.id).unwrap().1;
+        assert_eq!(board1_count, 2);
+        assert_eq!(board2_count, 3);
+    }
+
+    #[test]
+    fn test_get_unread_posts_no_position() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+
+        create_test_post(&db, board_id, user_id);
+        create_test_post(&db, board_id, user_id);
+        create_test_post(&db, board_id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+        let posts = repo.get_unread_posts(user_id, board_id).unwrap();
+
+        assert_eq!(posts.len(), 3);
+    }
+
+    #[test]
+    fn test_get_unread_posts_with_position() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+
+        let post1_id = create_test_post(&db, board_id, user_id);
+        create_test_post(&db, board_id, user_id);
+        create_test_post(&db, board_id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+        repo.mark_as_read(user_id, board_id, post1_id).unwrap();
+
+        let posts = repo.get_unread_posts(user_id, board_id).unwrap();
+        assert_eq!(posts.len(), 2);
+        // All returned posts should have ID > post1_id
+        for post in &posts {
+            assert!(post.id > post1_id);
+        }
+    }
+
+    #[test]
+    fn test_get_unread_posts_paginated() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+
+        for _ in 0..5 {
+            create_test_post(&db, board_id, user_id);
+        }
+
+        let repo = UnreadRepository::new(&db);
+
+        // Get first page
+        let page1 = repo
+            .get_unread_posts_paginated(user_id, board_id, 0, 2)
+            .unwrap();
+        assert_eq!(page1.len(), 2);
+
+        // Get second page
+        let page2 = repo
+            .get_unread_posts_paginated(user_id, board_id, 2, 2)
+            .unwrap();
+        assert_eq!(page2.len(), 2);
+
+        // Get third page
+        let page3 = repo
+            .get_unread_posts_paginated(user_id, board_id, 4, 2)
+            .unwrap();
+        assert_eq!(page3.len(), 1);
+    }
+
+    #[test]
+    fn test_mark_all_as_read() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+
+        create_test_post(&db, board_id, user_id);
+        create_test_post(&db, board_id, user_id);
+        let post3_id = create_test_post(&db, board_id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+
+        // Initially 3 unread
+        assert_eq!(repo.get_unread_count(user_id, board_id).unwrap(), 3);
+
+        // Mark all as read
+        let result = repo.mark_all_as_read(user_id, board_id).unwrap();
+        assert!(result);
+
+        // Now 0 unread
+        assert_eq!(repo.get_unread_count(user_id, board_id).unwrap(), 0);
+
+        // Check read position
+        let pos = repo.get_read_position(user_id, board_id).unwrap().unwrap();
+        assert_eq!(pos.last_read_post_id, post3_id);
+    }
+
+    #[test]
+    fn test_mark_all_as_read_empty_board() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+
+        let repo = UnreadRepository::new(&db);
+        let result = repo.mark_all_as_read(user_id, board_id).unwrap();
+
+        assert!(!result); // No posts to mark
+    }
+
+    #[test]
+    fn test_delete_read_position() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+        let board_id = create_test_board(&db);
+        let post_id = create_test_post(&db, board_id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+        repo.mark_as_read(user_id, board_id, post_id).unwrap();
+
+        // Verify position exists
+        assert!(repo.get_read_position(user_id, board_id).unwrap().is_some());
+
+        // Delete position
+        let deleted = repo.delete_read_position(user_id, board_id).unwrap();
+        assert!(deleted);
+
+        // Verify position is gone
+        assert!(repo.get_read_position(user_id, board_id).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_delete_read_position_not_found() {
+        let db = setup_db();
+        let repo = UnreadRepository::new(&db);
+
+        let deleted = repo.delete_read_position(999, 999).unwrap();
+        assert!(!deleted);
+    }
+
+    #[test]
+    fn test_delete_all_read_positions() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let board_repo = BoardRepository::new(&db);
+        let board1 = board_repo.create(&NewBoard::new("board1")).unwrap();
+        let board2 = board_repo.create(&NewBoard::new("board2")).unwrap();
+
+        let post1_id = create_test_post(&db, board1.id, user_id);
+        let post2_id = create_test_post(&db, board2.id, user_id);
+
+        let repo = UnreadRepository::new(&db);
+        repo.mark_as_read(user_id, board1.id, post1_id).unwrap();
+        repo.mark_as_read(user_id, board2.id, post2_id).unwrap();
+
+        // Delete all positions
+        let deleted = repo.delete_all_read_positions(user_id).unwrap();
+        assert_eq!(deleted, 2);
+
+        // Verify all positions are gone
+        assert!(repo
+            .get_read_position(user_id, board1.id)
+            .unwrap()
+            .is_none());
+        assert!(repo
+            .get_read_position(user_id, board2.id)
+            .unwrap()
+            .is_none());
+    }
+}

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -85,6 +85,21 @@ CREATE INDEX idx_posts_thread_id ON posts(thread_id);
 CREATE INDEX idx_posts_author_id ON posts(author_id);
 CREATE INDEX idx_posts_created_at ON posts(created_at);
 "#,
+    // v6: Read positions table for unread management
+    r#"
+-- Read positions table for tracking user's last read position per board
+CREATE TABLE read_positions (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id             INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    board_id            INTEGER NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+    last_read_post_id   INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    last_read_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(user_id, board_id)
+);
+
+CREATE INDEX idx_read_positions_user_id ON read_positions(user_id);
+CREATE INDEX idx_read_positions_board_id ON read_positions(board_id);
+"#,
 ];
 
 #[cfg(test)]
@@ -148,5 +163,16 @@ mod tests {
         assert!(posts_migration.contains("author_id"));
         assert!(posts_migration.contains("title"));
         assert!(posts_migration.contains("body"));
+    }
+
+    #[test]
+    fn test_read_positions_migration_contains_read_positions_table() {
+        let read_positions_migration = MIGRATIONS[5];
+        assert!(read_positions_migration.contains("CREATE TABLE read_positions"));
+        assert!(read_positions_migration.contains("user_id"));
+        assert!(read_positions_migration.contains("board_id"));
+        assert!(read_positions_migration.contains("last_read_post_id"));
+        assert!(read_positions_migration.contains("last_read_at"));
+        assert!(read_positions_migration.contains("UNIQUE(user_id, board_id)"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub use auth::{
 };
 pub use board::{
     Board, BoardRepository, BoardService, BoardType, BoardUpdate, NewBoard, NewFlatPost, NewThread,
-    NewThreadPost, PaginatedResult, Pagination, Post, PostRepository, PostUpdate, Thread,
-    ThreadRepository, ThreadUpdate,
+    NewThreadPost, PaginatedResult, Pagination, Post, PostRepository, PostUpdate, ReadPosition,
+    Thread, ThreadRepository, ThreadUpdate, UnreadRepository,
 };
 pub use config::Config;
 pub use db::{Database, NewUser, Role, User, UserRepository, UserUpdate};


### PR DESCRIPTION
## Summary

- マイグレーション v6 追加（read_positions テーブル）
- `UnreadRepository` を追加し、未読管理機能を実装
- `ReadPosition` 構造体を追加

### read_positions テーブル

| カラム | 型 | 説明 |
|--------|-----|------|
| user_id | INTEGER | ユーザーID |
| board_id | INTEGER | 掲示板ID |
| last_read_post_id | INTEGER | 最後に読んだ投稿ID |
| last_read_at | TEXT | 最終既読日時 |

### UnreadRepository メソッド

| メソッド | 機能 |
|---------|------|
| `get_read_position()` | 既読位置を取得 |
| `mark_as_read()` | 特定の投稿まで既読にする |
| `get_unread_count()` | 未読数を取得 |
| `get_all_unread_counts()` | 全掲示板の未読数を一括取得 |
| `get_unread_posts()` | 未読投稿一覧を取得 |
| `get_unread_posts_paginated()` | 未読投稿一覧（ページング付き） |
| `mark_all_as_read()` | 掲示板の全投稿を既読にする |
| `delete_read_position()` | 既読位置を削除（未読に戻す） |
| `delete_all_read_positions()` | 全既読位置を削除 |

## Test plan

- [x] `cargo test` - 全442テスト成功（16件追加）
- [x] `cargo clippy` - 警告なし
- [x] `cargo fmt` - フォーマット済み

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)