### PR TITLE
feat: 画面表示・ANSI対応を実装

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod file;
 pub mod i18n;
 pub mod logging;
 pub mod mail;
+pub mod screen;
 pub mod server;
 pub mod template;
 pub mod terminal;
@@ -61,6 +62,9 @@ pub use server::{
     EchoMode, EncodeResult, InputResult, LineBuffer, MultiLineBuffer, NegotiationState,
     SessionInfo, SessionManager as TelnetSessionManager, SessionState, TelnetCommand, TelnetParser,
     TelnetServer, TelnetSession,
+};
+pub use screen::{
+    create_screen, create_screen_from_profile, AnsiScreen, Color, PlainScreen, Screen,
 };
 pub use terminal::TerminalProfile;
 

--- a/src/screen/ansi.rs
+++ b/src/screen/ansi.rs
@@ -1,0 +1,264 @@
+//! ANSI escape sequence implementation.
+//!
+//! Provides screen control using ANSI escape sequences for terminals
+//! that support them.
+
+use super::{Color, Screen};
+
+/// Escape character for ANSI sequences.
+const ESC: char = '\x1b';
+
+/// ANSI-capable screen implementation.
+///
+/// This implementation generates standard ANSI escape sequences
+/// for terminal control and decoration.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AnsiScreen;
+
+impl AnsiScreen {
+    /// Create a new ANSI screen.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Screen for AnsiScreen {
+    fn fg(&self, color: Color) -> String {
+        format!("{ESC}[{}m", color.fg_code())
+    }
+
+    fn bg(&self, color: Color) -> String {
+        format!("{ESC}[{}m", color.bg_code())
+    }
+
+    fn bold(&self) -> String {
+        format!("{ESC}[1m")
+    }
+
+    fn underline(&self) -> String {
+        format!("{ESC}[4m")
+    }
+
+    fn reverse(&self) -> String {
+        format!("{ESC}[7m")
+    }
+
+    fn reset(&self) -> String {
+        format!("{ESC}[0m")
+    }
+
+    fn goto(&self, x: u16, y: u16) -> String {
+        format!("{ESC}[{y};{x}H")
+    }
+
+    fn home(&self) -> String {
+        format!("{ESC}[H")
+    }
+
+    fn clear_screen(&self) -> String {
+        format!("{ESC}[2J")
+    }
+
+    fn clear_line(&self) -> String {
+        format!("{ESC}[K")
+    }
+
+    fn clear_to_end(&self) -> String {
+        format!("{ESC}[J")
+    }
+
+    fn hide_cursor(&self) -> String {
+        format!("{ESC}[?25l")
+    }
+
+    fn show_cursor(&self) -> String {
+        format!("{ESC}[?25h")
+    }
+
+    fn save_cursor(&self) -> String {
+        format!("{ESC}[s")
+    }
+
+    fn restore_cursor(&self) -> String {
+        format!("{ESC}[u")
+    }
+
+    fn cursor_up(&self, n: u16) -> String {
+        if n == 0 {
+            String::new()
+        } else {
+            format!("{ESC}[{n}A")
+        }
+    }
+
+    fn cursor_down(&self, n: u16) -> String {
+        if n == 0 {
+            String::new()
+        } else {
+            format!("{ESC}[{n}B")
+        }
+    }
+
+    fn cursor_forward(&self, n: u16) -> String {
+        if n == 0 {
+            String::new()
+        } else {
+            format!("{ESC}[{n}C")
+        }
+    }
+
+    fn cursor_backward(&self, n: u16) -> String {
+        if n == 0 {
+            String::new()
+        } else {
+            format!("{ESC}[{n}D")
+        }
+    }
+
+    fn is_ansi_enabled(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ansi_screen_new() {
+        let screen = AnsiScreen::new();
+        assert!(screen.is_ansi_enabled());
+    }
+
+    #[test]
+    fn test_ansi_screen_default() {
+        let screen = AnsiScreen::default();
+        assert!(screen.is_ansi_enabled());
+    }
+
+    #[test]
+    fn test_fg_colors() {
+        let screen = AnsiScreen::new();
+        assert_eq!(screen.fg(Color::Black), "\x1b[30m");
+        assert_eq!(screen.fg(Color::Red), "\x1b[31m");
+        assert_eq!(screen.fg(Color::Green), "\x1b[32m");
+        assert_eq!(screen.fg(Color::Yellow), "\x1b[33m");
+        assert_eq!(screen.fg(Color::Blue), "\x1b[34m");
+        assert_eq!(screen.fg(Color::Magenta), "\x1b[35m");
+        assert_eq!(screen.fg(Color::Cyan), "\x1b[36m");
+        assert_eq!(screen.fg(Color::White), "\x1b[37m");
+    }
+
+    #[test]
+    fn test_bg_colors() {
+        let screen = AnsiScreen::new();
+        assert_eq!(screen.bg(Color::Black), "\x1b[40m");
+        assert_eq!(screen.bg(Color::Red), "\x1b[41m");
+        assert_eq!(screen.bg(Color::Green), "\x1b[42m");
+        assert_eq!(screen.bg(Color::Yellow), "\x1b[43m");
+        assert_eq!(screen.bg(Color::Blue), "\x1b[44m");
+        assert_eq!(screen.bg(Color::Magenta), "\x1b[45m");
+        assert_eq!(screen.bg(Color::Cyan), "\x1b[46m");
+        assert_eq!(screen.bg(Color::White), "\x1b[47m");
+    }
+
+    #[test]
+    fn test_text_attributes() {
+        let screen = AnsiScreen::new();
+        assert_eq!(screen.bold(), "\x1b[1m");
+        assert_eq!(screen.underline(), "\x1b[4m");
+        assert_eq!(screen.reverse(), "\x1b[7m");
+        assert_eq!(screen.reset(), "\x1b[0m");
+    }
+
+    #[test]
+    fn test_cursor_movement() {
+        let screen = AnsiScreen::new();
+        assert_eq!(screen.goto(10, 20), "\x1b[20;10H");
+        assert_eq!(screen.goto(1, 1), "\x1b[1;1H");
+        assert_eq!(screen.home(), "\x1b[H");
+    }
+
+    #[test]
+    fn test_clear() {
+        let screen = AnsiScreen::new();
+        assert_eq!(screen.clear_screen(), "\x1b[2J");
+        assert_eq!(screen.clear_line(), "\x1b[K");
+        assert_eq!(screen.clear_to_end(), "\x1b[J");
+    }
+
+    #[test]
+    fn test_cursor_visibility() {
+        let screen = AnsiScreen::new();
+        assert_eq!(screen.hide_cursor(), "\x1b[?25l");
+        assert_eq!(screen.show_cursor(), "\x1b[?25h");
+    }
+
+    #[test]
+    fn test_cursor_save_restore() {
+        let screen = AnsiScreen::new();
+        assert_eq!(screen.save_cursor(), "\x1b[s");
+        assert_eq!(screen.restore_cursor(), "\x1b[u");
+    }
+
+    #[test]
+    fn test_cursor_relative_movement() {
+        let screen = AnsiScreen::new();
+        assert_eq!(screen.cursor_up(5), "\x1b[5A");
+        assert_eq!(screen.cursor_down(3), "\x1b[3B");
+        assert_eq!(screen.cursor_forward(10), "\x1b[10C");
+        assert_eq!(screen.cursor_backward(2), "\x1b[2D");
+    }
+
+    #[test]
+    fn test_cursor_relative_movement_zero() {
+        let screen = AnsiScreen::new();
+        assert_eq!(screen.cursor_up(0), "");
+        assert_eq!(screen.cursor_down(0), "");
+        assert_eq!(screen.cursor_forward(0), "");
+        assert_eq!(screen.cursor_backward(0), "");
+    }
+
+    #[test]
+    fn test_color_text() {
+        let screen = AnsiScreen::new();
+        let result = screen.color_text("Hello", Color::Red);
+        assert_eq!(result, "\x1b[31mHello\x1b[0m");
+    }
+
+    #[test]
+    fn test_bold_text() {
+        let screen = AnsiScreen::new();
+        let result = screen.bold_text("Important");
+        assert_eq!(result, "\x1b[1mImportant\x1b[0m");
+    }
+
+    #[test]
+    fn test_underline_text() {
+        let screen = AnsiScreen::new();
+        let result = screen.underline_text("Link");
+        assert_eq!(result, "\x1b[4mLink\x1b[0m");
+    }
+
+    #[test]
+    fn test_combined_sequences() {
+        let screen = AnsiScreen::new();
+        // Combine multiple attributes
+        let output = format!(
+            "{}{}{}Hello{}",
+            screen.bold(),
+            screen.fg(Color::Red),
+            screen.bg(Color::White),
+            screen.reset()
+        );
+        assert_eq!(output, "\x1b[1m\x1b[31m\x1b[47mHello\x1b[0m");
+    }
+
+    #[test]
+    fn test_screen_clear_and_home() {
+        let screen = AnsiScreen::new();
+        // Common pattern: clear screen and go home
+        let output = format!("{}{}", screen.clear_screen(), screen.home());
+        assert_eq!(output, "\x1b[2J\x1b[H");
+    }
+}

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -1,0 +1,311 @@
+//! Screen display module.
+//!
+//! Provides ANSI escape sequences for screen decoration and a plain text fallback.
+
+mod ansi;
+mod plain;
+
+pub use ansi::AnsiScreen;
+pub use plain::PlainScreen;
+
+/// Terminal colors (ANSI standard 8 colors).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Color {
+    /// Black (color code 0).
+    Black = 0,
+    /// Red (color code 1).
+    Red = 1,
+    /// Green (color code 2).
+    Green = 2,
+    /// Yellow (color code 3).
+    Yellow = 3,
+    /// Blue (color code 4).
+    Blue = 4,
+    /// Magenta (color code 5).
+    Magenta = 5,
+    /// Cyan (color code 6).
+    Cyan = 6,
+    /// White (color code 7).
+    White = 7,
+}
+
+impl Color {
+    /// Get the ANSI color code for foreground.
+    pub fn fg_code(self) -> u8 {
+        30 + self as u8
+    }
+
+    /// Get the ANSI color code for background.
+    pub fn bg_code(self) -> u8 {
+        40 + self as u8
+    }
+}
+
+/// Screen output trait for terminal decoration.
+///
+/// This trait provides methods for generating terminal control sequences.
+/// Implementations include `AnsiScreen` for ANSI-capable terminals and
+/// `PlainScreen` for terminals without ANSI support.
+pub trait Screen: Send + Sync {
+    /// Set foreground (text) color.
+    ///
+    /// # Arguments
+    ///
+    /// * `color` - The color to set.
+    ///
+    /// # Returns
+    ///
+    /// An escape sequence string to set the color.
+    fn fg(&self, color: Color) -> String;
+
+    /// Set background color.
+    ///
+    /// # Arguments
+    ///
+    /// * `color` - The color to set.
+    ///
+    /// # Returns
+    ///
+    /// An escape sequence string to set the color.
+    fn bg(&self, color: Color) -> String;
+
+    /// Enable bold text.
+    fn bold(&self) -> String;
+
+    /// Enable underlined text.
+    fn underline(&self) -> String;
+
+    /// Enable reversed (inverse) colors.
+    fn reverse(&self) -> String;
+
+    /// Reset all text attributes to default.
+    fn reset(&self) -> String;
+
+    /// Move cursor to specified position.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - Column number (1-based).
+    /// * `y` - Row number (1-based).
+    ///
+    /// # Returns
+    ///
+    /// An escape sequence string to move the cursor.
+    fn goto(&self, x: u16, y: u16) -> String;
+
+    /// Move cursor to home position (top-left corner).
+    fn home(&self) -> String;
+
+    /// Clear the entire screen.
+    fn clear_screen(&self) -> String;
+
+    /// Clear from cursor to end of line.
+    fn clear_line(&self) -> String;
+
+    /// Clear from cursor to end of screen.
+    fn clear_to_end(&self) -> String;
+
+    /// Format text with a foreground color.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - The text to colorize.
+    /// * `color` - The foreground color.
+    ///
+    /// # Returns
+    ///
+    /// The text wrapped with color escape sequences.
+    fn color_text(&self, text: &str, color: Color) -> String {
+        format!("{}{}{}", self.fg(color), text, self.reset())
+    }
+
+    /// Format text as bold.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - The text to make bold.
+    ///
+    /// # Returns
+    ///
+    /// The text wrapped with bold escape sequences.
+    fn bold_text(&self, text: &str) -> String {
+        format!("{}{}{}", self.bold(), text, self.reset())
+    }
+
+    /// Format text as underlined.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - The text to underline.
+    ///
+    /// # Returns
+    ///
+    /// The text wrapped with underline escape sequences.
+    fn underline_text(&self, text: &str) -> String {
+        format!("{}{}{}", self.underline(), text, self.reset())
+    }
+
+    /// Hide cursor.
+    fn hide_cursor(&self) -> String;
+
+    /// Show cursor.
+    fn show_cursor(&self) -> String;
+
+    /// Save cursor position.
+    fn save_cursor(&self) -> String;
+
+    /// Restore cursor position.
+    fn restore_cursor(&self) -> String;
+
+    /// Move cursor up by n lines.
+    fn cursor_up(&self, n: u16) -> String;
+
+    /// Move cursor down by n lines.
+    fn cursor_down(&self, n: u16) -> String;
+
+    /// Move cursor forward (right) by n columns.
+    fn cursor_forward(&self, n: u16) -> String;
+
+    /// Move cursor backward (left) by n columns.
+    fn cursor_backward(&self, n: u16) -> String;
+
+    /// Check if ANSI escape sequences are enabled.
+    fn is_ansi_enabled(&self) -> bool;
+}
+
+/// Create a screen instance based on ANSI support.
+///
+/// # Arguments
+///
+/// * `ansi_enabled` - Whether ANSI escape sequences are supported.
+///
+/// # Returns
+///
+/// A boxed screen implementation.
+///
+/// # Example
+///
+/// ```
+/// use hobbs::screen::{create_screen, Color};
+///
+/// let screen = create_screen(true);
+/// assert!(screen.is_ansi_enabled());
+/// assert!(!screen.fg(Color::Red).is_empty());
+///
+/// let plain = create_screen(false);
+/// assert!(!plain.is_ansi_enabled());
+/// assert!(plain.fg(Color::Red).is_empty());
+/// ```
+pub fn create_screen(ansi_enabled: bool) -> Box<dyn Screen> {
+    if ansi_enabled {
+        Box::new(AnsiScreen)
+    } else {
+        Box::new(PlainScreen)
+    }
+}
+
+/// Create a screen instance from a terminal profile.
+///
+/// This is a convenience function that creates the appropriate screen
+/// implementation based on the terminal profile's ANSI support setting.
+///
+/// # Arguments
+///
+/// * `profile` - The terminal profile.
+///
+/// # Returns
+///
+/// A boxed screen implementation.
+///
+/// # Example
+///
+/// ```
+/// use hobbs::screen::create_screen_from_profile;
+/// use hobbs::terminal::TerminalProfile;
+///
+/// let standard = TerminalProfile::standard();
+/// let screen = create_screen_from_profile(&standard);
+/// assert!(screen.is_ansi_enabled());
+///
+/// let c64 = TerminalProfile::c64();
+/// let plain = create_screen_from_profile(&c64);
+/// assert!(!plain.is_ansi_enabled());
+/// ```
+pub fn create_screen_from_profile(profile: &crate::terminal::TerminalProfile) -> Box<dyn Screen> {
+    create_screen(profile.ansi_enabled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_color_fg_code() {
+        assert_eq!(Color::Black.fg_code(), 30);
+        assert_eq!(Color::Red.fg_code(), 31);
+        assert_eq!(Color::Green.fg_code(), 32);
+        assert_eq!(Color::Yellow.fg_code(), 33);
+        assert_eq!(Color::Blue.fg_code(), 34);
+        assert_eq!(Color::Magenta.fg_code(), 35);
+        assert_eq!(Color::Cyan.fg_code(), 36);
+        assert_eq!(Color::White.fg_code(), 37);
+    }
+
+    #[test]
+    fn test_color_bg_code() {
+        assert_eq!(Color::Black.bg_code(), 40);
+        assert_eq!(Color::Red.bg_code(), 41);
+        assert_eq!(Color::Green.bg_code(), 42);
+        assert_eq!(Color::Yellow.bg_code(), 43);
+        assert_eq!(Color::Blue.bg_code(), 44);
+        assert_eq!(Color::Magenta.bg_code(), 45);
+        assert_eq!(Color::Cyan.bg_code(), 46);
+        assert_eq!(Color::White.bg_code(), 47);
+    }
+
+    #[test]
+    fn test_create_screen_ansi() {
+        let screen = create_screen(true);
+        assert!(screen.is_ansi_enabled());
+    }
+
+    #[test]
+    fn test_create_screen_plain() {
+        let screen = create_screen(false);
+        assert!(!screen.is_ansi_enabled());
+    }
+
+    #[test]
+    fn test_color_equality() {
+        assert_eq!(Color::Red, Color::Red);
+        assert_ne!(Color::Red, Color::Blue);
+    }
+
+    #[test]
+    fn test_color_copy() {
+        let c1 = Color::Green;
+        let c2 = c1;
+        assert_eq!(c1, c2);
+    }
+
+    #[test]
+    fn test_create_screen_from_profile_standard() {
+        let profile = crate::terminal::TerminalProfile::standard();
+        let screen = create_screen_from_profile(&profile);
+        assert!(screen.is_ansi_enabled());
+    }
+
+    #[test]
+    fn test_create_screen_from_profile_c64() {
+        let profile = crate::terminal::TerminalProfile::c64();
+        let screen = create_screen_from_profile(&profile);
+        assert!(!screen.is_ansi_enabled());
+    }
+
+    #[test]
+    fn test_create_screen_from_profile_c64_ansi() {
+        let profile = crate::terminal::TerminalProfile::c64_ansi();
+        let screen = create_screen_from_profile(&profile);
+        assert!(screen.is_ansi_enabled());
+    }
+}

--- a/src/screen/plain.rs
+++ b/src/screen/plain.rs
@@ -1,0 +1,229 @@
+//! Plain text screen implementation.
+//!
+//! Provides a no-op implementation of the Screen trait for terminals
+//! that do not support ANSI escape sequences.
+
+use super::{Color, Screen};
+
+/// Plain text screen implementation (no ANSI support).
+///
+/// All methods return empty strings, allowing code to use the Screen trait
+/// without generating any escape sequences.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PlainScreen;
+
+impl PlainScreen {
+    /// Create a new plain screen.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Screen for PlainScreen {
+    fn fg(&self, _color: Color) -> String {
+        String::new()
+    }
+
+    fn bg(&self, _color: Color) -> String {
+        String::new()
+    }
+
+    fn bold(&self) -> String {
+        String::new()
+    }
+
+    fn underline(&self) -> String {
+        String::new()
+    }
+
+    fn reverse(&self) -> String {
+        String::new()
+    }
+
+    fn reset(&self) -> String {
+        String::new()
+    }
+
+    fn goto(&self, _x: u16, _y: u16) -> String {
+        String::new()
+    }
+
+    fn home(&self) -> String {
+        String::new()
+    }
+
+    fn clear_screen(&self) -> String {
+        String::new()
+    }
+
+    fn clear_line(&self) -> String {
+        String::new()
+    }
+
+    fn clear_to_end(&self) -> String {
+        String::new()
+    }
+
+    fn hide_cursor(&self) -> String {
+        String::new()
+    }
+
+    fn show_cursor(&self) -> String {
+        String::new()
+    }
+
+    fn save_cursor(&self) -> String {
+        String::new()
+    }
+
+    fn restore_cursor(&self) -> String {
+        String::new()
+    }
+
+    fn cursor_up(&self, _n: u16) -> String {
+        String::new()
+    }
+
+    fn cursor_down(&self, _n: u16) -> String {
+        String::new()
+    }
+
+    fn cursor_forward(&self, _n: u16) -> String {
+        String::new()
+    }
+
+    fn cursor_backward(&self, _n: u16) -> String {
+        String::new()
+    }
+
+    fn is_ansi_enabled(&self) -> bool {
+        false
+    }
+
+    fn color_text(&self, text: &str, _color: Color) -> String {
+        text.to_string()
+    }
+
+    fn bold_text(&self, text: &str) -> String {
+        text.to_string()
+    }
+
+    fn underline_text(&self, text: &str) -> String {
+        text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plain_screen_new() {
+        let screen = PlainScreen::new();
+        assert!(!screen.is_ansi_enabled());
+    }
+
+    #[test]
+    fn test_plain_screen_default() {
+        let screen = PlainScreen::default();
+        assert!(!screen.is_ansi_enabled());
+    }
+
+    #[test]
+    fn test_fg_colors_empty() {
+        let screen = PlainScreen::new();
+        assert_eq!(screen.fg(Color::Black), "");
+        assert_eq!(screen.fg(Color::Red), "");
+        assert_eq!(screen.fg(Color::Green), "");
+        assert_eq!(screen.fg(Color::Yellow), "");
+        assert_eq!(screen.fg(Color::Blue), "");
+        assert_eq!(screen.fg(Color::Magenta), "");
+        assert_eq!(screen.fg(Color::Cyan), "");
+        assert_eq!(screen.fg(Color::White), "");
+    }
+
+    #[test]
+    fn test_bg_colors_empty() {
+        let screen = PlainScreen::new();
+        assert_eq!(screen.bg(Color::Black), "");
+        assert_eq!(screen.bg(Color::Red), "");
+        assert_eq!(screen.bg(Color::White), "");
+    }
+
+    #[test]
+    fn test_text_attributes_empty() {
+        let screen = PlainScreen::new();
+        assert_eq!(screen.bold(), "");
+        assert_eq!(screen.underline(), "");
+        assert_eq!(screen.reverse(), "");
+        assert_eq!(screen.reset(), "");
+    }
+
+    #[test]
+    fn test_cursor_movement_empty() {
+        let screen = PlainScreen::new();
+        assert_eq!(screen.goto(10, 20), "");
+        assert_eq!(screen.home(), "");
+        assert_eq!(screen.cursor_up(5), "");
+        assert_eq!(screen.cursor_down(3), "");
+        assert_eq!(screen.cursor_forward(10), "");
+        assert_eq!(screen.cursor_backward(2), "");
+    }
+
+    #[test]
+    fn test_clear_empty() {
+        let screen = PlainScreen::new();
+        assert_eq!(screen.clear_screen(), "");
+        assert_eq!(screen.clear_line(), "");
+        assert_eq!(screen.clear_to_end(), "");
+    }
+
+    #[test]
+    fn test_cursor_visibility_empty() {
+        let screen = PlainScreen::new();
+        assert_eq!(screen.hide_cursor(), "");
+        assert_eq!(screen.show_cursor(), "");
+    }
+
+    #[test]
+    fn test_cursor_save_restore_empty() {
+        let screen = PlainScreen::new();
+        assert_eq!(screen.save_cursor(), "");
+        assert_eq!(screen.restore_cursor(), "");
+    }
+
+    #[test]
+    fn test_color_text_plain() {
+        let screen = PlainScreen::new();
+        let result = screen.color_text("Hello", Color::Red);
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn test_bold_text_plain() {
+        let screen = PlainScreen::new();
+        let result = screen.bold_text("Important");
+        assert_eq!(result, "Important");
+    }
+
+    #[test]
+    fn test_underline_text_plain() {
+        let screen = PlainScreen::new();
+        let result = screen.underline_text("Link");
+        assert_eq!(result, "Link");
+    }
+
+    #[test]
+    fn test_combined_plain_no_escape() {
+        let screen = PlainScreen::new();
+        // Even with combined calls, no escape sequences
+        let output = format!(
+            "{}{}{}Hello{}",
+            screen.bold(),
+            screen.fg(Color::Red),
+            screen.bg(Color::White),
+            screen.reset()
+        );
+        assert_eq!(output, "Hello");
+    }
+}


### PR DESCRIPTION
## Summary
- `src/screen/` モジュールを新規作成
- ANSI エスケープシーケンスによる画面装飾機能を実装
- 端末プロファイルによるANSI有効/無効切り替え対応

## 変更内容

### Screen トレイト
| メソッド | 説明 |
|----------|------|
| `fg(color)` | 前景色設定 |
| `bg(color)` | 背景色設定 |
| `bold()` | 太字 |
| `underline()` | 下線 |
| `reverse()` | 反転表示 |
| `reset()` | 装飾リセット |
| `goto(x, y)` | カーソル移動 |
| `clear_screen()` | 画面クリア |
| `clear_line()` | 行末までクリア |
| `hide_cursor()` / `show_cursor()` | カーソル表示制御 |
| `save_cursor()` / `restore_cursor()` | カーソル位置保存/復元 |
| `cursor_up/down/forward/backward(n)` | 相対カーソル移動 |

### Color 列挙型
- Black, Red, Green, Yellow, Blue, Magenta, Cyan, White（ANSI標準8色）

### 実装
- `AnsiScreen`: ANSI対応端末用（エスケープシーケンスを生成）
- `PlainScreen`: ANSI非対応端末用（空文字列を返す）

### ファクトリ関数
- `create_screen(ansi_enabled)`: bool値からスクリーン生成
- `create_screen_from_profile(profile)`: 端末プロファイルから生成

## Test plan
- [x] `cargo test screen` - 38件のテストがパス
- [x] `cargo clippy` - 警告なし

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)