### PR TITLE
feat: テンプレートエンジンを実装

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod i18n;
 pub mod logging;
 pub mod mail;
 pub mod server;
+pub mod template;
 pub mod terminal;
 
 pub use admin::{
@@ -64,3 +65,4 @@ pub use server::{
 pub use terminal::TerminalProfile;
 
 pub use i18n::{I18n, I18nError, I18nManager, DEFAULT_LOCALE};
+pub use template::{Node, Parser, Renderer, TemplateContext, TemplateEngine, TemplateError, Value};

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -1,0 +1,559 @@
+//! Template engine module for HOBBS.
+//!
+//! Provides a Handlebars-style template engine for rendering dynamic content.
+//!
+//! # Features
+//!
+//! - Variable expansion: `{{variable}}`
+//! - Translation reference: `{{t "key"}}` or `{{t "key" name=value}}`
+//! - Conditionals: `{{#if condition}}...{{else}}...{{/if}}`
+//! - Loops: `{{#each items}}...{{/each}}`
+//! - Escaping: `\{{` to output literal `{{`
+//!
+//! # Example
+//!
+//! ```
+//! use hobbs::template::{TemplateEngine, TemplateContext, Value};
+//! use hobbs::i18n::I18n;
+//! use std::sync::Arc;
+//!
+//! let mut engine = TemplateEngine::new();
+//! engine.load("greeting", "Hello, {{name}}!");
+//!
+//! let i18n = Arc::new(I18n::empty("en"));
+//! let mut context = TemplateContext::new(i18n);
+//! context.set("name", Value::String("World".to_string()));
+//!
+//! let result = engine.render("greeting", &context).unwrap();
+//! assert_eq!(result, "Hello, World!");
+//! ```
+
+mod parser;
+mod renderer;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use thiserror::Error;
+
+use crate::i18n::I18n;
+
+pub use parser::{Node, Parser};
+pub use renderer::Renderer;
+
+/// Template-related errors.
+#[derive(Error, Debug)]
+pub enum TemplateError {
+    /// Template not found.
+    #[error("Template not found: {0}")]
+    NotFound(String),
+
+    /// Parse error.
+    #[error("Parse error: {0}")]
+    Parse(String),
+
+    /// Render error.
+    #[error("Render error: {0}")]
+    Render(String),
+
+    /// Variable not found.
+    #[error("Variable not found: {0}")]
+    VariableNotFound(String),
+}
+
+/// Result type for template operations.
+pub type Result<T> = std::result::Result<T, TemplateError>;
+
+/// A value that can be used in templates.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    /// A string value.
+    String(String),
+    /// A numeric value.
+    Number(i64),
+    /// A floating-point value.
+    Float(f64),
+    /// A boolean value.
+    Bool(bool),
+    /// A list of values.
+    List(Vec<Value>),
+    /// An object (key-value pairs).
+    Object(HashMap<String, Value>),
+    /// A null/empty value.
+    Null,
+}
+
+impl Value {
+    /// Convert the value to a string for display.
+    pub fn to_display_string(&self) -> String {
+        match self {
+            Value::String(s) => s.clone(),
+            Value::Number(n) => n.to_string(),
+            Value::Float(f) => f.to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::List(_) => "[list]".to_string(),
+            Value::Object(_) => "[object]".to_string(),
+            Value::Null => "".to_string(),
+        }
+    }
+
+    /// Check if the value is truthy.
+    pub fn is_truthy(&self) -> bool {
+        match self {
+            Value::String(s) => !s.is_empty(),
+            Value::Number(n) => *n != 0,
+            Value::Float(f) => *f != 0.0,
+            Value::Bool(b) => *b,
+            Value::List(l) => !l.is_empty(),
+            Value::Object(o) => !o.is_empty(),
+            Value::Null => false,
+        }
+    }
+
+    /// Get a nested value by dot-separated path.
+    pub fn get_path(&self, path: &str) -> Option<&Value> {
+        let parts: Vec<&str> = path.split('.').collect();
+        let mut current = self;
+
+        for part in parts {
+            match current {
+                Value::Object(map) => {
+                    current = map.get(part)?;
+                }
+                Value::List(list) => {
+                    let index: usize = part.parse().ok()?;
+                    current = list.get(index)?;
+                }
+                _ => return None,
+            }
+        }
+
+        Some(current)
+    }
+
+    /// Create a Value from a string.
+    pub fn string(s: impl Into<String>) -> Self {
+        Value::String(s.into())
+    }
+
+    /// Create a Value from a number.
+    pub fn number(n: i64) -> Self {
+        Value::Number(n)
+    }
+
+    /// Create a Value from a boolean.
+    pub fn bool(b: bool) -> Self {
+        Value::Bool(b)
+    }
+
+    /// Create a list Value.
+    pub fn list(items: Vec<Value>) -> Self {
+        Value::List(items)
+    }
+
+    /// Create an object Value.
+    pub fn object(items: HashMap<String, Value>) -> Self {
+        Value::Object(items)
+    }
+}
+
+impl From<&str> for Value {
+    fn from(s: &str) -> Self {
+        Value::String(s.to_string())
+    }
+}
+
+impl From<String> for Value {
+    fn from(s: String) -> Self {
+        Value::String(s)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(n: i64) -> Self {
+        Value::Number(n)
+    }
+}
+
+impl From<i32> for Value {
+    fn from(n: i32) -> Self {
+        Value::Number(n as i64)
+    }
+}
+
+impl From<bool> for Value {
+    fn from(b: bool) -> Self {
+        Value::Bool(b)
+    }
+}
+
+impl<T: Into<Value>> From<Vec<T>> for Value {
+    fn from(v: Vec<T>) -> Self {
+        Value::List(v.into_iter().map(Into::into).collect())
+    }
+}
+
+/// Context for template rendering.
+#[derive(Debug, Clone)]
+pub struct TemplateContext {
+    /// Variables available in the template.
+    variables: HashMap<String, Value>,
+    /// Internationalization instance.
+    i18n: Arc<I18n>,
+}
+
+impl TemplateContext {
+    /// Create a new template context.
+    pub fn new(i18n: Arc<I18n>) -> Self {
+        Self {
+            variables: HashMap::new(),
+            i18n,
+        }
+    }
+
+    /// Set a variable in the context.
+    pub fn set(&mut self, name: impl Into<String>, value: Value) {
+        self.variables.insert(name.into(), value);
+    }
+
+    /// Get a variable from the context.
+    pub fn get(&self, name: &str) -> Option<&Value> {
+        // First try direct lookup
+        if let Some(value) = self.variables.get(name) {
+            return Some(value);
+        }
+
+        // Try dot-notation path lookup
+        if name.contains('.') {
+            let parts: Vec<&str> = name.splitn(2, '.').collect();
+            if parts.len() == 2 {
+                if let Some(root) = self.variables.get(parts[0]) {
+                    return root.get_path(parts[1]);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Get the i18n instance.
+    pub fn i18n(&self) -> &I18n {
+        &self.i18n
+    }
+
+    /// Set multiple variables from a HashMap.
+    pub fn set_many(&mut self, variables: HashMap<String, Value>) {
+        self.variables.extend(variables);
+    }
+
+    /// Clear all variables.
+    pub fn clear(&mut self) {
+        self.variables.clear();
+    }
+
+    /// Create a child context with additional variables.
+    ///
+    /// The child context inherits all variables from the parent.
+    pub fn child(&self) -> Self {
+        Self {
+            variables: self.variables.clone(),
+            i18n: Arc::clone(&self.i18n),
+        }
+    }
+}
+
+/// Template engine for parsing and rendering templates.
+#[derive(Debug, Default)]
+pub struct TemplateEngine {
+    /// Parsed templates.
+    templates: HashMap<String, Vec<Node>>,
+}
+
+impl TemplateEngine {
+    /// Create a new template engine.
+    pub fn new() -> Self {
+        Self {
+            templates: HashMap::new(),
+        }
+    }
+
+    /// Load a template from a string.
+    pub fn load(&mut self, name: impl Into<String>, content: &str) -> Result<()> {
+        let parser = Parser::new(content);
+        let nodes = parser.parse()?;
+        self.templates.insert(name.into(), nodes);
+        Ok(())
+    }
+
+    /// Render a template with the given context.
+    pub fn render(&self, name: &str, context: &TemplateContext) -> Result<String> {
+        let nodes = self
+            .templates
+            .get(name)
+            .ok_or_else(|| TemplateError::NotFound(name.to_string()))?;
+
+        let renderer = Renderer::new(context);
+        renderer.render(nodes)
+    }
+
+    /// Render a template string directly without loading.
+    pub fn render_string(content: &str, context: &TemplateContext) -> Result<String> {
+        let parser = Parser::new(content);
+        let nodes = parser.parse()?;
+        let renderer = Renderer::new(context);
+        renderer.render(&nodes)
+    }
+
+    /// Check if a template is loaded.
+    pub fn has_template(&self, name: &str) -> bool {
+        self.templates.contains_key(name)
+    }
+
+    /// Get the list of loaded template names.
+    pub fn template_names(&self) -> Vec<&str> {
+        self.templates.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Remove a template.
+    pub fn unload(&mut self, name: &str) -> bool {
+        self.templates.remove(name).is_some()
+    }
+
+    /// Clear all loaded templates.
+    pub fn clear(&mut self) {
+        self.templates.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_context() -> TemplateContext {
+        let i18n = Arc::new(I18n::empty("ja"));
+        TemplateContext::new(i18n)
+    }
+
+    // Value tests
+    #[test]
+    fn test_value_to_display_string() {
+        assert_eq!(Value::String("hello".to_string()).to_display_string(), "hello");
+        assert_eq!(Value::Number(42).to_display_string(), "42");
+        assert_eq!(Value::Float(3.14).to_display_string(), "3.14");
+        assert_eq!(Value::Bool(true).to_display_string(), "true");
+        assert_eq!(Value::Bool(false).to_display_string(), "false");
+        assert_eq!(Value::List(vec![]).to_display_string(), "[list]");
+        assert_eq!(Value::Object(HashMap::new()).to_display_string(), "[object]");
+        assert_eq!(Value::Null.to_display_string(), "");
+    }
+
+    #[test]
+    fn test_value_is_truthy() {
+        assert!(Value::String("hello".to_string()).is_truthy());
+        assert!(!Value::String("".to_string()).is_truthy());
+        assert!(Value::Number(1).is_truthy());
+        assert!(!Value::Number(0).is_truthy());
+        assert!(Value::Float(0.1).is_truthy());
+        assert!(!Value::Float(0.0).is_truthy());
+        assert!(Value::Bool(true).is_truthy());
+        assert!(!Value::Bool(false).is_truthy());
+        assert!(Value::List(vec![Value::Number(1)]).is_truthy());
+        assert!(!Value::List(vec![]).is_truthy());
+        assert!(!Value::Null.is_truthy());
+    }
+
+    #[test]
+    fn test_value_get_path() {
+        let mut inner = HashMap::new();
+        inner.insert("name".to_string(), Value::String("test".to_string()));
+        inner.insert("count".to_string(), Value::Number(5));
+
+        let value = Value::Object({
+            let mut map = HashMap::new();
+            map.insert("user".to_string(), Value::Object(inner));
+            map
+        });
+
+        assert_eq!(
+            value.get_path("user.name"),
+            Some(&Value::String("test".to_string()))
+        );
+        assert_eq!(value.get_path("user.count"), Some(&Value::Number(5)));
+        assert_eq!(value.get_path("user.missing"), None);
+        assert_eq!(value.get_path("missing"), None);
+    }
+
+    #[test]
+    fn test_value_from_traits() {
+        let s: Value = "hello".into();
+        assert_eq!(s, Value::String("hello".to_string()));
+
+        let n: Value = 42i64.into();
+        assert_eq!(n, Value::Number(42));
+
+        let n32: Value = 42i32.into();
+        assert_eq!(n32, Value::Number(42));
+
+        let b: Value = true.into();
+        assert_eq!(b, Value::Bool(true));
+
+        let list: Value = vec!["a", "b", "c"].into();
+        assert_eq!(
+            list,
+            Value::List(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+                Value::String("c".to_string()),
+            ])
+        );
+    }
+
+    // TemplateContext tests
+    #[test]
+    fn test_context_set_and_get() {
+        let mut context = create_context();
+        context.set("name", Value::String("Alice".to_string()));
+        context.set("age", Value::Number(30));
+
+        assert_eq!(
+            context.get("name"),
+            Some(&Value::String("Alice".to_string()))
+        );
+        assert_eq!(context.get("age"), Some(&Value::Number(30)));
+        assert_eq!(context.get("missing"), None);
+    }
+
+    #[test]
+    fn test_context_get_nested() {
+        let mut context = create_context();
+
+        let mut user = HashMap::new();
+        user.insert("name".to_string(), Value::String("Bob".to_string()));
+        user.insert("age".to_string(), Value::Number(25));
+        context.set("user", Value::Object(user));
+
+        assert_eq!(
+            context.get("user.name"),
+            Some(&Value::String("Bob".to_string()))
+        );
+        assert_eq!(context.get("user.age"), Some(&Value::Number(25)));
+        assert_eq!(context.get("user.missing"), None);
+    }
+
+    #[test]
+    fn test_context_child() {
+        let mut context = create_context();
+        context.set("parent", Value::String("parent_value".to_string()));
+
+        let mut child = context.child();
+        child.set("child", Value::String("child_value".to_string()));
+
+        // Child has both parent and child variables
+        assert_eq!(
+            child.get("parent"),
+            Some(&Value::String("parent_value".to_string()))
+        );
+        assert_eq!(
+            child.get("child"),
+            Some(&Value::String("child_value".to_string()))
+        );
+
+        // Parent doesn't have child variable
+        assert_eq!(context.get("child"), None);
+    }
+
+    #[test]
+    fn test_context_set_many() {
+        let mut context = create_context();
+        let mut vars = HashMap::new();
+        vars.insert("a".to_string(), Value::Number(1));
+        vars.insert("b".to_string(), Value::Number(2));
+        context.set_many(vars);
+
+        assert_eq!(context.get("a"), Some(&Value::Number(1)));
+        assert_eq!(context.get("b"), Some(&Value::Number(2)));
+    }
+
+    #[test]
+    fn test_context_clear() {
+        let mut context = create_context();
+        context.set("name", Value::String("test".to_string()));
+        assert!(context.get("name").is_some());
+
+        context.clear();
+        assert!(context.get("name").is_none());
+    }
+
+    // TemplateEngine tests
+    #[test]
+    fn test_engine_load_and_render() {
+        let mut engine = TemplateEngine::new();
+        engine.load("test", "Hello, {{name}}!").unwrap();
+
+        let mut context = create_context();
+        context.set("name", Value::String("World".to_string()));
+
+        let result = engine.render("test", &context).unwrap();
+        assert_eq!(result, "Hello, World!");
+    }
+
+    #[test]
+    fn test_engine_render_not_found() {
+        let engine = TemplateEngine::new();
+        let context = create_context();
+
+        let result = engine.render("missing", &context);
+        assert!(matches!(result, Err(TemplateError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_engine_render_string() {
+        let mut context = create_context();
+        context.set("x", Value::Number(10));
+
+        let result = TemplateEngine::render_string("x = {{x}}", &context).unwrap();
+        assert_eq!(result, "x = 10");
+    }
+
+    #[test]
+    fn test_engine_has_template() {
+        let mut engine = TemplateEngine::new();
+        assert!(!engine.has_template("test"));
+
+        engine.load("test", "content").unwrap();
+        assert!(engine.has_template("test"));
+    }
+
+    #[test]
+    fn test_engine_template_names() {
+        let mut engine = TemplateEngine::new();
+        engine.load("a", "").unwrap();
+        engine.load("b", "").unwrap();
+
+        let names = engine.template_names();
+        assert!(names.contains(&"a"));
+        assert!(names.contains(&"b"));
+    }
+
+    #[test]
+    fn test_engine_unload() {
+        let mut engine = TemplateEngine::new();
+        engine.load("test", "content").unwrap();
+        assert!(engine.has_template("test"));
+
+        assert!(engine.unload("test"));
+        assert!(!engine.has_template("test"));
+        assert!(!engine.unload("test")); // Already removed
+    }
+
+    #[test]
+    fn test_engine_clear() {
+        let mut engine = TemplateEngine::new();
+        engine.load("a", "").unwrap();
+        engine.load("b", "").unwrap();
+
+        engine.clear();
+        assert!(!engine.has_template("a"));
+        assert!(!engine.has_template("b"));
+    }
+}

--- a/src/template/parser.rs
+++ b/src/template/parser.rs
@@ -1,0 +1,643 @@
+//! Template parser module.
+//!
+//! Parses template strings into an AST (Abstract Syntax Tree) of nodes.
+
+use super::{Result, TemplateError};
+
+/// A node in the template AST.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Node {
+    /// Raw text content.
+    Text(String),
+
+    /// Variable reference: `{{name}}` or `{{user.name}}`
+    Variable(String),
+
+    /// Translation reference: `{{t "key"}}` or `{{t "key" param=value}}`
+    Translation {
+        key: String,
+        params: Vec<(String, String)>,
+    },
+
+    /// Conditional block: `{{#if condition}}...{{else}}...{{/if}}`
+    If {
+        condition: String,
+        then_branch: Vec<Node>,
+        else_branch: Vec<Node>,
+    },
+
+    /// Loop block: `{{#each items}}...{{/each}}`
+    Each {
+        variable: String,
+        item_name: Option<String>,
+        body: Vec<Node>,
+    },
+
+    /// Unless block (inverse of if): `{{#unless condition}}...{{/unless}}`
+    Unless {
+        condition: String,
+        body: Vec<Node>,
+    },
+
+    /// With block (scope change): `{{#with object}}...{{/with}}`
+    With {
+        variable: String,
+        body: Vec<Node>,
+    },
+}
+
+/// Template parser.
+pub struct Parser<'a> {
+    input: &'a str,
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    /// Create a new parser for the given input.
+    pub fn new(input: &'a str) -> Self {
+        Self { input, pos: 0 }
+    }
+
+    /// Parse the template into a list of nodes.
+    pub fn parse(mut self) -> Result<Vec<Node>> {
+        self.parse_nodes(None)
+    }
+
+    /// Parse nodes until reaching a closing tag or end of input.
+    fn parse_nodes(&mut self, end_tag: Option<&str>) -> Result<Vec<Node>> {
+        let mut nodes = Vec::new();
+
+        while self.pos < self.input.len() {
+            // Check for closing tag
+            if let Some(tag) = end_tag {
+                if self.peek_str(&format!("{{{{/{tag}}}}}")) {
+                    break;
+                }
+                // Also check for {{else}} in if blocks
+                if tag == "if" && self.peek_str("{{else}}") {
+                    break;
+                }
+            }
+
+            // Try to parse a tag
+            if self.peek_str("\\{{") {
+                // Escaped opening brace
+                self.pos += 3; // Skip \{{
+                nodes.push(Node::Text("{{".to_string()));
+            } else if self.peek_str("{{") {
+                let node = self.parse_tag()?;
+                nodes.push(node);
+            } else {
+                // Collect text until next tag or escape
+                let text = self.collect_text();
+                if !text.is_empty() {
+                    nodes.push(Node::Text(text));
+                }
+            }
+        }
+
+        Ok(nodes)
+    }
+
+    /// Parse a single tag.
+    fn parse_tag(&mut self) -> Result<Node> {
+        self.expect("{{")?;
+        self.skip_whitespace();
+
+        // Check for block tags
+        if self.peek_char() == Some('#') {
+            self.advance(); // Skip #
+            self.skip_whitespace();
+            return self.parse_block_tag();
+        }
+
+        // Check for translation
+        if self.peek_str("t ") || self.peek_str("t\"") {
+            return self.parse_translation();
+        }
+
+        // Parse variable
+        let name = self.parse_identifier()?;
+        self.skip_whitespace();
+        self.expect("}}")?;
+
+        Ok(Node::Variable(name))
+    }
+
+    /// Parse a block tag (if, each, unless, with).
+    fn parse_block_tag(&mut self) -> Result<Node> {
+        let tag_name = self.parse_identifier()?;
+        self.skip_whitespace();
+
+        match tag_name.as_str() {
+            "if" => self.parse_if_block(),
+            "each" => self.parse_each_block(),
+            "unless" => self.parse_unless_block(),
+            "with" => self.parse_with_block(),
+            _ => Err(TemplateError::Parse(format!(
+                "Unknown block tag: {tag_name}"
+            ))),
+        }
+    }
+
+    /// Parse an if block.
+    fn parse_if_block(&mut self) -> Result<Node> {
+        let condition = self.parse_identifier()?;
+        self.skip_whitespace();
+        self.expect("}}")?;
+
+        let then_branch = self.parse_nodes(Some("if"))?;
+
+        let else_branch = if self.peek_str("{{else}}") {
+            self.expect("{{else}}")?;
+            self.parse_nodes(Some("if"))?
+        } else {
+            Vec::new()
+        };
+
+        self.expect("{{/if}}")?;
+
+        Ok(Node::If {
+            condition,
+            then_branch,
+            else_branch,
+        })
+    }
+
+    /// Parse an each block.
+    fn parse_each_block(&mut self) -> Result<Node> {
+        let variable = self.parse_identifier()?;
+        self.skip_whitespace();
+
+        // Check for "as item" syntax
+        let item_name = if self.peek_str("as ") {
+            self.expect("as ")?;
+            self.skip_whitespace();
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
+
+        self.skip_whitespace();
+        self.expect("}}")?;
+
+        let body = self.parse_nodes(Some("each"))?;
+        self.expect("{{/each}}")?;
+
+        Ok(Node::Each {
+            variable,
+            item_name,
+            body,
+        })
+    }
+
+    /// Parse an unless block.
+    fn parse_unless_block(&mut self) -> Result<Node> {
+        let condition = self.parse_identifier()?;
+        self.skip_whitespace();
+        self.expect("}}")?;
+
+        let body = self.parse_nodes(Some("unless"))?;
+        self.expect("{{/unless}}")?;
+
+        Ok(Node::Unless { condition, body })
+    }
+
+    /// Parse a with block.
+    fn parse_with_block(&mut self) -> Result<Node> {
+        let variable = self.parse_identifier()?;
+        self.skip_whitespace();
+        self.expect("}}")?;
+
+        let body = self.parse_nodes(Some("with"))?;
+        self.expect("{{/with}}")?;
+
+        Ok(Node::With { variable, body })
+    }
+
+    /// Parse a translation tag.
+    fn parse_translation(&mut self) -> Result<Node> {
+        self.expect("t")?;
+        self.skip_whitespace();
+
+        // Parse the key (quoted string)
+        let key = self.parse_quoted_string()?;
+        self.skip_whitespace();
+
+        // Parse optional parameters
+        let mut params = Vec::new();
+        while self.peek_char() != Some('}') {
+            let param_name = self.parse_identifier()?;
+            self.skip_whitespace();
+            self.expect("=")?;
+            self.skip_whitespace();
+
+            let param_value = if self.peek_char() == Some('"') {
+                // Keep quotes to indicate literal string in renderer
+                format!("\"{}\"", self.parse_quoted_string()?)
+            } else {
+                self.parse_identifier()?
+            };
+
+            params.push((param_name, param_value));
+            self.skip_whitespace();
+        }
+
+        self.expect("}}")?;
+
+        Ok(Node::Translation { key, params })
+    }
+
+    /// Parse a quoted string.
+    fn parse_quoted_string(&mut self) -> Result<String> {
+        self.expect("\"")?;
+
+        let start = self.pos;
+        while self.pos < self.input.len() {
+            let ch = self.current_char();
+            if ch == '"' {
+                let s = self.input[start..self.pos].to_string();
+                self.advance();
+                return Ok(s);
+            }
+            if ch == '\\' && self.pos + 1 < self.input.len() {
+                self.advance(); // Skip escape char
+            }
+            self.advance();
+        }
+
+        Err(TemplateError::Parse("Unterminated string".to_string()))
+    }
+
+    /// Parse an identifier (variable name, including dot notation).
+    fn parse_identifier(&mut self) -> Result<String> {
+        let start = self.pos;
+
+        while self.pos < self.input.len() {
+            let ch = self.current_char();
+            if ch.is_alphanumeric() || ch == '_' || ch == '.' || ch == '-' {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        if self.pos == start {
+            return Err(TemplateError::Parse("Expected identifier".to_string()));
+        }
+
+        Ok(self.input[start..self.pos].to_string())
+    }
+
+    /// Collect text until the next tag or escape sequence.
+    fn collect_text(&mut self) -> String {
+        let start = self.pos;
+
+        while self.pos < self.input.len() {
+            if self.peek_str("{{") || self.peek_str("\\{{") {
+                break;
+            }
+            self.advance();
+        }
+
+        self.input[start..self.pos].to_string()
+    }
+
+    /// Skip whitespace characters.
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.input.len() && self.current_char().is_whitespace() {
+            self.advance();
+        }
+    }
+
+    /// Check if the input starts with the given string at current position.
+    fn peek_str(&self, s: &str) -> bool {
+        self.input[self.pos..].starts_with(s)
+    }
+
+    /// Peek at the current character.
+    fn peek_char(&self) -> Option<char> {
+        self.input[self.pos..].chars().next()
+    }
+
+    /// Get the current character.
+    fn current_char(&self) -> char {
+        self.input[self.pos..].chars().next().unwrap_or('\0')
+    }
+
+    /// Advance position by one character.
+    fn advance(&mut self) {
+        if self.pos < self.input.len() {
+            self.pos += self.current_char().len_utf8();
+        }
+    }
+
+    /// Expect a specific string and consume it.
+    fn expect(&mut self, s: &str) -> Result<()> {
+        if self.peek_str(s) {
+            self.pos += s.len();
+            Ok(())
+        } else {
+            let found: String = self.input[self.pos..].chars().take(10).collect();
+            Err(TemplateError::Parse(format!(
+                "Expected '{s}' but found '{found}'"
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_text_only() {
+        let parser = Parser::new("Hello, World!");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(nodes, vec![Node::Text("Hello, World!".to_string())]);
+    }
+
+    #[test]
+    fn test_parse_variable() {
+        let parser = Parser::new("Hello, {{name}}!");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![
+                Node::Text("Hello, ".to_string()),
+                Node::Variable("name".to_string()),
+                Node::Text("!".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_variable_with_dots() {
+        let parser = Parser::new("{{user.name}}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(nodes, vec![Node::Variable("user.name".to_string())]);
+    }
+
+    #[test]
+    fn test_parse_multiple_variables() {
+        let parser = Parser::new("{{a}} and {{b}}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![
+                Node::Variable("a".to_string()),
+                Node::Text(" and ".to_string()),
+                Node::Variable("b".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_translation_simple() {
+        let parser = Parser::new(r#"{{t "menu.main"}}"#);
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::Translation {
+                key: "menu.main".to_string(),
+                params: vec![],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_translation_with_params() {
+        let parser = Parser::new(r#"{{t "welcome" name="World"}}"#);
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::Translation {
+                key: "welcome".to_string(),
+                // Quoted strings keep quotes to distinguish from variable refs
+                params: vec![("name".to_string(), "\"World\"".to_string())],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_translation_with_variable_param() {
+        let parser = Parser::new(r#"{{t "welcome" name=username}}"#);
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::Translation {
+                key: "welcome".to_string(),
+                params: vec![("name".to_string(), "username".to_string())],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_if_simple() {
+        let parser = Parser::new("{{#if show}}visible{{/if}}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::If {
+                condition: "show".to_string(),
+                then_branch: vec![Node::Text("visible".to_string())],
+                else_branch: vec![],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_if_else() {
+        let parser = Parser::new("{{#if show}}yes{{else}}no{{/if}}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::If {
+                condition: "show".to_string(),
+                then_branch: vec![Node::Text("yes".to_string())],
+                else_branch: vec![Node::Text("no".to_string())],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_if_with_variables() {
+        let parser = Parser::new("{{#if logged_in}}Hello, {{name}}{{/if}}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::If {
+                condition: "logged_in".to_string(),
+                then_branch: vec![
+                    Node::Text("Hello, ".to_string()),
+                    Node::Variable("name".to_string()),
+                ],
+                else_branch: vec![],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_each_simple() {
+        let parser = Parser::new("{{#each items}}{{name}}{{/each}}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::Each {
+                variable: "items".to_string(),
+                item_name: None,
+                body: vec![Node::Variable("name".to_string())],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_each_with_as() {
+        let parser = Parser::new("{{#each items as item}}{{item.name}}{{/each}}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::Each {
+                variable: "items".to_string(),
+                item_name: Some("item".to_string()),
+                body: vec![Node::Variable("item.name".to_string())],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_unless() {
+        let parser = Parser::new("{{#unless hidden}}shown{{/unless}}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::Unless {
+                condition: "hidden".to_string(),
+                body: vec![Node::Text("shown".to_string())],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_with() {
+        let parser = Parser::new("{{#with user}}{{name}}{{/with}}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::With {
+                variable: "user".to_string(),
+                body: vec![Node::Variable("name".to_string())],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_escaped_braces() {
+        let parser = Parser::new("Use \\{{name}} for variables");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![
+                Node::Text("Use ".to_string()),
+                Node::Text("{{".to_string()),
+                Node::Text("name}} for variables".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_nested_blocks() {
+        let parser = Parser::new("{{#if show}}{{#each items}}{{name}}{{/each}}{{/if}}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(
+            nodes,
+            vec![Node::If {
+                condition: "show".to_string(),
+                then_branch: vec![Node::Each {
+                    variable: "items".to_string(),
+                    item_name: None,
+                    body: vec![Node::Variable("name".to_string())],
+                }],
+                else_branch: vec![],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_whitespace_in_tags() {
+        let parser = Parser::new("{{ name }}");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(nodes, vec![Node::Variable("name".to_string())]);
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        let parser = Parser::new("");
+        let nodes = parser.parse().unwrap();
+
+        assert_eq!(nodes, Vec::<Node>::new());
+    }
+
+    #[test]
+    fn test_parse_complex_template() {
+        let template = r#"{{t "welcome.title"}}
+
+Hello, {{username}}!
+
+{{#if is_admin}}
+Admin Menu:
+{{#each admin_items as item}}
+  [{{item.key}}] {{item.label}}
+{{/each}}
+{{else}}
+User Menu:
+{{/if}}"#;
+
+        let parser = Parser::new(template);
+        let nodes = parser.parse().unwrap();
+
+        // Just verify it parses without error
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn test_parse_error_unclosed_tag() {
+        let parser = Parser::new("{{name");
+        let result = parser.parse();
+
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+    }
+
+    #[test]
+    fn test_parse_error_unclosed_block() {
+        let parser = Parser::new("{{#if show}}content");
+        let result = parser.parse();
+
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+    }
+
+    #[test]
+    fn test_parse_error_unknown_block() {
+        let parser = Parser::new("{{#unknown}}content{{/unknown}}");
+        let result = parser.parse();
+
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+    }
+}

--- a/src/template/renderer.rs
+++ b/src/template/renderer.rs
@@ -1,0 +1,637 @@
+//! Template renderer module.
+//!
+//! Renders parsed template nodes with the given context.
+
+use super::parser::Node;
+use super::{Result, TemplateContext, TemplateError, Value};
+
+/// Template renderer.
+pub struct Renderer<'a> {
+    context: &'a TemplateContext,
+}
+
+impl<'a> Renderer<'a> {
+    /// Create a new renderer with the given context.
+    pub fn new(context: &'a TemplateContext) -> Self {
+        Self { context }
+    }
+
+    /// Render a list of nodes to a string.
+    pub fn render(&self, nodes: &[Node]) -> Result<String> {
+        let mut output = String::new();
+
+        for node in nodes {
+            output.push_str(&self.render_node(node)?);
+        }
+
+        Ok(output)
+    }
+
+    /// Render a single node.
+    fn render_node(&self, node: &Node) -> Result<String> {
+        match node {
+            Node::Text(text) => Ok(text.clone()),
+            Node::Variable(name) => self.render_variable(name),
+            Node::Translation { key, params } => self.render_translation(key, params),
+            Node::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => self.render_if(condition, then_branch, else_branch),
+            Node::Each {
+                variable,
+                item_name,
+                body,
+            } => self.render_each(variable, item_name.as_deref(), body),
+            Node::Unless { condition, body } => self.render_unless(condition, body),
+            Node::With { variable, body } => self.render_with(variable, body),
+        }
+    }
+
+    /// Render a variable reference.
+    fn render_variable(&self, name: &str) -> Result<String> {
+        match self.context.get(name) {
+            Some(value) => Ok(value.to_display_string()),
+            None => {
+                // Return empty string for missing variables (like Handlebars)
+                Ok(String::new())
+            }
+        }
+    }
+
+    /// Render a translation reference.
+    fn render_translation(&self, key: &str, params: &[(String, String)]) -> Result<String> {
+        let i18n = self.context.i18n();
+
+        if params.is_empty() {
+            Ok(i18n.t(key).to_string())
+        } else {
+            // Build parameter list, resolving variable references
+            let resolved_params: Vec<(&str, String)> = params
+                .iter()
+                .map(|(name, value)| {
+                    let resolved = if value.starts_with('"') && value.ends_with('"') {
+                        // Literal string - strip the quotes
+                        value[1..value.len() - 1].to_string()
+                    } else {
+                        // Variable reference
+                        self.context
+                            .get(value)
+                            .map(|v| v.to_display_string())
+                            .unwrap_or_default()
+                    };
+                    (name.as_str(), resolved)
+                })
+                .collect();
+
+            let param_refs: Vec<(&str, &str)> = resolved_params
+                .iter()
+                .map(|(name, value)| (*name, value.as_str()))
+                .collect();
+
+            Ok(i18n.t_with(key, &param_refs))
+        }
+    }
+
+    /// Render an if block.
+    fn render_if(
+        &self,
+        condition: &str,
+        then_branch: &[Node],
+        else_branch: &[Node],
+    ) -> Result<String> {
+        let is_truthy = self
+            .context
+            .get(condition)
+            .map(|v| v.is_truthy())
+            .unwrap_or(false);
+
+        if is_truthy {
+            self.render(then_branch)
+        } else {
+            self.render(else_branch)
+        }
+    }
+
+    /// Render an each block.
+    fn render_each(
+        &self,
+        variable: &str,
+        item_name: Option<&str>,
+        body: &[Node],
+    ) -> Result<String> {
+        let list = match self.context.get(variable) {
+            Some(Value::List(items)) => items,
+            Some(_) => {
+                return Err(TemplateError::Render(format!(
+                    "'{variable}' is not a list"
+                )));
+            }
+            None => return Ok(String::new()),
+        };
+
+        let mut output = String::new();
+        let item_var_name = item_name.unwrap_or("this");
+
+        for (index, item) in list.iter().enumerate() {
+            // Create a child context with loop variables
+            let mut child_context = self.context.child();
+            child_context.set(item_var_name, item.clone());
+            child_context.set("@index", Value::Number(index as i64));
+            child_context.set("@first", Value::Bool(index == 0));
+            child_context.set("@last", Value::Bool(index == list.len() - 1));
+
+            // If item is an object, also expose its fields directly
+            if let Value::Object(obj) = item {
+                for (key, value) in obj {
+                    child_context.set(key.clone(), value.clone());
+                }
+            }
+
+            let child_renderer = Renderer::new(&child_context);
+            output.push_str(&child_renderer.render(body)?);
+        }
+
+        Ok(output)
+    }
+
+    /// Render an unless block.
+    fn render_unless(&self, condition: &str, body: &[Node]) -> Result<String> {
+        let is_truthy = self
+            .context
+            .get(condition)
+            .map(|v| v.is_truthy())
+            .unwrap_or(false);
+
+        if !is_truthy {
+            self.render(body)
+        } else {
+            Ok(String::new())
+        }
+    }
+
+    /// Render a with block.
+    fn render_with(&self, variable: &str, body: &[Node]) -> Result<String> {
+        let value = match self.context.get(variable) {
+            Some(v) => v.clone(),
+            None => return Ok(String::new()),
+        };
+
+        let mut child_context = self.context.child();
+
+        // If value is an object, expose its fields directly
+        if let Value::Object(obj) = &value {
+            for (key, val) in obj {
+                child_context.set(key.clone(), val.clone());
+            }
+        }
+
+        // Also expose the value as "this"
+        child_context.set("this", value);
+
+        let child_renderer = Renderer::new(&child_context);
+        child_renderer.render(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::i18n::I18n;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn create_context() -> TemplateContext {
+        let i18n = Arc::new(I18n::empty("ja"));
+        TemplateContext::new(i18n)
+    }
+
+    fn create_context_with_i18n() -> TemplateContext {
+        let content = r#"
+[menu]
+main = "メインメニュー"
+
+[welcome]
+message = "こんにちは、{{name}}さん"
+"#;
+        let i18n = Arc::new(I18n::from_str("ja", content).unwrap());
+        TemplateContext::new(i18n)
+    }
+
+    #[test]
+    fn test_render_text() {
+        let context = create_context();
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Text("Hello, World!".to_string())];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "Hello, World!");
+    }
+
+    #[test]
+    fn test_render_variable() {
+        let mut context = create_context();
+        context.set("name", Value::String("Alice".to_string()));
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![
+            Node::Text("Hello, ".to_string()),
+            Node::Variable("name".to_string()),
+            Node::Text("!".to_string()),
+        ];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "Hello, Alice!");
+    }
+
+    #[test]
+    fn test_render_variable_missing() {
+        let context = create_context();
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Variable("missing".to_string())];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_render_variable_nested() {
+        let mut context = create_context();
+        let mut user = HashMap::new();
+        user.insert("name".to_string(), Value::String("Bob".to_string()));
+        context.set("user", Value::Object(user));
+
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Variable("user.name".to_string())];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "Bob");
+    }
+
+    #[test]
+    fn test_render_translation_simple() {
+        let context = create_context_with_i18n();
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Translation {
+            key: "menu.main".to_string(),
+            params: vec![],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "メインメニュー");
+    }
+
+    #[test]
+    fn test_render_translation_with_params() {
+        let context = create_context_with_i18n();
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Translation {
+            key: "welcome.message".to_string(),
+            // Literal strings are wrapped in quotes by parser
+            params: vec![("name".to_string(), "\"太郎\"".to_string())],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "こんにちは、太郎さん");
+    }
+
+    #[test]
+    fn test_render_translation_with_variable_param() {
+        let mut context = create_context_with_i18n();
+        context.set("username", Value::String("花子".to_string()));
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Translation {
+            key: "welcome.message".to_string(),
+            params: vec![("name".to_string(), "username".to_string())],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "こんにちは、花子さん");
+    }
+
+    #[test]
+    fn test_render_if_true() {
+        let mut context = create_context();
+        context.set("show", Value::Bool(true));
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::If {
+            condition: "show".to_string(),
+            then_branch: vec![Node::Text("visible".to_string())],
+            else_branch: vec![Node::Text("hidden".to_string())],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "visible");
+    }
+
+    #[test]
+    fn test_render_if_false() {
+        let mut context = create_context();
+        context.set("show", Value::Bool(false));
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::If {
+            condition: "show".to_string(),
+            then_branch: vec![Node::Text("visible".to_string())],
+            else_branch: vec![Node::Text("hidden".to_string())],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "hidden");
+    }
+
+    #[test]
+    fn test_render_if_missing_variable() {
+        let context = create_context();
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::If {
+            condition: "missing".to_string(),
+            then_branch: vec![Node::Text("yes".to_string())],
+            else_branch: vec![Node::Text("no".to_string())],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        // Missing variable is falsy
+        assert_eq!(result, "no");
+    }
+
+    #[test]
+    fn test_render_if_truthy_string() {
+        let mut context = create_context();
+        context.set("name", Value::String("Alice".to_string()));
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::If {
+            condition: "name".to_string(),
+            then_branch: vec![Node::Text("has name".to_string())],
+            else_branch: vec![],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "has name");
+    }
+
+    #[test]
+    fn test_render_each() {
+        let mut context = create_context();
+        context.set(
+            "items",
+            Value::List(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+                Value::String("c".to_string()),
+            ]),
+        );
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Each {
+            variable: "items".to_string(),
+            item_name: Some("item".to_string()),
+            body: vec![
+                Node::Text("[".to_string()),
+                Node::Variable("item".to_string()),
+                Node::Text("]".to_string()),
+            ],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "[a][b][c]");
+    }
+
+    #[test]
+    fn test_render_each_with_index() {
+        let mut context = create_context();
+        context.set(
+            "items",
+            Value::List(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+            ]),
+        );
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Each {
+            variable: "items".to_string(),
+            item_name: Some("item".to_string()),
+            body: vec![
+                Node::Variable("@index".to_string()),
+                Node::Text(":".to_string()),
+                Node::Variable("item".to_string()),
+                Node::Text(" ".to_string()),
+            ],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "0:a 1:b ");
+    }
+
+    #[test]
+    fn test_render_each_with_objects() {
+        let mut context = create_context();
+        context.set(
+            "users",
+            Value::List(vec![
+                Value::Object({
+                    let mut m = HashMap::new();
+                    m.insert("name".to_string(), Value::String("Alice".to_string()));
+                    m
+                }),
+                Value::Object({
+                    let mut m = HashMap::new();
+                    m.insert("name".to_string(), Value::String("Bob".to_string()));
+                    m
+                }),
+            ]),
+        );
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Each {
+            variable: "users".to_string(),
+            item_name: None,
+            body: vec![
+                Node::Variable("name".to_string()),
+                Node::Text(", ".to_string()),
+            ],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "Alice, Bob, ");
+    }
+
+    #[test]
+    fn test_render_each_empty_list() {
+        let mut context = create_context();
+        context.set("items", Value::List(vec![]));
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Each {
+            variable: "items".to_string(),
+            item_name: None,
+            body: vec![Node::Text("item".to_string())],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_render_each_missing_variable() {
+        let context = create_context();
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Each {
+            variable: "missing".to_string(),
+            item_name: None,
+            body: vec![Node::Text("item".to_string())],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_render_unless_false() {
+        let mut context = create_context();
+        context.set("hidden", Value::Bool(false));
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Unless {
+            condition: "hidden".to_string(),
+            body: vec![Node::Text("shown".to_string())],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "shown");
+    }
+
+    #[test]
+    fn test_render_unless_true() {
+        let mut context = create_context();
+        context.set("hidden", Value::Bool(true));
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Unless {
+            condition: "hidden".to_string(),
+            body: vec![Node::Text("shown".to_string())],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_render_with() {
+        let mut context = create_context();
+        context.set(
+            "user",
+            Value::Object({
+                let mut m = HashMap::new();
+                m.insert("name".to_string(), Value::String("Charlie".to_string()));
+                m.insert("age".to_string(), Value::Number(30));
+                m
+            }),
+        );
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::With {
+            variable: "user".to_string(),
+            body: vec![
+                Node::Variable("name".to_string()),
+                Node::Text(" is ".to_string()),
+                Node::Variable("age".to_string()),
+                Node::Text(" years old".to_string()),
+            ],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "Charlie is 30 years old");
+    }
+
+    #[test]
+    fn test_render_with_missing() {
+        let context = create_context();
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::With {
+            variable: "missing".to_string(),
+            body: vec![Node::Text("content".to_string())],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_render_nested_blocks() {
+        let mut context = create_context();
+        context.set("show_list", Value::Bool(true));
+        context.set(
+            "items",
+            Value::List(vec![
+                Value::String("x".to_string()),
+                Value::String("y".to_string()),
+            ]),
+        );
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::If {
+            condition: "show_list".to_string(),
+            then_branch: vec![
+                Node::Text("Items: ".to_string()),
+                Node::Each {
+                    variable: "items".to_string(),
+                    item_name: Some("i".to_string()),
+                    body: vec![Node::Variable("i".to_string()), Node::Text(" ".to_string())],
+                },
+            ],
+            else_branch: vec![],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "Items: x y ");
+    }
+
+    #[test]
+    fn test_render_first_last() {
+        let mut context = create_context();
+        context.set(
+            "items",
+            Value::List(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+                Value::String("c".to_string()),
+            ]),
+        );
+        let renderer = Renderer::new(&context);
+
+        let nodes = vec![Node::Each {
+            variable: "items".to_string(),
+            item_name: Some("item".to_string()),
+            body: vec![
+                Node::If {
+                    condition: "@first".to_string(),
+                    then_branch: vec![Node::Text("[FIRST]".to_string())],
+                    else_branch: vec![],
+                },
+                Node::Variable("item".to_string()),
+                Node::If {
+                    condition: "@last".to_string(),
+                    then_branch: vec![Node::Text("[LAST]".to_string())],
+                    else_branch: vec![],
+                },
+                Node::Text(" ".to_string()),
+            ],
+        }];
+        let result = renderer.render(&nodes).unwrap();
+
+        assert_eq!(result, "[FIRST]a b c[LAST] ");
+    }
+}


### PR DESCRIPTION
## Summary

- `src/template/mod.rs` を作成
  - `Value` 列挙型: テンプレート変数の値（String, Number, Bool, List, Object, Null）
  - `TemplateContext`: 変数とi18nを保持するレンダリングコンテキスト
  - `TemplateEngine`: テンプレートの読み込みとレンダリング
- `src/template/parser.rs` を作成（Handlebars風の構文をパース）
  - 変数展開: `{{variable}}`
  - 翻訳参照: `{{t "key"}}` / `{{t "key" param=value}}`
  - 条件分岐: `{{#if}}...{{else}}...{{/if}}`
  - ループ: `{{#each items as item}}...{{/each}}`
  - スコープ変更: `{{#with object}}...{{/with}}`
  - 否定条件: `{{#unless}}...{{/unless}}`
  - エスケープ: `\{{` でリテラル `{{`
- `src/template/renderer.rs` を作成
  - パースしたノードのレンダリング
  - ループ内で `@index`, `@first`, `@last` 変数を提供
  - ネストされたオブジェクトのドット記法サポート
- 60件の単体テストを追加

## 使用例

```rust
use hobbs::template::{TemplateEngine, TemplateContext, Value};
use hobbs::i18n::I18n;
use std::sync::Arc;

let mut engine = TemplateEngine::new();
engine.load("greeting", "Hello, {{name}}!");

let i18n = Arc::new(I18n::empty("en"));
let mut context = TemplateContext::new(i18n);
context.set("name", Value::String("World".to_string()));

let result = engine.render("greeting", &context).unwrap();
assert_eq!(result, "Hello, World!");
```

## Test plan

- [x] `cargo build` が成功すること
- [x] `cargo test template` で60件のテストが全て成功すること
- [x] `cargo clippy -- -D warnings` が警告なしで通ること

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)