### PR TITLE
feat: メールテーブル実装

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -117,6 +117,25 @@ CREATE INDEX idx_chat_logs_room_id ON chat_logs(room_id);
 CREATE INDEX idx_chat_logs_created_at ON chat_logs(created_at);
 CREATE INDEX idx_chat_logs_room_created ON chat_logs(room_id, created_at);
 "#,
+    // v8: Mails table for internal mail system
+    r#"
+-- Mails table for internal mail system
+CREATE TABLE mails (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    sender_id               INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    recipient_id            INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    subject                 TEXT NOT NULL,
+    body                    TEXT NOT NULL,
+    is_read                 INTEGER NOT NULL DEFAULT 0,
+    is_deleted_by_sender    INTEGER NOT NULL DEFAULT 0,
+    is_deleted_by_recipient INTEGER NOT NULL DEFAULT 0,
+    created_at              TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_mails_sender_id ON mails(sender_id);
+CREATE INDEX idx_mails_recipient_id ON mails(recipient_id);
+CREATE INDEX idx_mails_created_at ON mails(created_at);
+"#,
 ];
 
 #[cfg(test)]
@@ -203,5 +222,19 @@ mod tests {
         assert!(chat_logs_migration.contains("message_type"));
         assert!(chat_logs_migration.contains("content"));
         assert!(chat_logs_migration.contains("created_at"));
+    }
+
+    #[test]
+    fn test_mails_migration_contains_mails_table() {
+        let mails_migration = MIGRATIONS[7];
+        assert!(mails_migration.contains("CREATE TABLE mails"));
+        assert!(mails_migration.contains("sender_id"));
+        assert!(mails_migration.contains("recipient_id"));
+        assert!(mails_migration.contains("subject"));
+        assert!(mails_migration.contains("body"));
+        assert!(mails_migration.contains("is_read"));
+        assert!(mails_migration.contains("is_deleted_by_sender"));
+        assert!(mails_migration.contains("is_deleted_by_recipient"));
+        assert!(mails_migration.contains("created_at"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod db;
 pub mod error;
 pub mod logging;
+pub mod mail;
 pub mod server;
 pub mod terminal;
 
@@ -33,6 +34,10 @@ pub use chat::{
 pub use config::Config;
 pub use db::{Database, NewUser, Role, User, UserRepository, UserUpdate};
 pub use error::{HobbsError, Result};
+pub use mail::{
+    Mail, MailRepository, MailUpdate, NewMail, MAX_BODY_LENGTH as MAX_MAIL_BODY_LENGTH,
+    MAX_SUBJECT_LENGTH as MAX_MAIL_SUBJECT_LENGTH,
+};
 pub use server::{
     decode_from_client, decode_shiftjis, decode_shiftjis_strict, encode_for_client,
     encode_shiftjis, encode_shiftjis_strict, initial_negotiation, CharacterEncoding, DecodeResult,

--- a/src/mail/mod.rs
+++ b/src/mail/mod.rs
@@ -1,0 +1,13 @@
+//! Mail module for HOBBS.
+//!
+//! This module provides internal mail functionality including:
+//! - Mail sending and receiving
+//! - Inbox and sent mail management
+//! - Read/unread status tracking
+//! - Logical deletion (per sender/recipient)
+
+mod repository;
+mod types;
+
+pub use repository::MailRepository;
+pub use types::{Mail, MailUpdate, NewMail, MAX_BODY_LENGTH, MAX_SUBJECT_LENGTH};

--- a/src/mail/repository.rs
+++ b/src/mail/repository.rs
@@ -1,0 +1,543 @@
+//! Mail repository for HOBBS.
+
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, OptionalExtension};
+
+use super::types::{Mail, MailUpdate, NewMail};
+
+/// Repository for mail operations.
+pub struct MailRepository;
+
+impl MailRepository {
+    /// Create a new mail.
+    pub fn create(conn: &Connection, mail: &NewMail) -> rusqlite::Result<Mail> {
+        conn.execute(
+            r#"
+            INSERT INTO mails (sender_id, recipient_id, subject, body)
+            VALUES (?1, ?2, ?3, ?4)
+            "#,
+            params![mail.sender_id, mail.recipient_id, mail.subject, mail.body],
+        )?;
+
+        let id = conn.last_insert_rowid();
+        Self::get_by_id(conn, id)?.ok_or_else(|| rusqlite::Error::QueryReturnedNoRows)
+    }
+
+    /// Get a mail by ID.
+    pub fn get_by_id(conn: &Connection, id: i64) -> rusqlite::Result<Option<Mail>> {
+        conn.query_row(
+            r#"
+            SELECT id, sender_id, recipient_id, subject, body,
+                   is_read, is_deleted_by_sender, is_deleted_by_recipient, created_at
+            FROM mails
+            WHERE id = ?1
+            "#,
+            [id],
+            Self::map_row,
+        )
+        .optional()
+    }
+
+    /// List inbox mails for a user (received mails, not deleted by recipient).
+    pub fn list_inbox(conn: &Connection, user_id: i64) -> rusqlite::Result<Vec<Mail>> {
+        let mut stmt = conn.prepare(
+            r#"
+            SELECT id, sender_id, recipient_id, subject, body,
+                   is_read, is_deleted_by_sender, is_deleted_by_recipient, created_at
+            FROM mails
+            WHERE recipient_id = ?1 AND is_deleted_by_recipient = 0
+            ORDER BY created_at DESC, id DESC
+            "#,
+        )?;
+
+        let mails: Vec<Mail> = stmt
+            .query_map([user_id], Self::map_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(mails)
+    }
+
+    /// List sent mails for a user (not deleted by sender).
+    pub fn list_sent(conn: &Connection, user_id: i64) -> rusqlite::Result<Vec<Mail>> {
+        let mut stmt = conn.prepare(
+            r#"
+            SELECT id, sender_id, recipient_id, subject, body,
+                   is_read, is_deleted_by_sender, is_deleted_by_recipient, created_at
+            FROM mails
+            WHERE sender_id = ?1 AND is_deleted_by_sender = 0
+            ORDER BY created_at DESC, id DESC
+            "#,
+        )?;
+
+        let mails: Vec<Mail> = stmt
+            .query_map([user_id], Self::map_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(mails)
+    }
+
+    /// Count unread mails for a user.
+    pub fn count_unread(conn: &Connection, user_id: i64) -> rusqlite::Result<i64> {
+        conn.query_row(
+            r#"
+            SELECT COUNT(*)
+            FROM mails
+            WHERE recipient_id = ?1 AND is_read = 0 AND is_deleted_by_recipient = 0
+            "#,
+            [user_id],
+            |row| row.get(0),
+        )
+    }
+
+    /// Update a mail.
+    pub fn update(conn: &Connection, id: i64, update: &MailUpdate) -> rusqlite::Result<bool> {
+        if update.is_empty() {
+            return Ok(false);
+        }
+
+        let mut sets = Vec::new();
+        let mut values: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+        if let Some(is_read) = update.is_read {
+            sets.push("is_read = ?");
+            values.push(Box::new(is_read as i32));
+        }
+
+        if let Some(deleted) = update.is_deleted_by_sender {
+            sets.push("is_deleted_by_sender = ?");
+            values.push(Box::new(deleted as i32));
+        }
+
+        if let Some(deleted) = update.is_deleted_by_recipient {
+            sets.push("is_deleted_by_recipient = ?");
+            values.push(Box::new(deleted as i32));
+        }
+
+        values.push(Box::new(id));
+
+        let sql = format!("UPDATE mails SET {} WHERE id = ?", sets.join(", "));
+
+        let params: Vec<&dyn rusqlite::ToSql> = values.iter().map(|v| v.as_ref()).collect();
+        let rows = conn.execute(&sql, params.as_slice())?;
+        Ok(rows > 0)
+    }
+
+    /// Mark a mail as read.
+    pub fn mark_as_read(conn: &Connection, id: i64) -> rusqlite::Result<bool> {
+        Self::update(conn, id, &MailUpdate::new().mark_as_read())
+    }
+
+    /// Delete a mail (logical deletion).
+    /// Marks the mail as deleted by the specified user.
+    pub fn delete_by_user(conn: &Connection, id: i64, user_id: i64) -> rusqlite::Result<bool> {
+        // First, get the mail to determine if user is sender or recipient
+        let mail = match Self::get_by_id(conn, id)? {
+            Some(m) => m,
+            None => return Ok(false),
+        };
+
+        let update = if mail.sender_id == user_id {
+            MailUpdate::new().delete_by_sender()
+        } else if mail.recipient_id == user_id {
+            MailUpdate::new().delete_by_recipient()
+        } else {
+            // User is neither sender nor recipient
+            return Ok(false);
+        };
+
+        Self::update(conn, id, &update)
+    }
+
+    /// Physically delete a mail.
+    /// Should only be used for mails that have been deleted by both sender and recipient.
+    pub fn purge(conn: &Connection, id: i64) -> rusqlite::Result<bool> {
+        let rows = conn.execute("DELETE FROM mails WHERE id = ?1", [id])?;
+        Ok(rows > 0)
+    }
+
+    /// Purge all mails that have been deleted by both sender and recipient.
+    pub fn purge_all_deleted(conn: &Connection) -> rusqlite::Result<usize> {
+        conn.execute(
+            "DELETE FROM mails WHERE is_deleted_by_sender = 1 AND is_deleted_by_recipient = 1",
+            [],
+        )
+    }
+
+    /// Count total mails in the database.
+    pub fn count(conn: &Connection) -> rusqlite::Result<i64> {
+        conn.query_row("SELECT COUNT(*) FROM mails", [], |row| row.get(0))
+    }
+
+    /// Map a database row to a Mail.
+    fn map_row(row: &rusqlite::Row) -> rusqlite::Result<Mail> {
+        let created_at_str: String = row.get(8)?;
+        let created_at = DateTime::parse_from_rfc3339(&created_at_str)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc::now());
+
+        Ok(Mail {
+            id: row.get(0)?,
+            sender_id: row.get(1)?,
+            recipient_id: row.get(2)?,
+            subject: row.get(3)?,
+            body: row.get(4)?,
+            is_read: row.get::<_, i32>(5)? != 0,
+            is_deleted_by_sender: row.get::<_, i32>(6)? != 0,
+            is_deleted_by_recipient: row.get::<_, i32>(7)? != 0,
+            created_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{Database, NewUser, UserRepository};
+
+    fn setup_db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    fn create_test_users(db: &Database) -> (i64, i64) {
+        let repo = UserRepository::new(db);
+        let user1 = NewUser::new("alice", "password123", "Alice");
+        let user2 = NewUser::new("bob", "password123", "Bob");
+        let id1 = repo.create(&user1).unwrap().id;
+        let id2 = repo.create(&user2).unwrap().id;
+        (id1, id2)
+    }
+
+    #[test]
+    fn test_create_mail() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        let new_mail = NewMail::new(sender_id, recipient_id, "Hello", "How are you?");
+        let mail = MailRepository::create(db.conn(), &new_mail).unwrap();
+
+        assert!(mail.id > 0);
+        assert_eq!(mail.sender_id, sender_id);
+        assert_eq!(mail.recipient_id, recipient_id);
+        assert_eq!(mail.subject, "Hello");
+        assert_eq!(mail.body, "How are you?");
+        assert!(!mail.is_read);
+        assert!(!mail.is_deleted_by_sender);
+        assert!(!mail.is_deleted_by_recipient);
+    }
+
+    #[test]
+    fn test_get_by_id() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        let new_mail = NewMail::new(sender_id, recipient_id, "Test", "Body");
+        let created = MailRepository::create(db.conn(), &new_mail).unwrap();
+
+        let retrieved = MailRepository::get_by_id(db.conn(), created.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(retrieved.id, created.id);
+        assert_eq!(retrieved.subject, "Test");
+    }
+
+    #[test]
+    fn test_get_by_id_not_found() {
+        let db = setup_db();
+        let result = MailRepository::get_by_id(db.conn(), 999).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_list_inbox() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        // Create some mails
+        MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail 1", "Body 1"),
+        )
+        .unwrap();
+        MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail 2", "Body 2"),
+        )
+        .unwrap();
+
+        let inbox = MailRepository::list_inbox(db.conn(), recipient_id).unwrap();
+        assert_eq!(inbox.len(), 2);
+        // Should be ordered by created_at DESC (most recent first)
+        assert_eq!(inbox[0].subject, "Mail 2");
+        assert_eq!(inbox[1].subject, "Mail 1");
+    }
+
+    #[test]
+    fn test_list_inbox_excludes_deleted() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        let mail = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail", "Body"),
+        )
+        .unwrap();
+
+        // Delete by recipient
+        MailRepository::update(db.conn(), mail.id, &MailUpdate::new().delete_by_recipient())
+            .unwrap();
+
+        let inbox = MailRepository::list_inbox(db.conn(), recipient_id).unwrap();
+        assert!(inbox.is_empty());
+    }
+
+    #[test]
+    fn test_list_sent() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Sent Mail", "Body"),
+        )
+        .unwrap();
+
+        let sent = MailRepository::list_sent(db.conn(), sender_id).unwrap();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].subject, "Sent Mail");
+    }
+
+    #[test]
+    fn test_list_sent_excludes_deleted() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        let mail = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail", "Body"),
+        )
+        .unwrap();
+
+        MailRepository::update(db.conn(), mail.id, &MailUpdate::new().delete_by_sender()).unwrap();
+
+        let sent = MailRepository::list_sent(db.conn(), sender_id).unwrap();
+        assert!(sent.is_empty());
+    }
+
+    #[test]
+    fn test_count_unread() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        // Initially no unread
+        assert_eq!(
+            MailRepository::count_unread(db.conn(), recipient_id).unwrap(),
+            0
+        );
+
+        // Create two mails
+        MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail 1", "Body"),
+        )
+        .unwrap();
+        let mail2 = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail 2", "Body"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            MailRepository::count_unread(db.conn(), recipient_id).unwrap(),
+            2
+        );
+
+        // Mark one as read
+        MailRepository::mark_as_read(db.conn(), mail2.id).unwrap();
+
+        assert_eq!(
+            MailRepository::count_unread(db.conn(), recipient_id).unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_mark_as_read() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        let mail = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail", "Body"),
+        )
+        .unwrap();
+
+        assert!(!mail.is_read);
+
+        MailRepository::mark_as_read(db.conn(), mail.id).unwrap();
+
+        let updated = MailRepository::get_by_id(db.conn(), mail.id)
+            .unwrap()
+            .unwrap();
+        assert!(updated.is_read);
+    }
+
+    #[test]
+    fn test_delete_by_user_sender() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        let mail = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail", "Body"),
+        )
+        .unwrap();
+
+        MailRepository::delete_by_user(db.conn(), mail.id, sender_id).unwrap();
+
+        let updated = MailRepository::get_by_id(db.conn(), mail.id)
+            .unwrap()
+            .unwrap();
+        assert!(updated.is_deleted_by_sender);
+        assert!(!updated.is_deleted_by_recipient);
+    }
+
+    #[test]
+    fn test_delete_by_user_recipient() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        let mail = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail", "Body"),
+        )
+        .unwrap();
+
+        MailRepository::delete_by_user(db.conn(), mail.id, recipient_id).unwrap();
+
+        let updated = MailRepository::get_by_id(db.conn(), mail.id)
+            .unwrap()
+            .unwrap();
+        assert!(!updated.is_deleted_by_sender);
+        assert!(updated.is_deleted_by_recipient);
+    }
+
+    #[test]
+    fn test_delete_by_user_not_involved() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        // Create a third user
+        let repo = UserRepository::new(&db);
+        let user3 = NewUser::new("charlie", "password123", "Charlie");
+        let user3_id = repo.create(&user3).unwrap().id;
+
+        let mail = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail", "Body"),
+        )
+        .unwrap();
+
+        // User3 tries to delete - should fail
+        let result = MailRepository::delete_by_user(db.conn(), mail.id, user3_id).unwrap();
+        assert!(!result);
+
+        // Mail should be unchanged
+        let unchanged = MailRepository::get_by_id(db.conn(), mail.id)
+            .unwrap()
+            .unwrap();
+        assert!(!unchanged.is_deleted_by_sender);
+        assert!(!unchanged.is_deleted_by_recipient);
+    }
+
+    #[test]
+    fn test_purge() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        let mail = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail", "Body"),
+        )
+        .unwrap();
+
+        MailRepository::purge(db.conn(), mail.id).unwrap();
+
+        let result = MailRepository::get_by_id(db.conn(), mail.id).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_purge_all_deleted() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        // Create three mails
+        let mail1 = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail 1", "Body"),
+        )
+        .unwrap();
+        let mail2 = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail 2", "Body"),
+        )
+        .unwrap();
+        let _mail3 = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail 3", "Body"),
+        )
+        .unwrap();
+
+        // Delete mail1 by both users
+        MailRepository::delete_by_user(db.conn(), mail1.id, sender_id).unwrap();
+        MailRepository::delete_by_user(db.conn(), mail1.id, recipient_id).unwrap();
+
+        // Delete mail2 only by sender
+        MailRepository::delete_by_user(db.conn(), mail2.id, sender_id).unwrap();
+
+        // Purge should only remove mail1
+        let purged = MailRepository::purge_all_deleted(db.conn()).unwrap();
+        assert_eq!(purged, 1);
+
+        // mail1 should be gone
+        assert!(MailRepository::get_by_id(db.conn(), mail1.id)
+            .unwrap()
+            .is_none());
+
+        // mail2 and mail3 should still exist
+        assert!(MailRepository::get_by_id(db.conn(), mail2.id)
+            .unwrap()
+            .is_some());
+
+        assert_eq!(MailRepository::count(db.conn()).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_count() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        assert_eq!(MailRepository::count(db.conn()).unwrap(), 0);
+
+        MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail", "Body"),
+        )
+        .unwrap();
+
+        assert_eq!(MailRepository::count(db.conn()).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_update_empty() {
+        let db = setup_db();
+        let (sender_id, recipient_id) = create_test_users(&db);
+
+        let mail = MailRepository::create(
+            db.conn(),
+            &NewMail::new(sender_id, recipient_id, "Mail", "Body"),
+        )
+        .unwrap();
+
+        let result = MailRepository::update(db.conn(), mail.id, &MailUpdate::new()).unwrap();
+        assert!(!result);
+    }
+}

--- a/src/mail/types.rs
+++ b/src/mail/types.rs
@@ -1,0 +1,255 @@
+//! Mail types for HOBBS.
+
+use chrono::{DateTime, Utc};
+
+/// Maximum length for mail subject.
+pub const MAX_SUBJECT_LENGTH: usize = 100;
+
+/// Maximum length for mail body.
+pub const MAX_BODY_LENGTH: usize = 10000;
+
+/// A mail message.
+#[derive(Debug, Clone)]
+pub struct Mail {
+    /// Mail ID.
+    pub id: i64,
+    /// Sender user ID.
+    pub sender_id: i64,
+    /// Recipient user ID.
+    pub recipient_id: i64,
+    /// Mail subject.
+    pub subject: String,
+    /// Mail body.
+    pub body: String,
+    /// Whether the mail has been read by the recipient.
+    pub is_read: bool,
+    /// Whether the mail has been deleted by the sender.
+    pub is_deleted_by_sender: bool,
+    /// Whether the mail has been deleted by the recipient.
+    pub is_deleted_by_recipient: bool,
+    /// When the mail was created.
+    pub created_at: DateTime<Utc>,
+}
+
+impl Mail {
+    /// Check if the mail is visible to the sender.
+    pub fn is_visible_to_sender(&self) -> bool {
+        !self.is_deleted_by_sender
+    }
+
+    /// Check if the mail is visible to the recipient.
+    pub fn is_visible_to_recipient(&self) -> bool {
+        !self.is_deleted_by_recipient
+    }
+
+    /// Check if the mail can be physically deleted.
+    /// A mail can be deleted when both sender and recipient have deleted it.
+    pub fn can_be_purged(&self) -> bool {
+        self.is_deleted_by_sender && self.is_deleted_by_recipient
+    }
+}
+
+/// New mail for creation.
+#[derive(Debug, Clone)]
+pub struct NewMail {
+    /// Sender user ID.
+    pub sender_id: i64,
+    /// Recipient user ID.
+    pub recipient_id: i64,
+    /// Mail subject.
+    pub subject: String,
+    /// Mail body.
+    pub body: String,
+}
+
+impl NewMail {
+    /// Create a new mail.
+    pub fn new(
+        sender_id: i64,
+        recipient_id: i64,
+        subject: impl Into<String>,
+        body: impl Into<String>,
+    ) -> Self {
+        Self {
+            sender_id,
+            recipient_id,
+            subject: subject.into(),
+            body: body.into(),
+        }
+    }
+}
+
+/// Mail update request.
+#[derive(Debug, Clone, Default)]
+pub struct MailUpdate {
+    /// Mark as read.
+    pub is_read: Option<bool>,
+    /// Mark as deleted by sender.
+    pub is_deleted_by_sender: Option<bool>,
+    /// Mark as deleted by recipient.
+    pub is_deleted_by_recipient: Option<bool>,
+}
+
+impl MailUpdate {
+    /// Create a new update request.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark as read.
+    pub fn mark_as_read(mut self) -> Self {
+        self.is_read = Some(true);
+        self
+    }
+
+    /// Mark as unread.
+    pub fn mark_as_unread(mut self) -> Self {
+        self.is_read = Some(false);
+        self
+    }
+
+    /// Mark as deleted by sender.
+    pub fn delete_by_sender(mut self) -> Self {
+        self.is_deleted_by_sender = Some(true);
+        self
+    }
+
+    /// Mark as deleted by recipient.
+    pub fn delete_by_recipient(mut self) -> Self {
+        self.is_deleted_by_recipient = Some(true);
+        self
+    }
+
+    /// Check if the update is empty.
+    pub fn is_empty(&self) -> bool {
+        self.is_read.is_none()
+            && self.is_deleted_by_sender.is_none()
+            && self.is_deleted_by_recipient.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_mail() {
+        let mail = NewMail::new(1, 2, "Hello", "Body text");
+        assert_eq!(mail.sender_id, 1);
+        assert_eq!(mail.recipient_id, 2);
+        assert_eq!(mail.subject, "Hello");
+        assert_eq!(mail.body, "Body text");
+    }
+
+    #[test]
+    fn test_mail_visibility_sender() {
+        let mail = Mail {
+            id: 1,
+            sender_id: 1,
+            recipient_id: 2,
+            subject: "Test".to_string(),
+            body: "Body".to_string(),
+            is_read: false,
+            is_deleted_by_sender: false,
+            is_deleted_by_recipient: false,
+            created_at: Utc::now(),
+        };
+        assert!(mail.is_visible_to_sender());
+
+        let deleted_mail = Mail {
+            is_deleted_by_sender: true,
+            ..mail.clone()
+        };
+        assert!(!deleted_mail.is_visible_to_sender());
+    }
+
+    #[test]
+    fn test_mail_visibility_recipient() {
+        let mail = Mail {
+            id: 1,
+            sender_id: 1,
+            recipient_id: 2,
+            subject: "Test".to_string(),
+            body: "Body".to_string(),
+            is_read: false,
+            is_deleted_by_sender: false,
+            is_deleted_by_recipient: false,
+            created_at: Utc::now(),
+        };
+        assert!(mail.is_visible_to_recipient());
+
+        let deleted_mail = Mail {
+            is_deleted_by_recipient: true,
+            ..mail.clone()
+        };
+        assert!(!deleted_mail.is_visible_to_recipient());
+    }
+
+    #[test]
+    fn test_mail_can_be_purged() {
+        let mail = Mail {
+            id: 1,
+            sender_id: 1,
+            recipient_id: 2,
+            subject: "Test".to_string(),
+            body: "Body".to_string(),
+            is_read: false,
+            is_deleted_by_sender: false,
+            is_deleted_by_recipient: false,
+            created_at: Utc::now(),
+        };
+        assert!(!mail.can_be_purged());
+
+        let sender_deleted = Mail {
+            is_deleted_by_sender: true,
+            ..mail.clone()
+        };
+        assert!(!sender_deleted.can_be_purged());
+
+        let both_deleted = Mail {
+            is_deleted_by_sender: true,
+            is_deleted_by_recipient: true,
+            ..mail.clone()
+        };
+        assert!(both_deleted.can_be_purged());
+    }
+
+    #[test]
+    fn test_mail_update_empty() {
+        let update = MailUpdate::new();
+        assert!(update.is_empty());
+    }
+
+    #[test]
+    fn test_mail_update_mark_as_read() {
+        let update = MailUpdate::new().mark_as_read();
+        assert_eq!(update.is_read, Some(true));
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_mail_update_mark_as_unread() {
+        let update = MailUpdate::new().mark_as_unread();
+        assert_eq!(update.is_read, Some(false));
+    }
+
+    #[test]
+    fn test_mail_update_delete_by_sender() {
+        let update = MailUpdate::new().delete_by_sender();
+        assert_eq!(update.is_deleted_by_sender, Some(true));
+    }
+
+    #[test]
+    fn test_mail_update_delete_by_recipient() {
+        let update = MailUpdate::new().delete_by_recipient();
+        assert_eq!(update.is_deleted_by_recipient, Some(true));
+    }
+
+    #[test]
+    fn test_mail_update_combined() {
+        let update = MailUpdate::new().mark_as_read().delete_by_recipient();
+        assert_eq!(update.is_read, Some(true));
+        assert_eq!(update.is_deleted_by_recipient, Some(true));
+        assert!(update.is_deleted_by_sender.is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- mails テーブルのマイグレーション (v8) を追加
- Mail, NewMail, MailUpdate 構造体を定義
- MailRepository (CRUD、論理削除) を実装

## Changes
- `src/db/schema.rs`: v8 マイグレーション追加
- `src/mail/mod.rs`: メールモジュール定義
- `src/mail/types.rs`: Mail, NewMail, MailUpdate 構造体
- `src/mail/repository.rs`: MailRepository 実装
- `src/lib.rs`: mail モジュールのエクスポート

## Features
- 送信/受信一覧取得
- 未読カウント
- 既読マーク
- 論理削除（送信者/受信者別）
- 物理削除（パージ）

## Test plan
- [x] 17件の単体テストを追加
- [x] `cargo test` - 532 tests passed
- [x] `cargo clippy` - no warnings

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)