### PR TITLE
[Phase 10-2] 画面遷移の実装

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,9 +3,11 @@
 //! Provides the main application logic and session handling.
 
 mod menu;
+pub mod screens;
 mod session_handler;
 
 pub use menu::{MenuAction, MenuError};
+pub use screens::ScreenResult;
 pub use session_handler::SessionHandler;
 
 use std::sync::Arc;

--- a/src/app/screens/admin.rs
+++ b/src/app/screens/admin.rs
@@ -1,0 +1,322 @@
+//! Admin screen handler.
+
+use super::common::ScreenContext;
+use super::ScreenResult;
+use crate::error::Result;
+use crate::server::TelnetSession;
+
+/// Admin screen handler (placeholder).
+///
+/// Full admin functionality will be implemented in a future phase.
+pub struct AdminScreen;
+
+impl AdminScreen {
+    /// Run the admin menu.
+    pub async fn run(ctx: &mut ScreenContext, session: &mut TelnetSession) -> Result<ScreenResult> {
+        // Check admin permission
+        if !Self::is_admin(ctx, session) {
+            ctx.send_line(session, ctx.i18n.t("menu.admin_required"))
+                .await?;
+            return Ok(ScreenResult::Back);
+        }
+
+        loop {
+            ctx.send_line(session, "").await?;
+            ctx.send_line(session, &format!("=== {} ===", ctx.i18n.t("menu.admin")))
+                .await?;
+            ctx.send_line(session, "").await?;
+
+            ctx.send_line(
+                session,
+                &format!("=== {} ===", ctx.i18n.t("admin.board_management")),
+            )
+            .await?;
+            ctx.send_line(session, "  [1] Board List").await?;
+            ctx.send_line(session, "  [2] Create Board").await?;
+            ctx.send_line(session, "").await?;
+
+            ctx.send_line(
+                session,
+                &format!("=== {} ===", ctx.i18n.t("admin.user_management")),
+            )
+            .await?;
+            ctx.send_line(session, "  [3] User List").await?;
+            ctx.send_line(session, "  [4] Active Sessions").await?;
+            ctx.send_line(session, "").await?;
+
+            ctx.send_line(
+                session,
+                &format!("=== {} ===", ctx.i18n.t("admin.system_status")),
+            )
+            .await?;
+            ctx.send_line(session, "  [5] System Status").await?;
+            ctx.send_line(session, "").await?;
+
+            ctx.send(
+                session,
+                &format!(
+                    "{} [Q={}]: ",
+                    ctx.i18n.t("menu.select_prompt"),
+                    ctx.i18n.t("common.back")
+                ),
+            )
+            .await?;
+
+            let input = ctx.read_line(session).await?;
+            let input = input.trim();
+
+            match input.to_ascii_lowercase().as_str() {
+                "q" | "" => return Ok(ScreenResult::Back),
+                "1" => Self::show_board_list(ctx, session).await?,
+                "2" => Self::create_board(ctx, session).await?,
+                "3" => Self::show_user_list(ctx, session).await?,
+                "4" => Self::show_sessions(ctx, session).await?,
+                "5" => Self::show_system_status(ctx, session).await?,
+                _ => {}
+            }
+        }
+    }
+
+    /// Show board list (admin view).
+    async fn show_board_list(ctx: &mut ScreenContext, session: &mut TelnetSession) -> Result<()> {
+        use crate::board::BoardRepository;
+
+        let board_repo = BoardRepository::new(&ctx.db);
+        let boards = board_repo.list_all()?;
+
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            &format!("=== {} ===", ctx.i18n.t("admin.board_management")),
+        )
+        .await?;
+        ctx.send_line(session, "").await?;
+
+        if boards.is_empty() {
+            ctx.send_line(session, ctx.i18n.t("board.no_boards"))
+                .await?;
+        } else {
+            ctx.send_line(
+                session,
+                &format!("{:<4} {:<20} {:<10} {:<8}", "ID", "Name", "Type", "Active"),
+            )
+            .await?;
+            ctx.send_line(session, &"-".repeat(50)).await?;
+
+            for board in &boards {
+                ctx.send_line(
+                    session,
+                    &format!(
+                        "{:<4} {:<20} {:<10} {:<8}",
+                        board.id,
+                        board.name,
+                        board.board_type.as_str(),
+                        if board.is_active { "Yes" } else { "No" }
+                    ),
+                )
+                .await?;
+            }
+        }
+
+        ctx.send_line(session, "").await?;
+        ctx.wait_for_enter(session).await?;
+        Ok(())
+    }
+
+    /// Create a new board.
+    async fn create_board(ctx: &mut ScreenContext, session: &mut TelnetSession) -> Result<()> {
+        use crate::board::{BoardRepository, BoardType, NewBoard};
+
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            &format!("=== {} ===", ctx.i18n.t("admin.create_board")),
+        )
+        .await?;
+        ctx.send_line(session, "").await?;
+
+        // Get board name
+        ctx.send(session, "Board name: ").await?;
+        let name = ctx.read_line(session).await?;
+        let name = name.trim();
+
+        if name.is_empty() {
+            return Ok(());
+        }
+
+        // Get board type
+        ctx.send(session, "Type (thread/flat) [thread]: ").await?;
+        let type_input = ctx.read_line(session).await?;
+        let board_type = if type_input.trim().eq_ignore_ascii_case("flat") {
+            BoardType::Flat
+        } else {
+            BoardType::Thread
+        };
+
+        // Get description
+        ctx.send(session, "Description (optional): ").await?;
+        let description = ctx.read_line(session).await?;
+        let description = description.trim();
+
+        // Create board
+        let board_repo = BoardRepository::new(&ctx.db);
+        let new_board = if description.is_empty() {
+            NewBoard::new(name).with_board_type(board_type)
+        } else {
+            NewBoard::new(name)
+                .with_board_type(board_type)
+                .with_description(description)
+        };
+
+        match board_repo.create(&new_board) {
+            Ok(board) => {
+                ctx.send_line(
+                    session,
+                    &format!("Board '{}' created (ID: {})", board.name, board.id),
+                )
+                .await?;
+            }
+            Err(e) => {
+                ctx.send_line(session, &format!("Failed to create board: {}", e))
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Show user list.
+    async fn show_user_list(ctx: &mut ScreenContext, session: &mut TelnetSession) -> Result<()> {
+        use crate::db::UserRepository;
+
+        let user_repo = UserRepository::new(&ctx.db);
+        let users = user_repo.list_all()?;
+
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            &format!("=== {} ===", ctx.i18n.t("admin.user_list")),
+        )
+        .await?;
+        ctx.send_line(session, "").await?;
+
+        if users.is_empty() {
+            ctx.send_line(session, "No users found.").await?;
+        } else {
+            ctx.send_line(
+                session,
+                &format!(
+                    "{:<4} {:<16} {:<16} {:<8}",
+                    "ID", "Username", "Nickname", "Role"
+                ),
+            )
+            .await?;
+            ctx.send_line(session, &"-".repeat(50)).await?;
+
+            for user in &users {
+                ctx.send_line(
+                    session,
+                    &format!(
+                        "{:<4} {:<16} {:<16} {:?}",
+                        user.id, user.username, user.nickname, user.role
+                    ),
+                )
+                .await?;
+            }
+        }
+
+        ctx.send_line(session, "").await?;
+        ctx.wait_for_enter(session).await?;
+        Ok(())
+    }
+
+    /// Show active sessions.
+    async fn show_sessions(ctx: &mut ScreenContext, session: &mut TelnetSession) -> Result<()> {
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            &format!("=== {} ===", ctx.i18n.t("admin.session_list")),
+        )
+        .await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, ctx.i18n.t("feature.not_implemented"))
+            .await?;
+        ctx.send_line(session, "").await?;
+
+        ctx.wait_for_enter(session).await?;
+        Ok(())
+    }
+
+    /// Show system status.
+    async fn show_system_status(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+    ) -> Result<()> {
+        use crate::board::BoardRepository;
+        use crate::db::UserRepository;
+
+        let user_repo = UserRepository::new(&ctx.db);
+        let board_repo = BoardRepository::new(&ctx.db);
+
+        let user_count = user_repo.count()?;
+        let board_count = board_repo.count()?;
+
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            &format!("=== {} ===", ctx.i18n.t("admin.system_status")),
+        )
+        .await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, &format!("BBS Name: {}", ctx.config.bbs.name))
+            .await?;
+        ctx.send_line(session, &format!("SysOp: {}", ctx.config.bbs.sysop_name))
+            .await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, &format!("Total Users: {}", user_count))
+            .await?;
+        ctx.send_line(session, &format!("Total Boards: {}", board_count))
+            .await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            &format!(
+                "Server: {}:{}",
+                ctx.config.server.host, ctx.config.server.port
+            ),
+        )
+        .await?;
+        ctx.send_line(
+            session,
+            &format!("Max Connections: {}", ctx.config.server.max_connections),
+        )
+        .await?;
+        ctx.send_line(session, "").await?;
+
+        ctx.wait_for_enter(session).await?;
+        Ok(())
+    }
+
+    /// Check if user is admin.
+    fn is_admin(ctx: &ScreenContext, session: &TelnetSession) -> bool {
+        use crate::db::{Role, UserRepository};
+
+        if let Some(user_id) = session.user_id() {
+            let user_repo = UserRepository::new(&ctx.db);
+            if let Ok(Some(user)) = user_repo.get_by_id(user_id) {
+                return user.role >= Role::SubOp;
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_admin_screen_exists() {
+        let _ = AdminScreen;
+    }
+}

--- a/src/app/screens/board.rs
+++ b/src/app/screens/board.rs
@@ -1,0 +1,681 @@
+//! Board screen handler.
+
+use tracing::error;
+
+use super::common::{Pagination, ScreenContext};
+use super::ScreenResult;
+use crate::board::{
+    BoardService, BoardType, Pagination as BoardPagination, PostRepository, ThreadRepository,
+};
+use crate::db::{Role, UserRepository};
+use crate::error::Result;
+use crate::server::TelnetSession;
+
+/// Board screen handler.
+pub struct BoardScreen;
+
+impl BoardScreen {
+    /// Run the board list screen.
+    pub async fn run_list(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+    ) -> Result<ScreenResult> {
+        loop {
+            // Get boards
+            let user_role = Self::get_user_role(ctx, session);
+            let board_service = BoardService::new(&ctx.db);
+            let boards = board_service.list_boards(user_role)?;
+
+            // Display board list
+            ctx.send_line(session, "").await?;
+            ctx.send_line(session, &format!("=== {} ===", ctx.i18n.t("board.list")))
+                .await?;
+            ctx.send_line(session, "").await?;
+
+            if boards.is_empty() {
+                ctx.send_line(session, ctx.i18n.t("board.no_boards"))
+                    .await?;
+            } else {
+                ctx.send_line(
+                    session,
+                    &format!(
+                        "  {:<4} {:<20} {:>8}",
+                        ctx.i18n.t("common.number"),
+                        ctx.i18n.t("board.title"),
+                        ctx.i18n.t("board.replies")
+                    ),
+                )
+                .await?;
+                ctx.send_line(session, &"-".repeat(40)).await?;
+
+                for (i, board) in boards.iter().enumerate() {
+                    let count = if board.board_type == BoardType::Thread {
+                        let thread_repo = ThreadRepository::new(&ctx.db);
+                        thread_repo.count_by_board(board.id)?
+                    } else {
+                        let post_repo = PostRepository::new(&ctx.db);
+                        post_repo.count_by_flat_board(board.id)?
+                    };
+
+                    ctx.send_line(
+                        session,
+                        &format!("  {:<4} {:<20} {:>8}", i + 1, board.name, count),
+                    )
+                    .await?;
+                }
+            }
+
+            ctx.send_line(session, "").await?;
+            ctx.send(
+                session,
+                &format!(
+                    "{} [Q={}]: ",
+                    ctx.i18n.t("menu.select_prompt"),
+                    ctx.i18n.t("common.back")
+                ),
+            )
+            .await?;
+
+            let input = ctx.read_line(session).await?;
+            let input = input.trim();
+
+            if input.eq_ignore_ascii_case("q") || input.is_empty() {
+                return Ok(ScreenResult::Back);
+            }
+
+            if let Some(num) = ctx.parse_number(input) {
+                let idx = (num - 1) as usize;
+                if idx < boards.len() {
+                    let board = &boards[idx];
+                    match board.board_type {
+                        BoardType::Thread => {
+                            Self::run_thread_list(ctx, session, board.id).await?;
+                        }
+                        BoardType::Flat => {
+                            Self::run_flat_list(ctx, session, board.id).await?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Run the thread list screen (for thread-type boards).
+    async fn run_thread_list(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        board_id: i64,
+    ) -> Result<ScreenResult> {
+        let per_page: i64 = 10;
+        let mut pagination = Pagination::new(1, per_page as usize, 0);
+
+        loop {
+            // Get board info
+            let user_role = Self::get_user_role(ctx, session);
+            let board_service = BoardService::new(&ctx.db);
+            let board = board_service.get_board(board_id, user_role)?;
+
+            // Get threads using service with pagination
+            let board_pagination =
+                BoardPagination::new(pagination.offset() as i64, pagination.per_page as i64);
+            let result = board_service.list_threads(board_id, user_role, board_pagination)?;
+
+            pagination.total = result.total as usize;
+
+            // Display thread list
+            ctx.send_line(session, "").await?;
+            ctx.send_line(
+                session,
+                &format!("=== {}: {} ===", ctx.i18n.t("board.list"), board.name),
+            )
+            .await?;
+            ctx.send_line(session, "").await?;
+
+            if result.items.is_empty() {
+                ctx.send_line(session, ctx.i18n.t("board.no_threads"))
+                    .await?;
+            } else {
+                ctx.send_line(
+                    session,
+                    &format!(
+                        "  {:<4} {:<30} {:>6}",
+                        ctx.i18n.t("common.number"),
+                        ctx.i18n.t("board.title"),
+                        ctx.i18n.t("board.replies")
+                    ),
+                )
+                .await?;
+                ctx.send_line(session, &"-".repeat(50)).await?;
+
+                for (i, thread) in result.items.iter().enumerate() {
+                    let num = pagination.offset() + i + 1;
+                    let title = if thread.title.chars().count() > 28 {
+                        let truncated: String = thread.title.chars().take(25).collect();
+                        format!("{}...", truncated)
+                    } else {
+                        thread.title.clone()
+                    };
+                    ctx.send_line(
+                        session,
+                        &format!("  {:<4} {:<30} {:>6}", num, title, thread.post_count),
+                    )
+                    .await?;
+                }
+            }
+
+            // Show pagination
+            ctx.send_line(session, "").await?;
+            ctx.send_line(
+                session,
+                &ctx.i18n.t_with(
+                    "board.page_of",
+                    &[
+                        ("current", &pagination.page.to_string()),
+                        ("total", &pagination.total_pages().to_string()),
+                    ],
+                ),
+            )
+            .await?;
+
+            // Prompt
+            ctx.send(
+                session,
+                &format!(
+                    "[N]={} [P]={} [W]={} [Q]={}: ",
+                    ctx.i18n.t("common.next"),
+                    ctx.i18n.t("common.previous"),
+                    ctx.i18n.t("board.new_thread"),
+                    ctx.i18n.t("common.back")
+                ),
+            )
+            .await?;
+
+            let input = ctx.read_line(session).await?;
+            let input = input.trim();
+
+            match input.to_ascii_lowercase().as_str() {
+                "q" | "" => return Ok(ScreenResult::Back),
+                "n" => pagination.next(),
+                "p" => pagination.prev(),
+                "w" => {
+                    if session.user_id().is_some() {
+                        Self::create_thread(ctx, session, board_id).await?;
+                    } else {
+                        ctx.send_line(session, ctx.i18n.t("menu.login_required"))
+                            .await?;
+                    }
+                }
+                _ => {
+                    if let Some(num) = ctx.parse_number(input) {
+                        let offset = pagination.offset();
+                        let idx = num as i64 - 1 - offset as i64;
+                        if idx >= 0 && (idx as usize) < result.items.len() {
+                            Self::run_thread_view(ctx, session, result.items[idx as usize].id)
+                                .await?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Run the flat post list screen (for flat-type boards).
+    async fn run_flat_list(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        board_id: i64,
+    ) -> Result<ScreenResult> {
+        let per_page: i64 = 10;
+        let mut pagination = Pagination::new(1, per_page as usize, 0);
+
+        loop {
+            // Get board info
+            let user_role = Self::get_user_role(ctx, session);
+            let board_service = BoardService::new(&ctx.db);
+            let board = board_service.get_board(board_id, user_role)?;
+
+            // Get posts using service with pagination
+            let board_pagination =
+                BoardPagination::new(pagination.offset() as i64, pagination.per_page as i64);
+            let result =
+                board_service.list_posts_in_flat_board(board_id, user_role, board_pagination)?;
+
+            pagination.total = result.total as usize;
+
+            // Display post list
+            ctx.send_line(session, "").await?;
+            ctx.send_line(
+                session,
+                &format!("=== {}: {} ===", ctx.i18n.t("board.list"), board.name),
+            )
+            .await?;
+            ctx.send_line(session, "").await?;
+
+            if result.items.is_empty() {
+                ctx.send_line(session, ctx.i18n.t("board.no_posts")).await?;
+            } else {
+                ctx.send_line(
+                    session,
+                    &format!(
+                        "  {:<4} {:<30} {:<10}",
+                        ctx.i18n.t("common.number"),
+                        ctx.i18n.t("board.title"),
+                        ctx.i18n.t("board.author")
+                    ),
+                )
+                .await?;
+                ctx.send_line(session, &"-".repeat(50)).await?;
+
+                let user_repo = UserRepository::new(&ctx.db);
+                for (i, post) in result.items.iter().enumerate() {
+                    let num = pagination.offset() + i + 1;
+                    let title = post.title.as_deref().unwrap_or("(no title)");
+                    let title = if title.chars().count() > 28 {
+                        let truncated: String = title.chars().take(25).collect();
+                        format!("{}...", truncated)
+                    } else {
+                        title.to_string()
+                    };
+                    let author = user_repo
+                        .get_by_id(post.author_id)?
+                        .map(|u| u.nickname)
+                        .unwrap_or_else(|| "Unknown".to_string());
+
+                    ctx.send_line(
+                        session,
+                        &format!("  {:<4} {:<30} {:<10}", num, title, author),
+                    )
+                    .await?;
+                }
+            }
+
+            // Show pagination
+            ctx.send_line(session, "").await?;
+            ctx.send_line(
+                session,
+                &ctx.i18n.t_with(
+                    "board.page_of",
+                    &[
+                        ("current", &pagination.page.to_string()),
+                        ("total", &pagination.total_pages().to_string()),
+                    ],
+                ),
+            )
+            .await?;
+
+            // Prompt
+            ctx.send(
+                session,
+                &format!(
+                    "[N]={} [P]={} [W]={} [Q]={}: ",
+                    ctx.i18n.t("common.next"),
+                    ctx.i18n.t("common.previous"),
+                    ctx.i18n.t("board.new_post"),
+                    ctx.i18n.t("common.back")
+                ),
+            )
+            .await?;
+
+            let input = ctx.read_line(session).await?;
+            let input = input.trim();
+
+            match input.to_ascii_lowercase().as_str() {
+                "q" | "" => return Ok(ScreenResult::Back),
+                "n" => pagination.next(),
+                "p" => pagination.prev(),
+                "w" => {
+                    if session.user_id().is_some() {
+                        Self::create_flat_post(ctx, session, board_id).await?;
+                    } else {
+                        ctx.send_line(session, ctx.i18n.t("menu.login_required"))
+                            .await?;
+                    }
+                }
+                _ => {
+                    if let Some(num) = ctx.parse_number(input) {
+                        let offset = pagination.offset();
+                        let idx = num as i64 - 1 - offset as i64;
+                        if idx >= 0 && (idx as usize) < result.items.len() {
+                            Self::run_post_view(ctx, session, result.items[idx as usize].id)
+                                .await?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// View a thread and its posts.
+    async fn run_thread_view(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        thread_id: i64,
+    ) -> Result<ScreenResult> {
+        let per_page: i64 = 10;
+        let mut pagination = Pagination::new(1, per_page as usize, 0);
+
+        loop {
+            // Get thread info
+            let user_role = Self::get_user_role(ctx, session);
+            let board_service = BoardService::new(&ctx.db);
+            let thread = board_service.get_thread(thread_id, user_role)?;
+
+            // Get posts using service with pagination
+            let board_pagination =
+                BoardPagination::new(pagination.offset() as i64, pagination.per_page as i64);
+            let result =
+                board_service.list_posts_in_thread(thread_id, user_role, board_pagination)?;
+
+            pagination.total = result.total as usize;
+
+            // Display thread
+            ctx.send_line(session, "").await?;
+            ctx.send_line(session, &format!("=== {} ===", thread.title))
+                .await?;
+            ctx.send_line(session, "").await?;
+
+            if result.items.is_empty() {
+                ctx.send_line(session, ctx.i18n.t("board.no_posts")).await?;
+            } else {
+                let user_repo = UserRepository::new(&ctx.db);
+                for post in &result.items {
+                    let author = user_repo
+                        .get_by_id(post.author_id)?
+                        .map(|u| u.nickname)
+                        .unwrap_or_else(|| "Unknown".to_string());
+
+                    ctx.send_line(
+                        session,
+                        &format!("--- {} ({}) ---", author, post.created_at),
+                    )
+                    .await?;
+                    ctx.send_line(session, &post.body).await?;
+                    ctx.send_line(session, "").await?;
+                }
+            }
+
+            // Show pagination
+            ctx.send_line(
+                session,
+                &ctx.i18n.t_with(
+                    "board.page_of",
+                    &[
+                        ("current", &pagination.page.to_string()),
+                        ("total", &pagination.total_pages().to_string()),
+                    ],
+                ),
+            )
+            .await?;
+
+            // Prompt
+            ctx.send(
+                session,
+                &format!(
+                    "[N]={} [P]={} [R]={} [Q]={}: ",
+                    ctx.i18n.t("common.next"),
+                    ctx.i18n.t("common.previous"),
+                    ctx.i18n.t("board.reply"),
+                    ctx.i18n.t("common.back")
+                ),
+            )
+            .await?;
+
+            let input = ctx.read_line(session).await?;
+            let input = input.trim();
+
+            match input.to_ascii_lowercase().as_str() {
+                "q" | "" => return Ok(ScreenResult::Back),
+                "n" => pagination.next(),
+                "p" => pagination.prev(),
+                "r" => {
+                    if session.user_id().is_some() {
+                        Self::create_reply(ctx, session, thread_id).await?;
+                    } else {
+                        ctx.send_line(session, ctx.i18n.t("menu.login_required"))
+                            .await?;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// View a single post.
+    async fn run_post_view(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        post_id: i64,
+    ) -> Result<ScreenResult> {
+        let user_role = Self::get_user_role(ctx, session);
+        let board_service = BoardService::new(&ctx.db);
+        let post = board_service.get_post(post_id, user_role)?;
+
+        let user_repo = UserRepository::new(&ctx.db);
+        let author = user_repo
+            .get_by_id(post.author_id)?
+            .map(|u| u.nickname)
+            .unwrap_or_else(|| "Unknown".to_string());
+
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            &format!("=== {} ===", post.title.as_deref().unwrap_or("(no title)")),
+        )
+        .await?;
+        ctx.send_line(
+            session,
+            &format!(
+                "{}: {} ({})",
+                ctx.i18n.t("board.author"),
+                author,
+                post.created_at
+            ),
+        )
+        .await?;
+        ctx.send_line(session, &"-".repeat(40)).await?;
+        ctx.send_line(session, &post.body).await?;
+        ctx.send_line(session, &"-".repeat(40)).await?;
+
+        ctx.wait_for_enter(session).await?;
+        Ok(ScreenResult::Back)
+    }
+
+    /// Create a new thread.
+    async fn create_thread(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        board_id: i64,
+    ) -> Result<()> {
+        let user_id = match session.user_id() {
+            Some(id) => id,
+            None => return Ok(()),
+        };
+
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            &format!("=== {} ===", ctx.i18n.t("board.new_thread")),
+        )
+        .await?;
+
+        // Get title
+        ctx.send(session, &format!("{}: ", ctx.i18n.t("board.title")))
+            .await?;
+        let title = ctx.read_line(session).await?;
+        let title = title.trim();
+
+        if title.is_empty() {
+            return Ok(());
+        }
+
+        // Create thread using BoardService
+        let user_role = Self::get_user_role(ctx, session);
+        let board_service = BoardService::new(&ctx.db);
+
+        match board_service.create_thread(board_id, title, user_id, user_role) {
+            Ok(_) => {
+                ctx.send_line(session, ctx.i18n.t("board.thread_created"))
+                    .await?;
+            }
+            Err(e) => {
+                error!("Failed to create thread: {}", e);
+                ctx.send_line(session, ctx.i18n.t("common.operation_failed"))
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Create a reply to a thread.
+    async fn create_reply(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        thread_id: i64,
+    ) -> Result<()> {
+        let user_id = match session.user_id() {
+            Some(id) => id,
+            None => return Ok(()),
+        };
+
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, &format!("=== {} ===", ctx.i18n.t("board.reply")))
+            .await?;
+
+        // Get body
+        ctx.send_line(
+            session,
+            &format!(
+                "{} ({}): ",
+                ctx.i18n.t("board.body"),
+                ctx.i18n.t("common.end_with_dot")
+            ),
+        )
+        .await?;
+        let body = Self::read_multiline(ctx, session).await?;
+
+        if body.is_empty() {
+            return Ok(());
+        }
+
+        // Create post using BoardService
+        let user_role = Self::get_user_role(ctx, session);
+        let board_service = BoardService::new(&ctx.db);
+
+        match board_service.create_thread_post(thread_id, user_id, &body, user_role) {
+            Ok(_) => {
+                ctx.send_line(session, ctx.i18n.t("board.post_created"))
+                    .await?;
+            }
+            Err(e) => {
+                error!("Failed to create post: {}", e);
+                ctx.send_line(session, ctx.i18n.t("common.operation_failed"))
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Create a post in a flat board.
+    async fn create_flat_post(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        board_id: i64,
+    ) -> Result<()> {
+        let user_id = match session.user_id() {
+            Some(id) => id,
+            None => return Ok(()),
+        };
+
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            &format!("=== {} ===", ctx.i18n.t("board.new_post")),
+        )
+        .await?;
+
+        // Get title
+        ctx.send(session, &format!("{}: ", ctx.i18n.t("board.title")))
+            .await?;
+        let title = ctx.read_line(session).await?;
+        let title = title.trim().to_string();
+
+        // Get body
+        ctx.send_line(
+            session,
+            &format!(
+                "{} ({}): ",
+                ctx.i18n.t("board.body"),
+                ctx.i18n.t("common.end_with_dot")
+            ),
+        )
+        .await?;
+        let body = Self::read_multiline(ctx, session).await?;
+
+        if body.is_empty() {
+            return Ok(());
+        }
+
+        // Create post using BoardService
+        let user_role = Self::get_user_role(ctx, session);
+        let board_service = BoardService::new(&ctx.db);
+
+        match board_service.create_flat_post(board_id, user_id, &title, &body, user_role) {
+            Ok(_) => {
+                ctx.send_line(session, ctx.i18n.t("board.post_created"))
+                    .await?;
+            }
+            Err(e) => {
+                error!("Failed to create post: {}", e);
+                ctx.send_line(session, ctx.i18n.t("common.operation_failed"))
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Read multiline input (ends with a line containing only ".").
+    async fn read_multiline(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+    ) -> Result<String> {
+        let mut lines = Vec::new();
+
+        loop {
+            ctx.send(session, "> ").await?;
+            let line = ctx.read_line(session).await?;
+
+            if line.trim() == "." {
+                break;
+            }
+
+            lines.push(line);
+        }
+
+        Ok(lines.join("\n"))
+    }
+
+    /// Get user role from session.
+    fn get_user_role(ctx: &ScreenContext, session: &TelnetSession) -> Role {
+        if let Some(user_id) = session.user_id() {
+            let user_repo = UserRepository::new(&ctx.db);
+            if let Ok(Some(user)) = user_repo.get_by_id(user_id) {
+                return user.role;
+            }
+        }
+        Role::Guest
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_board_screen_exists() {
+        // Basic existence test
+        let _ = BoardScreen;
+    }
+}

--- a/src/app/screens/chat.rs
+++ b/src/app/screens/chat.rs
@@ -1,0 +1,91 @@
+//! Chat screen handler.
+
+use super::common::ScreenContext;
+use super::ScreenResult;
+use crate::error::Result;
+use crate::server::TelnetSession;
+
+/// Chat screen handler.
+pub struct ChatScreen;
+
+impl ChatScreen {
+    /// Run the chat room list screen.
+    pub async fn run_list(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+    ) -> Result<ScreenResult> {
+        loop {
+            // Display chat room list
+            ctx.send_line(session, "").await?;
+            ctx.send_line(
+                session,
+                &format!("=== {} ===", ctx.i18n.t("chat.room_list")),
+            )
+            .await?;
+            ctx.send_line(session, "").await?;
+
+            // Static room list for now (will be managed dynamically later)
+            let rooms = ["Lobby", "Tech", "Random"];
+
+            ctx.send_line(
+                session,
+                &format!(
+                    "  {:<4} {:<20}",
+                    ctx.i18n.t("common.number"),
+                    ctx.i18n.t("chat.room_name")
+                ),
+            )
+            .await?;
+            ctx.send_line(session, &"-".repeat(30)).await?;
+
+            for (i, room) in rooms.iter().enumerate() {
+                ctx.send_line(session, &format!("  {:<4} {:<20}", i + 1, room))
+                    .await?;
+            }
+
+            ctx.send_line(session, "").await?;
+            ctx.send(
+                session,
+                &format!(
+                    "{} [Q={}]: ",
+                    ctx.i18n.t("menu.select_prompt"),
+                    ctx.i18n.t("common.back")
+                ),
+            )
+            .await?;
+
+            let input = ctx.read_line(session).await?;
+            let input = input.trim();
+
+            if input.eq_ignore_ascii_case("q") || input.is_empty() {
+                return Ok(ScreenResult::Back);
+            }
+
+            if let Some(num) = ctx.parse_number(input) {
+                let idx = (num - 1) as usize;
+                if idx < rooms.len() {
+                    // For now, show "not implemented" message
+                    ctx.send_line(session, "").await?;
+                    ctx.send_line(session, ctx.i18n.t("feature.not_implemented"))
+                        .await?;
+                    ctx.send_line(
+                        session,
+                        "Chat functionality requires ChatRoomManager integration.",
+                    )
+                    .await?;
+                    ctx.wait_for_enter(session).await?;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chat_screen_exists() {
+        let _ = ChatScreen;
+    }
+}

--- a/src/app/screens/common.rs
+++ b/src/app/screens/common.rs
@@ -1,0 +1,321 @@
+//! Common utilities for screen handlers.
+
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::config::Config;
+use crate::db::Database;
+use crate::error::Result;
+use crate::i18n::I18n;
+use crate::server::{
+    encode_for_client, CharacterEncoding, EchoMode, InputResult, LineBuffer, TelnetSession,
+};
+use crate::template::{create_system_context, TemplateContext, TemplateLoader, Value};
+use crate::terminal::TerminalProfile;
+
+/// Shared context for screen handlers.
+pub struct ScreenContext {
+    /// Database connection.
+    pub db: Arc<Database>,
+    /// Application configuration.
+    pub config: Arc<Config>,
+    /// Template loader.
+    pub template_loader: Arc<TemplateLoader>,
+    /// Terminal profile.
+    pub profile: TerminalProfile,
+    /// Current i18n instance.
+    pub i18n: Arc<I18n>,
+    /// Line buffer for input.
+    pub line_buffer: LineBuffer,
+}
+
+impl ScreenContext {
+    /// Create a new screen context.
+    pub fn new(
+        db: Arc<Database>,
+        config: Arc<Config>,
+        template_loader: Arc<TemplateLoader>,
+        profile: TerminalProfile,
+        i18n: Arc<I18n>,
+    ) -> Self {
+        Self {
+            db,
+            config,
+            template_loader,
+            profile,
+            i18n,
+            line_buffer: LineBuffer::with_encoding(1024, CharacterEncoding::default()),
+        }
+    }
+
+    /// Create a template context with system variables.
+    pub fn create_context(&self) -> TemplateContext {
+        let mut context = create_system_context(Arc::clone(&self.i18n));
+        context.set("bbs.name", Value::string(self.config.bbs.name.clone()));
+        context.set(
+            "bbs.description",
+            Value::string(self.config.bbs.description.clone()),
+        );
+        context.set(
+            "bbs.sysop",
+            Value::string(self.config.bbs.sysop_name.clone()),
+        );
+        context
+    }
+
+    /// Send data to the client.
+    pub async fn send(&self, session: &mut TelnetSession, data: &str) -> Result<()> {
+        let encoded = encode_for_client(data, session.encoding());
+        session.stream_mut().write_all(&encoded).await?;
+        session.stream_mut().flush().await?;
+        Ok(())
+    }
+
+    /// Send a line to the client with CRLF.
+    pub async fn send_line(&self, session: &mut TelnetSession, data: &str) -> Result<()> {
+        self.send(session, &format!("{}\r\n", data)).await
+    }
+
+    /// Read a line of input from the client.
+    pub async fn read_line(&mut self, session: &mut TelnetSession) -> Result<String> {
+        self.line_buffer.clear();
+        let mut buf = [0u8; 1];
+
+        loop {
+            match session.stream_mut().read(&mut buf).await {
+                Ok(0) => {
+                    // Connection closed
+                    return Ok(String::new());
+                }
+                Ok(_) => {
+                    let (result, echo) = self.line_buffer.process_byte(buf[0]);
+
+                    // Handle echo based on mode
+                    if !echo.is_empty() {
+                        match self.line_buffer.echo_mode() {
+                            EchoMode::Normal => {
+                                let _ = session.stream_mut().write_all(&echo).await;
+                                let _ = session.stream_mut().flush().await;
+                            }
+                            EchoMode::Password => {
+                                // For password mode, echo asterisks for regular chars, but allow backspace
+                                if echo.len() == 1 && echo[0] != b'\x08' {
+                                    let _ = session.stream_mut().write_all(b"*").await;
+                                    let _ = session.stream_mut().flush().await;
+                                } else if echo.len() > 1 && echo[0] == b'\x08' {
+                                    // Backspace echo
+                                    let _ = session.stream_mut().write_all(&echo).await;
+                                    let _ = session.stream_mut().flush().await;
+                                }
+                            }
+                            EchoMode::Masked(c) => {
+                                if echo.len() == 1 && echo[0] != b'\x08' {
+                                    let _ = session.stream_mut().write_all(&[c as u8]).await;
+                                    let _ = session.stream_mut().flush().await;
+                                } else if echo.len() > 1 && echo[0] == b'\x08' {
+                                    let _ = session.stream_mut().write_all(&echo).await;
+                                    let _ = session.stream_mut().flush().await;
+                                }
+                            }
+                        }
+                    }
+
+                    match result {
+                        InputResult::Line(line) => {
+                            return Ok(line);
+                        }
+                        InputResult::Buffering => {
+                            // Continue reading
+                        }
+                        InputResult::Cancel | InputResult::Eof => {
+                            return Ok(String::new());
+                        }
+                    }
+                }
+                Err(e) => {
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+
+    /// Read a single character.
+    pub async fn read_char(&self, session: &mut TelnetSession) -> Result<char> {
+        let mut buf = [0u8; 1];
+        loop {
+            match session.stream_mut().read(&mut buf).await {
+                Ok(0) => return Ok('\0'),
+                Ok(_) => {
+                    let ch = buf[0] as char;
+                    if ch.is_ascii_graphic() || ch == '\r' || ch == '\n' {
+                        return Ok(ch);
+                    }
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
+    /// Wait for Enter key press.
+    pub async fn wait_for_enter(&self, session: &mut TelnetSession) -> Result<()> {
+        self.send(session, self.i18n.t("common.press_enter"))
+            .await?;
+        let mut buf = [0u8; 1];
+        loop {
+            match session.stream_mut().read(&mut buf).await {
+                Ok(0) => break,
+                Ok(_) => {
+                    if buf[0] == b'\r' || buf[0] == b'\n' {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        Ok(())
+    }
+
+    /// Parse a number from input.
+    pub fn parse_number(&self, input: &str) -> Option<i64> {
+        input.trim().parse().ok()
+    }
+
+    /// Render a template.
+    pub fn render_template(&self, name: &str, context: &TemplateContext) -> Result<String> {
+        self.template_loader
+            .render(name, self.profile.width, context)
+            .map_err(Into::into)
+    }
+
+    /// Set line buffer echo mode.
+    pub fn set_echo_mode(&mut self, mode: EchoMode) {
+        self.line_buffer.set_echo_mode(mode);
+    }
+}
+
+/// Pagination helper.
+#[derive(Debug, Clone)]
+pub struct Pagination {
+    /// Current page (1-indexed).
+    pub page: usize,
+    /// Items per page.
+    pub per_page: usize,
+    /// Total items.
+    pub total: usize,
+}
+
+impl Pagination {
+    /// Create a new pagination.
+    pub fn new(page: usize, per_page: usize, total: usize) -> Self {
+        Self {
+            page: page.max(1),
+            per_page,
+            total,
+        }
+    }
+
+    /// Get the total number of pages.
+    pub fn total_pages(&self) -> usize {
+        if self.total == 0 {
+            1
+        } else {
+            (self.total + self.per_page - 1) / self.per_page
+        }
+    }
+
+    /// Check if there is a next page.
+    pub fn has_next(&self) -> bool {
+        self.page < self.total_pages()
+    }
+
+    /// Check if there is a previous page.
+    pub fn has_prev(&self) -> bool {
+        self.page > 1
+    }
+
+    /// Get the offset for database queries.
+    pub fn offset(&self) -> usize {
+        (self.page - 1) * self.per_page
+    }
+
+    /// Go to the next page.
+    pub fn next(&mut self) {
+        if self.has_next() {
+            self.page += 1;
+        }
+    }
+
+    /// Go to the previous page.
+    pub fn prev(&mut self) {
+        if self.has_prev() {
+            self.page -= 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pagination_new() {
+        let p = Pagination::new(1, 10, 100);
+        assert_eq!(p.page, 1);
+        assert_eq!(p.per_page, 10);
+        assert_eq!(p.total, 100);
+    }
+
+    #[test]
+    fn test_pagination_total_pages() {
+        assert_eq!(Pagination::new(1, 10, 100).total_pages(), 10);
+        assert_eq!(Pagination::new(1, 10, 95).total_pages(), 10);
+        assert_eq!(Pagination::new(1, 10, 91).total_pages(), 10);
+        assert_eq!(Pagination::new(1, 10, 0).total_pages(), 1);
+    }
+
+    #[test]
+    fn test_pagination_has_next() {
+        assert!(Pagination::new(1, 10, 100).has_next());
+        assert!(Pagination::new(9, 10, 100).has_next());
+        assert!(!Pagination::new(10, 10, 100).has_next());
+    }
+
+    #[test]
+    fn test_pagination_has_prev() {
+        assert!(!Pagination::new(1, 10, 100).has_prev());
+        assert!(Pagination::new(2, 10, 100).has_prev());
+        assert!(Pagination::new(10, 10, 100).has_prev());
+    }
+
+    #[test]
+    fn test_pagination_offset() {
+        assert_eq!(Pagination::new(1, 10, 100).offset(), 0);
+        assert_eq!(Pagination::new(2, 10, 100).offset(), 10);
+        assert_eq!(Pagination::new(10, 10, 100).offset(), 90);
+    }
+
+    #[test]
+    fn test_pagination_next_prev() {
+        let mut p = Pagination::new(5, 10, 100);
+        p.next();
+        assert_eq!(p.page, 6);
+        p.prev();
+        assert_eq!(p.page, 5);
+
+        // Test bounds
+        let mut p = Pagination::new(10, 10, 100);
+        p.next();
+        assert_eq!(p.page, 10); // No change at last page
+
+        let mut p = Pagination::new(1, 10, 100);
+        p.prev();
+        assert_eq!(p.page, 1); // No change at first page
+    }
+
+    #[test]
+    fn test_pagination_zero_page_normalized() {
+        let p = Pagination::new(0, 10, 100);
+        assert_eq!(p.page, 1); // Should be normalized to 1
+    }
+}

--- a/src/app/screens/file.rs
+++ b/src/app/screens/file.rs
@@ -1,0 +1,289 @@
+//! File screen handler.
+
+use super::common::{Pagination, ScreenContext};
+use super::ScreenResult;
+use crate::db::UserRepository;
+use crate::error::Result;
+use crate::file::{FileRepository, FolderRepository};
+use crate::server::TelnetSession;
+
+/// File screen handler.
+pub struct FileScreen;
+
+impl FileScreen {
+    /// Run the file browser screen.
+    pub async fn run_browser(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        folder_id: Option<i64>,
+    ) -> Result<ScreenResult> {
+        let mut current_folder = folder_id;
+        let mut pagination = Pagination::new(1, 10, 0);
+
+        loop {
+            // Get folder info
+            let folder_name = if let Some(fid) = current_folder {
+                FolderRepository::get_by_id(ctx.db.conn(), fid)?
+                    .map(|f| f.name.clone())
+                    .unwrap_or_else(|| ctx.i18n.t("file.folder_list").to_string())
+            } else {
+                ctx.i18n.t("file.folder_list").to_string()
+            };
+
+            // Get child folders
+            let child_folders = if let Some(fid) = current_folder {
+                FolderRepository::list_by_parent(ctx.db.conn(), fid)?
+            } else {
+                FolderRepository::list_root(ctx.db.conn())?
+            };
+
+            // Get files
+            let total = if let Some(fid) = current_folder {
+                FileRepository::count_by_folder(ctx.db.conn(), fid)? as usize
+            } else {
+                0 // Root folder doesn't have files directly
+            };
+            pagination.total = total;
+
+            let files = if let Some(fid) = current_folder {
+                FileRepository::list_by_folder(ctx.db.conn(), fid)?
+            } else {
+                vec![]
+            };
+
+            // Display
+            ctx.send_line(session, "").await?;
+            ctx.send_line(session, &format!("=== {} ===", folder_name))
+                .await?;
+            ctx.send_line(session, "").await?;
+
+            // Show child folders
+            if !child_folders.is_empty() {
+                ctx.send_line(session, &format!("{}:", ctx.i18n.t("file.folder_list")))
+                    .await?;
+                for (i, folder) in child_folders.iter().enumerate() {
+                    let letter = (b'A' + i as u8) as char;
+                    ctx.send_line(session, &format!("  [{}] {}", letter, folder.name))
+                        .await?;
+                }
+                ctx.send_line(session, "").await?;
+            }
+
+            // Show files
+            if files.is_empty() && child_folders.is_empty() {
+                ctx.send_line(session, ctx.i18n.t("file.no_files")).await?;
+            } else if !files.is_empty() {
+                ctx.send_line(session, &format!("{}:", ctx.i18n.t("file.file_list")))
+                    .await?;
+                ctx.send_line(
+                    session,
+                    &format!(
+                        "  {:<4} {:<20} {:>10} {:>6}",
+                        ctx.i18n.t("common.number"),
+                        ctx.i18n.t("file.filename"),
+                        ctx.i18n.t("file.size"),
+                        ctx.i18n.t("file.download_count")
+                    ),
+                )
+                .await?;
+                ctx.send_line(session, &"-".repeat(50)).await?;
+
+                for (i, file) in files.iter().enumerate() {
+                    let num = pagination.offset() + i + 1;
+                    let filename = if file.filename.chars().count() > 18 {
+                        let truncated: String = file.filename.chars().take(15).collect();
+                        format!("{}...", truncated)
+                    } else {
+                        file.filename.clone()
+                    };
+                    let size = Self::format_size(file.size);
+
+                    ctx.send_line(
+                        session,
+                        &format!(
+                            "  {:<4} {:<20} {:>10} {:>6}",
+                            num, filename, size, file.downloads
+                        ),
+                    )
+                    .await?;
+                }
+            }
+
+            // Show pagination
+            ctx.send_line(session, "").await?;
+            if pagination.total > 0 {
+                ctx.send_line(
+                    session,
+                    &ctx.i18n.t_with(
+                        "board.page_of",
+                        &[
+                            ("current", &pagination.page.to_string()),
+                            ("total", &pagination.total_pages().to_string()),
+                        ],
+                    ),
+                )
+                .await?;
+            }
+
+            // Prompt
+            let mut prompt = format!(
+                "[N]={} [P]={}",
+                ctx.i18n.t("common.next"),
+                ctx.i18n.t("common.previous")
+            );
+            if current_folder.is_some() {
+                prompt.push_str(&format!(" [B]={}", ctx.i18n.t("common.back")));
+            }
+            prompt.push_str(&format!(" [Q]={}: ", ctx.i18n.t("common.quit")));
+            ctx.send(session, &prompt).await?;
+
+            let input = ctx.read_line(session).await?;
+            let input = input.trim();
+
+            match input.to_ascii_lowercase().as_str() {
+                "q" => return Ok(ScreenResult::Back),
+                "" => {
+                    if current_folder.is_none() {
+                        return Ok(ScreenResult::Back);
+                    }
+                }
+                "n" => pagination.next(),
+                "p" => pagination.prev(),
+                "b" => {
+                    // Go back to parent folder
+                    if let Some(fid) = current_folder {
+                        let folder = FolderRepository::get_by_id(ctx.db.conn(), fid)?;
+                        current_folder = folder.and_then(|f| f.parent_id);
+                        pagination = Pagination::new(1, 10, 0);
+                    }
+                }
+                _ => {
+                    // Check if it's a folder letter
+                    if input.len() == 1 {
+                        let ch = input.chars().next().unwrap().to_ascii_uppercase();
+                        if ch >= 'A' {
+                            let idx = (ch as u8 - b'A') as usize;
+                            if idx < child_folders.len() {
+                                current_folder = Some(child_folders[idx].id);
+                                pagination = Pagination::new(1, 10, 0);
+                                continue;
+                            }
+                        }
+                    }
+
+                    // Check if it's a file number
+                    if let Some(num) = ctx.parse_number(input) {
+                        let idx = num as usize - 1;
+                        if idx < files.len() {
+                            Self::view_file(ctx, session, files[idx].id).await?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// View file details.
+    async fn view_file(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        file_id: i64,
+    ) -> Result<()> {
+        let file = match FileRepository::get_by_id(ctx.db.conn(), file_id)? {
+            Some(f) => f,
+            None => return Ok(()),
+        };
+
+        // Get uploader name
+        let user_repo = UserRepository::new(&ctx.db);
+        let uploader = user_repo
+            .get_by_id(file.uploader_id)?
+            .map(|u| u.nickname)
+            .unwrap_or_else(|| "Unknown".to_string());
+
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, &format!("=== {} ===", file.filename))
+            .await?;
+        ctx.send_line(
+            session,
+            &format!("{}: {}", ctx.i18n.t("file.filename"), file.filename),
+        )
+        .await?;
+        ctx.send_line(
+            session,
+            &format!(
+                "{}: {}",
+                ctx.i18n.t("file.size"),
+                Self::format_size(file.size)
+            ),
+        )
+        .await?;
+        ctx.send_line(
+            session,
+            &format!("{}: {}", ctx.i18n.t("file.uploaded_by"), uploader),
+        )
+        .await?;
+        ctx.send_line(
+            session,
+            &format!(
+                "{}: {}",
+                ctx.i18n.t("file.uploaded_at"),
+                file.created_at.format("%Y/%m/%d %H:%M")
+            ),
+        )
+        .await?;
+        ctx.send_line(
+            session,
+            &format!("{}: {}", ctx.i18n.t("file.download_count"), file.downloads),
+        )
+        .await?;
+
+        if let Some(desc) = &file.description {
+            ctx.send_line(session, &"-".repeat(40)).await?;
+            ctx.send_line(session, desc).await?;
+        }
+
+        ctx.send_line(session, &"-".repeat(40)).await?;
+        ctx.send_line(session, ctx.i18n.t("feature.not_implemented"))
+            .await?;
+
+        ctx.wait_for_enter(session).await?;
+        Ok(())
+    }
+
+    /// Format file size for display.
+    fn format_size(size: i64) -> String {
+        const KB: i64 = 1024;
+        const MB: i64 = KB * 1024;
+        const GB: i64 = MB * 1024;
+
+        if size >= GB {
+            format!("{:.1} GB", size as f64 / GB as f64)
+        } else if size >= MB {
+            format!("{:.1} MB", size as f64 / MB as f64)
+        } else if size >= KB {
+            format!("{:.1} KB", size as f64 / KB as f64)
+        } else {
+            format!("{} B", size)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_file_screen_exists() {
+        let _ = FileScreen;
+    }
+
+    #[test]
+    fn test_format_size() {
+        assert_eq!(FileScreen::format_size(500), "500 B");
+        assert_eq!(FileScreen::format_size(1024), "1.0 KB");
+        assert_eq!(FileScreen::format_size(1536), "1.5 KB");
+        assert_eq!(FileScreen::format_size(1048576), "1.0 MB");
+        assert_eq!(FileScreen::format_size(1073741824), "1.0 GB");
+    }
+}

--- a/src/app/screens/help.rs
+++ b/src/app/screens/help.rs
@@ -1,0 +1,209 @@
+//! Help screen handler.
+
+use super::common::ScreenContext;
+use super::ScreenResult;
+use crate::error::Result;
+use crate::server::TelnetSession;
+
+/// Help screen handler.
+pub struct HelpScreen;
+
+impl HelpScreen {
+    /// Run the help screen.
+    pub async fn run(ctx: &mut ScreenContext, session: &mut TelnetSession) -> Result<ScreenResult> {
+        loop {
+            // Display help menu
+            ctx.send_line(session, "").await?;
+            ctx.send_line(session, &format!("=== {} ===", ctx.i18n.t("common.help")))
+                .await?;
+            ctx.send_line(session, "").await?;
+
+            ctx.send_line(session, "  [1] About HOBBS").await?;
+            ctx.send_line(session, "  [2] Navigation").await?;
+            ctx.send_line(session, "  [3] Board Commands").await?;
+            ctx.send_line(session, "  [4] Chat Commands").await?;
+            ctx.send_line(session, "  [5] Mail Commands").await?;
+            ctx.send_line(session, "").await?;
+
+            ctx.send(
+                session,
+                &format!(
+                    "{} [Q={}]: ",
+                    ctx.i18n.t("menu.select_prompt"),
+                    ctx.i18n.t("common.back")
+                ),
+            )
+            .await?;
+
+            let input = ctx.read_line(session).await?;
+            let input = input.trim();
+
+            match input.to_ascii_lowercase().as_str() {
+                "q" | "" => return Ok(ScreenResult::Back),
+                "1" => Self::show_about(ctx, session).await?,
+                "2" => Self::show_navigation(ctx, session).await?,
+                "3" => Self::show_board_help(ctx, session).await?,
+                "4" => Self::show_chat_help(ctx, session).await?,
+                "5" => Self::show_mail_help(ctx, session).await?,
+                _ => {}
+            }
+        }
+    }
+
+    /// Show about screen.
+    async fn show_about(ctx: &ScreenContext, session: &mut TelnetSession) -> Result<()> {
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "=== About HOBBS ===").await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "HOBBS - Hobbyist Bulletin Board System")
+            .await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            "A retro-style BBS system that brings back the feel of",
+        )
+        .await?;
+        ctx.send_line(
+            session,
+            "classic bulletin board systems from the 80s and 90s.",
+        )
+        .await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "Features:").await?;
+        ctx.send_line(session, "  - Message boards (thread and flat formats)")
+            .await?;
+        ctx.send_line(session, "  - Real-time chat rooms").await?;
+        ctx.send_line(session, "  - Private mail between users")
+            .await?;
+        ctx.send_line(session, "  - File library").await?;
+        ctx.send_line(session, "  - User profiles").await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, &format!("SysOp: {}", ctx.config.bbs.sysop_name))
+            .await?;
+        ctx.send_line(session, "").await?;
+
+        ctx.wait_for_enter(session).await?;
+        Ok(())
+    }
+
+    /// Show navigation help.
+    async fn show_navigation(ctx: &ScreenContext, session: &mut TelnetSession) -> Result<()> {
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "=== Navigation ===").await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "Common Commands:").await?;
+        ctx.send_line(session, "  Q   - Go back / Quit current screen")
+            .await?;
+        ctx.send_line(session, "  N   - Next page").await?;
+        ctx.send_line(session, "  P   - Previous page").await?;
+        ctx.send_line(session, "  #   - Select item by number")
+            .await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "Main Menu:").await?;
+        ctx.send_line(session, "  B   - Boards").await?;
+        ctx.send_line(session, "  C   - Chat").await?;
+        ctx.send_line(session, "  M   - Mail").await?;
+        ctx.send_line(session, "  F   - Files").await?;
+        ctx.send_line(session, "  P   - Profile").await?;
+        ctx.send_line(session, "  H   - Help").await?;
+        ctx.send_line(session, "  Q   - Logout").await?;
+        ctx.send_line(session, "").await?;
+
+        ctx.wait_for_enter(session).await?;
+        Ok(())
+    }
+
+    /// Show board help.
+    async fn show_board_help(ctx: &ScreenContext, session: &mut TelnetSession) -> Result<()> {
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "=== Board Commands ===").await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "Board List:").await?;
+        ctx.send_line(session, "  #   - Open board by number")
+            .await?;
+        ctx.send_line(session, "  Q   - Return to main menu")
+            .await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "Thread/Post List:").await?;
+        ctx.send_line(session, "  #   - Open thread/post by number")
+            .await?;
+        ctx.send_line(session, "  W   - Write new thread/post")
+            .await?;
+        ctx.send_line(session, "  N   - Next page").await?;
+        ctx.send_line(session, "  P   - Previous page").await?;
+        ctx.send_line(session, "  Q   - Return to board list")
+            .await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "Reading Posts:").await?;
+        ctx.send_line(session, "  R   - Reply to thread").await?;
+        ctx.send_line(session, "  N   - Next page").await?;
+        ctx.send_line(session, "  P   - Previous page").await?;
+        ctx.send_line(session, "  Q   - Return to list").await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "Writing:").await?;
+        ctx.send_line(session, "  Enter text line by line").await?;
+        ctx.send_line(session, "  Type '.' on a line by itself to finish")
+            .await?;
+        ctx.send_line(session, "").await?;
+
+        ctx.wait_for_enter(session).await?;
+        Ok(())
+    }
+
+    /// Show chat help.
+    async fn show_chat_help(ctx: &ScreenContext, session: &mut TelnetSession) -> Result<()> {
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "=== Chat Commands ===").await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "In Chat Room:").await?;
+        ctx.send_line(session, "  /quit   - Leave the room").await?;
+        ctx.send_line(session, "  /who    - List participants")
+            .await?;
+        ctx.send_line(session, "  /me     - Action message (e.g., /me waves)")
+            .await?;
+        ctx.send_line(session, "  /help   - Show help").await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "Normal text is sent as a message to everyone.")
+            .await?;
+        ctx.send_line(session, "").await?;
+
+        ctx.wait_for_enter(session).await?;
+        Ok(())
+    }
+
+    /// Show mail help.
+    async fn show_mail_help(ctx: &ScreenContext, session: &mut TelnetSession) -> Result<()> {
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "=== Mail Commands ===").await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "Mail List:").await?;
+        ctx.send_line(session, "  #   - Read mail by number")
+            .await?;
+        ctx.send_line(session, "  W   - Write new mail").await?;
+        ctx.send_line(session, "  N   - Next page").await?;
+        ctx.send_line(session, "  P   - Previous page").await?;
+        ctx.send_line(session, "  Q   - Return to main menu")
+            .await?;
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, "Reading Mail:").await?;
+        ctx.send_line(session, "  R   - Reply to sender").await?;
+        ctx.send_line(session, "  D   - Delete mail").await?;
+        ctx.send_line(session, "  N   - Next mail").await?;
+        ctx.send_line(session, "  P   - Previous mail").await?;
+        ctx.send_line(session, "  Q   - Return to list").await?;
+        ctx.send_line(session, "").await?;
+
+        ctx.wait_for_enter(session).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_help_screen_exists() {
+        let _ = HelpScreen;
+    }
+}

--- a/src/app/screens/mod.rs
+++ b/src/app/screens/mod.rs
@@ -1,0 +1,47 @@
+//! Screen modules for HOBBS.
+//!
+//! This module provides individual screen handlers for different features.
+
+mod admin;
+mod board;
+mod chat;
+mod common;
+mod file;
+mod help;
+mod mail;
+mod profile;
+
+pub use admin::AdminScreen;
+pub use board::BoardScreen;
+pub use chat::ChatScreen;
+pub use common::ScreenContext;
+pub use file::FileScreen;
+pub use help::HelpScreen;
+pub use mail::MailScreen;
+pub use profile::ProfileScreen;
+
+/// Result of a screen action.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ScreenResult {
+    /// Go back to the previous screen.
+    Back,
+    /// Continue in the current screen.
+    Continue,
+    /// User wants to logout.
+    Logout,
+    /// User wants to quit.
+    Quit,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_screen_result_variants() {
+        assert_eq!(ScreenResult::Back, ScreenResult::Back);
+        assert_eq!(ScreenResult::Continue, ScreenResult::Continue);
+        assert_eq!(ScreenResult::Logout, ScreenResult::Logout);
+        assert_eq!(ScreenResult::Quit, ScreenResult::Quit);
+    }
+}

--- a/src/app/screens/profile.rs
+++ b/src/app/screens/profile.rs
@@ -1,0 +1,325 @@
+//! Profile screen handler.
+
+use tracing::error;
+
+use super::common::ScreenContext;
+use super::ScreenResult;
+use crate::auth::{change_password, update_profile, ProfileUpdateRequest};
+use crate::db::UserRepository;
+use crate::error::Result;
+use crate::server::{EchoMode, TelnetSession};
+
+/// Profile screen handler.
+pub struct ProfileScreen;
+
+impl ProfileScreen {
+    /// Run the profile screen.
+    pub async fn run(ctx: &mut ScreenContext, session: &mut TelnetSession) -> Result<ScreenResult> {
+        let user_id = match session.user_id() {
+            Some(id) => id,
+            None => {
+                ctx.send_line(session, ctx.i18n.t("menu.login_required"))
+                    .await?;
+                return Ok(ScreenResult::Back);
+            }
+        };
+
+        loop {
+            // Get user info
+            let user_repo = UserRepository::new(&ctx.db);
+            let user = match user_repo.get_by_id(user_id)? {
+                Some(u) => u,
+                None => return Ok(ScreenResult::Back),
+            };
+
+            // Display profile
+            ctx.send_line(session, "").await?;
+            ctx.send_line(session, &format!("=== {} ===", ctx.i18n.t("profile.title")))
+                .await?;
+            ctx.send_line(session, "").await?;
+            ctx.send_line(
+                session,
+                &format!("{}: {}", ctx.i18n.t("profile.username"), user.username),
+            )
+            .await?;
+            ctx.send_line(
+                session,
+                &format!("{}: {}", ctx.i18n.t("profile.nickname"), user.nickname),
+            )
+            .await?;
+            ctx.send_line(
+                session,
+                &format!(
+                    "{}: {}",
+                    ctx.i18n.t("auth.email"),
+                    user.email.as_deref().unwrap_or("-")
+                ),
+            )
+            .await?;
+            ctx.send_line(
+                session,
+                &format!("{}: {:?}", ctx.i18n.t("role.member"), user.role),
+            )
+            .await?;
+            ctx.send_line(
+                session,
+                &format!(
+                    "{}: {}",
+                    ctx.i18n.t("profile.member_since"),
+                    user.created_at
+                ),
+            )
+            .await?;
+            ctx.send_line(
+                session,
+                &format!(
+                    "{}: {}",
+                    ctx.i18n.t("profile.last_login"),
+                    user.last_login.as_deref().unwrap_or("-")
+                ),
+            )
+            .await?;
+
+            if let Some(ref profile_text) = user.profile {
+                ctx.send_line(session, "").await?;
+                ctx.send_line(session, &format!("--- {} ---", ctx.i18n.t("profile.bio")))
+                    .await?;
+                ctx.send_line(session, profile_text).await?;
+            }
+
+            ctx.send_line(session, "").await?;
+
+            // Options
+            ctx.send(
+                session,
+                &format!(
+                    "[E]={} [P]={} [Q]={}: ",
+                    ctx.i18n.t("profile.edit"),
+                    ctx.i18n.t("profile.change_password"),
+                    ctx.i18n.t("common.back")
+                ),
+            )
+            .await?;
+
+            let input = ctx.read_line(session).await?;
+            let input = input.trim();
+
+            match input.to_ascii_lowercase().as_str() {
+                "q" | "" => return Ok(ScreenResult::Back),
+                "e" => {
+                    Self::edit_profile(ctx, session, user_id).await?;
+                }
+                "p" => {
+                    Self::change_password(ctx, session, user_id).await?;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Edit profile.
+    async fn edit_profile(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        user_id: i64,
+    ) -> Result<()> {
+        // Get user info first
+        let (current_nickname, current_email) = {
+            let user_repo = UserRepository::new(&ctx.db);
+            let user = match user_repo.get_by_id(user_id)? {
+                Some(u) => u,
+                None => return Ok(()),
+            };
+            (user.nickname.clone(), user.email.clone())
+        };
+
+        ctx.send_line(session, "").await?;
+        ctx.send_line(session, &format!("=== {} ===", ctx.i18n.t("profile.edit")))
+            .await?;
+        ctx.send_line(session, ctx.i18n.t("common.press_enter"))
+            .await?;
+        ctx.send_line(session, "").await?;
+
+        // Edit nickname
+        ctx.send(
+            session,
+            &format!(
+                "{} [{}]: ",
+                ctx.i18n.t("profile.nickname"),
+                current_nickname
+            ),
+        )
+        .await?;
+        let nickname = ctx.read_line(session).await?;
+        let nickname = nickname.trim();
+        let new_nickname = if nickname.is_empty() {
+            None
+        } else {
+            Some(nickname.to_string())
+        };
+
+        // Edit email
+        ctx.send(
+            session,
+            &format!(
+                "{} [{}]: ",
+                ctx.i18n.t("auth.email"),
+                current_email.as_deref().unwrap_or("-")
+            ),
+        )
+        .await?;
+        let email = ctx.read_line(session).await?;
+        let email = email.trim();
+        let new_email = if email.is_empty() {
+            None
+        } else if email == "-" {
+            Some(None) // Clear email
+        } else {
+            Some(Some(email.to_string()))
+        };
+
+        // Edit profile text
+        ctx.send_line(
+            session,
+            &format!(
+                "{} ({}): ",
+                ctx.i18n.t("profile.bio"),
+                ctx.i18n.t("common.end_with_dot")
+            ),
+        )
+        .await?;
+        let profile_text = Self::read_multiline(ctx, session).await?;
+        let new_profile = if profile_text.is_empty() {
+            None
+        } else {
+            Some(Some(profile_text))
+        };
+
+        // Build update request
+        let mut request = ProfileUpdateRequest::new();
+        if let Some(nick) = new_nickname {
+            request = request.nickname(nick);
+        }
+        if let Some(email_opt) = new_email {
+            request = request.email(email_opt);
+        }
+        if let Some(profile_opt) = new_profile {
+            request = request.profile(profile_opt);
+        }
+
+        // Apply update - create a new user_repo for this operation
+        let user_repo = UserRepository::new(&ctx.db);
+        match update_profile(&user_repo, user_id, request) {
+            Ok(_) => {
+                ctx.send_line(session, ctx.i18n.t("profile.profile_updated"))
+                    .await?;
+            }
+            Err(e) => {
+                error!("Failed to update profile: {}", e);
+                ctx.send_line(session, ctx.i18n.t("common.operation_failed"))
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Change password.
+    async fn change_password(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+        user_id: i64,
+    ) -> Result<()> {
+        ctx.send_line(session, "").await?;
+        ctx.send_line(
+            session,
+            &format!("=== {} ===", ctx.i18n.t("profile.change_password")),
+        )
+        .await?;
+        ctx.send_line(session, "").await?;
+
+        // Get current password
+        ctx.send(
+            session,
+            &format!("{}: ", ctx.i18n.t("auth.current_password")),
+        )
+        .await?;
+        ctx.set_echo_mode(EchoMode::Password);
+        let current = ctx.read_line(session).await?;
+        ctx.set_echo_mode(EchoMode::Normal);
+        ctx.send_line(session, "").await?;
+
+        // Get new password
+        ctx.send(session, &format!("{}: ", ctx.i18n.t("auth.new_password")))
+            .await?;
+        ctx.set_echo_mode(EchoMode::Password);
+        let new_password = ctx.read_line(session).await?;
+        ctx.set_echo_mode(EchoMode::Normal);
+        ctx.send_line(session, "").await?;
+
+        // Confirm new password
+        ctx.send(
+            session,
+            &format!("{}: ", ctx.i18n.t("auth.password_confirm")),
+        )
+        .await?;
+        ctx.set_echo_mode(EchoMode::Password);
+        let confirm = ctx.read_line(session).await?;
+        ctx.set_echo_mode(EchoMode::Normal);
+        ctx.send_line(session, "").await?;
+
+        // Validate
+        if new_password != confirm {
+            ctx.send_line(session, ctx.i18n.t("auth.password_mismatch"))
+                .await?;
+            return Ok(());
+        }
+
+        // Change password
+        let user_repo = UserRepository::new(&ctx.db);
+        match change_password(&user_repo, user_id, &current, &new_password) {
+            Ok(()) => {
+                ctx.send_line(session, ctx.i18n.t("auth.password_changed"))
+                    .await?;
+            }
+            Err(e) => {
+                error!("Failed to change password: {}", e);
+                ctx.send_line(session, ctx.i18n.t("auth.password_incorrect"))
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Read multiline input.
+    async fn read_multiline(
+        ctx: &mut ScreenContext,
+        session: &mut TelnetSession,
+    ) -> Result<String> {
+        let mut lines = Vec::new();
+
+        loop {
+            ctx.send(session, "> ").await?;
+            let line = ctx.read_line(session).await?;
+
+            if line.trim() == "." {
+                break;
+            }
+
+            lines.push(line);
+        }
+
+        Ok(lines.join("\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_profile_screen_exists() {
+        let _ = ProfileScreen;
+    }
+}


### PR DESCRIPTION
## Summary
- **ScreenResult** enum を導入（Back, Continue, Logout, Quit）
- **ScreenContext** 共通コンテキストを作成（DB, Config, I18n, TemplateLoader, LineBuffer を共有）
- **Pagination** ヘルパーでページング処理を標準化
- 各スクリーンハンドラを `src/app/screens/` に実装
  - BoardScreen: 掲示板一覧、スレッド形式・フラット形式対応、投稿作成
  - ChatScreen: チャットルーム一覧（リアルタイム機能は後日）
  - MailScreen: 受信箱表示、メール送受信・返信・削除
  - FileScreen: フォルダ階層ナビゲーション、ファイル詳細表示
  - AdminScreen: 管理メニュー（掲示板・ユーザー管理、システム状態）
  - ProfileScreen: プロフィール表示・編集・パスワード変更
  - HelpScreen: ヘルプメニュー

## Test plan
- [x] `cargo test` 全テスト通過
- [x] `cargo clippy` エラーなし
- [x] `cargo fmt` 適用済み

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)