### PR TITLE
feat: チャットコマンド処理を実装

### DIFF
--- a/src/chat/command.rs
+++ b/src/chat/command.rs
@@ -1,0 +1,364 @@
+//! Chat command parser and handlers for HOBBS.
+//!
+//! This module provides parsing and handling of chat commands like
+//! /quit, /who, /me, and /help.
+
+/// Result of parsing a chat input line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChatInput {
+    /// Regular chat message.
+    Message(String),
+    /// Parsed command.
+    Command(ChatCommand),
+}
+
+/// A parsed chat command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChatCommand {
+    /// Exit the chat room.
+    Quit,
+    /// List participants in the room.
+    Who,
+    /// Send an action message (e.g., "/me yawns" -> "* user yawns").
+    Me(String),
+    /// Show help message.
+    Help,
+    /// Unknown command.
+    Unknown(String),
+}
+
+impl ChatCommand {
+    /// Get the command name.
+    pub fn name(&self) -> &str {
+        match self {
+            ChatCommand::Quit => "quit",
+            ChatCommand::Who => "who",
+            ChatCommand::Me(_) => "me",
+            ChatCommand::Help => "help",
+            ChatCommand::Unknown(cmd) => cmd,
+        }
+    }
+}
+
+impl std::fmt::Display for ChatCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChatCommand::Quit => write!(f, "/quit"),
+            ChatCommand::Who => write!(f, "/who"),
+            ChatCommand::Me(action) => write!(f, "/me {action}"),
+            ChatCommand::Help => write!(f, "/help"),
+            ChatCommand::Unknown(cmd) => write!(f, "/{cmd}"),
+        }
+    }
+}
+
+/// Parse a chat input line into a message or command.
+pub fn parse_input(input: &str) -> ChatInput {
+    let trimmed = input.trim();
+
+    if trimmed.is_empty() {
+        return ChatInput::Message(String::new());
+    }
+
+    if !trimmed.starts_with('/') {
+        return ChatInput::Message(trimmed.to_string());
+    }
+
+    // Parse command
+    let without_slash = &trimmed[1..];
+    let (cmd, args) = match without_slash.find(' ') {
+        Some(pos) => (&without_slash[..pos], without_slash[pos + 1..].trim()),
+        None => (without_slash, ""),
+    };
+
+    let command = match cmd.to_lowercase().as_str() {
+        "quit" | "q" | "exit" => ChatCommand::Quit,
+        "who" | "w" | "users" | "list" => ChatCommand::Who,
+        "me" | "action" => {
+            if args.is_empty() {
+                ChatCommand::Me(String::new())
+            } else {
+                ChatCommand::Me(args.to_string())
+            }
+        }
+        "help" | "h" | "?" => ChatCommand::Help,
+        _ => ChatCommand::Unknown(cmd.to_string()),
+    };
+
+    ChatInput::Command(command)
+}
+
+/// Chat command information for help display.
+pub struct CommandInfo {
+    /// Command name.
+    pub name: &'static str,
+    /// Command aliases.
+    pub aliases: &'static [&'static str],
+    /// Command syntax.
+    pub syntax: &'static str,
+    /// Command description.
+    pub description: &'static str,
+}
+
+/// Get all available command information.
+pub fn get_command_help() -> Vec<CommandInfo> {
+    vec![
+        CommandInfo {
+            name: "quit",
+            aliases: &["q", "exit"],
+            syntax: "/quit",
+            description: "チャットルームを退室します",
+        },
+        CommandInfo {
+            name: "who",
+            aliases: &["w", "users", "list"],
+            syntax: "/who",
+            description: "参加者一覧を表示します",
+        },
+        CommandInfo {
+            name: "me",
+            aliases: &["action"],
+            syntax: "/me <アクション>",
+            description: "アクションメッセージを送信します (例: /me yawns → * user yawns)",
+        },
+        CommandInfo {
+            name: "help",
+            aliases: &["h", "?"],
+            syntax: "/help",
+            description: "コマンドヘルプを表示します",
+        },
+    ]
+}
+
+/// Format the help message for display.
+pub fn format_help() -> String {
+    let mut lines = Vec::new();
+    lines.push("=== チャットコマンド ===".to_string());
+    lines.push(String::new());
+
+    for info in get_command_help() {
+        lines.push(info.syntax.to_string());
+        if !info.aliases.is_empty() {
+            lines.push(format!("  別名: /{}", info.aliases.join(", /")));
+        }
+        lines.push(format!("  {}", info.description));
+        lines.push(String::new());
+    }
+
+    lines.join("\n")
+}
+
+/// Format the participant list for display.
+pub fn format_who(participants: &[String], room_name: &str) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "=== {} の参加者 ({}) ===",
+        room_name,
+        participants.len()
+    ));
+
+    if participants.is_empty() {
+        lines.push("(参加者はいません)".to_string());
+    } else {
+        for name in participants {
+            lines.push(format!("  {name}"));
+        }
+    }
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_regular_message() {
+        let input = parse_input("Hello, world!");
+        assert_eq!(input, ChatInput::Message("Hello, world!".to_string()));
+    }
+
+    #[test]
+    fn test_parse_message_with_leading_whitespace() {
+        let input = parse_input("  Hello!");
+        assert_eq!(input, ChatInput::Message("Hello!".to_string()));
+    }
+
+    #[test]
+    fn test_parse_empty_message() {
+        let input = parse_input("");
+        assert_eq!(input, ChatInput::Message(String::new()));
+    }
+
+    #[test]
+    fn test_parse_whitespace_only() {
+        let input = parse_input("   ");
+        assert_eq!(input, ChatInput::Message(String::new()));
+    }
+
+    #[test]
+    fn test_parse_quit_command() {
+        assert_eq!(parse_input("/quit"), ChatInput::Command(ChatCommand::Quit));
+        assert_eq!(parse_input("/q"), ChatInput::Command(ChatCommand::Quit));
+        assert_eq!(parse_input("/exit"), ChatInput::Command(ChatCommand::Quit));
+    }
+
+    #[test]
+    fn test_parse_quit_case_insensitive() {
+        assert_eq!(parse_input("/QUIT"), ChatInput::Command(ChatCommand::Quit));
+        assert_eq!(parse_input("/Quit"), ChatInput::Command(ChatCommand::Quit));
+    }
+
+    #[test]
+    fn test_parse_who_command() {
+        assert_eq!(parse_input("/who"), ChatInput::Command(ChatCommand::Who));
+        assert_eq!(parse_input("/w"), ChatInput::Command(ChatCommand::Who));
+        assert_eq!(parse_input("/users"), ChatInput::Command(ChatCommand::Who));
+        assert_eq!(parse_input("/list"), ChatInput::Command(ChatCommand::Who));
+    }
+
+    #[test]
+    fn test_parse_me_command() {
+        assert_eq!(
+            parse_input("/me yawns"),
+            ChatInput::Command(ChatCommand::Me("yawns".to_string()))
+        );
+        assert_eq!(
+            parse_input("/action waves"),
+            ChatInput::Command(ChatCommand::Me("waves".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_me_with_multiple_words() {
+        assert_eq!(
+            parse_input("/me waves at everyone"),
+            ChatInput::Command(ChatCommand::Me("waves at everyone".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_me_empty() {
+        assert_eq!(
+            parse_input("/me"),
+            ChatInput::Command(ChatCommand::Me(String::new()))
+        );
+        assert_eq!(
+            parse_input("/me "),
+            ChatInput::Command(ChatCommand::Me(String::new()))
+        );
+    }
+
+    #[test]
+    fn test_parse_help_command() {
+        assert_eq!(parse_input("/help"), ChatInput::Command(ChatCommand::Help));
+        assert_eq!(parse_input("/h"), ChatInput::Command(ChatCommand::Help));
+        assert_eq!(parse_input("/?"), ChatInput::Command(ChatCommand::Help));
+    }
+
+    #[test]
+    fn test_parse_unknown_command() {
+        assert_eq!(
+            parse_input("/unknown"),
+            ChatInput::Command(ChatCommand::Unknown("unknown".to_string()))
+        );
+        assert_eq!(
+            parse_input("/foo bar"),
+            ChatInput::Command(ChatCommand::Unknown("foo".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_command_with_leading_whitespace() {
+        assert_eq!(
+            parse_input("  /quit"),
+            ChatInput::Command(ChatCommand::Quit)
+        );
+    }
+
+    #[test]
+    fn test_chat_command_name() {
+        assert_eq!(ChatCommand::Quit.name(), "quit");
+        assert_eq!(ChatCommand::Who.name(), "who");
+        assert_eq!(ChatCommand::Me("test".to_string()).name(), "me");
+        assert_eq!(ChatCommand::Help.name(), "help");
+        assert_eq!(ChatCommand::Unknown("foo".to_string()).name(), "foo");
+    }
+
+    #[test]
+    fn test_chat_command_display() {
+        assert_eq!(format!("{}", ChatCommand::Quit), "/quit");
+        assert_eq!(format!("{}", ChatCommand::Who), "/who");
+        assert_eq!(
+            format!("{}", ChatCommand::Me("waves".to_string())),
+            "/me waves"
+        );
+        assert_eq!(format!("{}", ChatCommand::Help), "/help");
+        assert_eq!(
+            format!("{}", ChatCommand::Unknown("foo".to_string())),
+            "/foo"
+        );
+    }
+
+    #[test]
+    fn test_get_command_help() {
+        let help = get_command_help();
+        assert_eq!(help.len(), 4);
+
+        let quit_info = &help[0];
+        assert_eq!(quit_info.name, "quit");
+        assert!(quit_info.aliases.contains(&"q"));
+        assert!(quit_info.aliases.contains(&"exit"));
+    }
+
+    #[test]
+    fn test_format_help() {
+        let help = format_help();
+        assert!(help.contains("チャットコマンド"));
+        assert!(help.contains("/quit"));
+        assert!(help.contains("/who"));
+        assert!(help.contains("/me"));
+        assert!(help.contains("/help"));
+    }
+
+    #[test]
+    fn test_format_who_with_participants() {
+        let participants = vec!["Alice".to_string(), "Bob".to_string()];
+        let result = format_who(&participants, "Lobby");
+
+        assert!(result.contains("Lobby"));
+        assert!(result.contains("(2)"));
+        assert!(result.contains("Alice"));
+        assert!(result.contains("Bob"));
+    }
+
+    #[test]
+    fn test_format_who_empty() {
+        let participants: Vec<String> = vec![];
+        let result = format_who(&participants, "Empty Room");
+
+        assert!(result.contains("Empty Room"));
+        assert!(result.contains("(0)"));
+        assert!(result.contains("参加者はいません"));
+    }
+
+    #[test]
+    fn test_message_starting_with_slash_space() {
+        // Messages like "/ something" should be treated as messages, not commands
+        // Actually, based on our logic, "/ " starts with '/' so it will try to parse
+        // Let's verify the behavior
+        let input = parse_input("/ test");
+        // This parses as an empty command name, which becomes Unknown("")
+        assert!(matches!(input, ChatInput::Command(ChatCommand::Unknown(_))));
+    }
+
+    #[test]
+    fn test_slash_only() {
+        let input = parse_input("/");
+        // Empty command name becomes Unknown("")
+        assert_eq!(
+            input,
+            ChatInput::Command(ChatCommand::Unknown(String::new()))
+        );
+    }
+}

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -4,7 +4,12 @@
 //! - Chat rooms with broadcast messaging
 //! - Participant management (join/leave)
 //! - Message types (chat, action, system, join, leave)
+//! - Chat commands (/quit, /who, /me, /help)
 
+mod command;
 mod room;
 
+pub use command::{
+    format_help, format_who, get_command_help, parse_input, ChatCommand, ChatInput, CommandInfo,
+};
 pub use room::{ChatMessage, ChatParticipant, ChatRoom, MessageType};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,10 @@ pub use board::{
     NewThreadPost, PaginatedResult, Pagination, Post, PostRepository, PostUpdate, ReadPosition,
     Thread, ThreadRepository, ThreadUpdate, UnreadRepository,
 };
-pub use chat::{ChatMessage, ChatParticipant, ChatRoom, MessageType};
+pub use chat::{
+    format_help, format_who, get_command_help, parse_input, ChatCommand, ChatInput, ChatMessage,
+    ChatParticipant, ChatRoom, CommandInfo, MessageType,
+};
 pub use config::Config;
 pub use db::{Database, NewUser, Role, User, UserRepository, UserUpdate};
 pub use error::{HobbsError, Result};


### PR DESCRIPTION
## Summary

- `src/chat/command.rs` を新規作成
- `ChatInput` enum: Message（通常メッセージ）または Command（コマンド）
- `ChatCommand` enum: Quit, Who, Me, Help, Unknown の5種類
- `parse_input()` 関数でユーザー入力をパース

### 対応コマンド

| コマンド | 別名 | 説明 |
|---------|------|------|
| `/quit` | `/q`, `/exit` | チャットルームを退室 |
| `/who` | `/w`, `/users`, `/list` | 参加者一覧を表示 |
| `/me <アクション>` | `/action` | アクションメッセージ |
| `/help` | `/h`, `/?` | ヘルプを表示 |

### ヘルパー関数

- `format_help()`: ヘルプメッセージを整形
- `format_who()`: 参加者一覧を整形
- `get_command_help()`: コマンド情報一覧を取得

## Test plan

- [x] 21件の単体テストを追加
- [x] `cargo test` で全488テストがパス
- [x] `cargo clippy` で警告なし

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)