### PR TITLE
[Phase 10-4] ドキュメント・README整備

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,12 @@ cargo watch -x test
 |------|------|------|
 | 単体テスト | 各モジュール内 `#[cfg(test)]` | 個々の関数・構造体のテスト |
 | 統合テスト | `tests/` ディレクトリ | モジュール間連携のテスト |
-| E2Eテスト | `tests/e2e/` | Telnet接続を含む全体テスト |
+| E2Eテスト | `tests/e2e_*.rs` | Telnet接続を含む全体テスト |
+
+```bash
+# E2Eテスト実行
+cargo test --test e2e_connection --test e2e_auth --test e2e_board --test e2e_mail --test e2e_admin
+```
 
 ## アーキテクチャ
 
@@ -255,3 +260,4 @@ type:
 - `05_protocol.md` - プロトコル仕様
 - `06_screens.md` - 画面設計
 - `07_security.md` - セキュリティ仕様
+- `operation_guide.md` - 運用ガイド

--- a/README.md
+++ b/README.md
@@ -1,0 +1,233 @@
+# HOBBS - Hobbyist Bulletin Board System
+
+[![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+Telnetプロトコルで接続するレトロなパソコン通信BBSホストプログラムです。1980〜90年代に栄えたパソコン通信文化を現代の技術で再現し、テキストベースのコミュニケーション体験を提供します。
+
+## 機能一覧
+
+| 機能 | 概要 |
+|------|------|
+| 会員管理 | 入会・退会・会員情報管理・3段階権限システム（SysOp/SubOp/一般） |
+| 掲示板 | スレッド形式/フラット形式両対応、動的追加・削除 |
+| チャット | 単一ロビー形式のリアルタイムチャット |
+| メール | BBS内部のプライベートメッセージ機能 |
+| ファイル | フォルダ単位の権限設定可能なファイル共有 |
+| ゲストアクセス | 会員登録なしでの一部コンテンツ閲覧 |
+| 国際化 | 日本語・英語の2言語対応 |
+
+## 技術仕様
+
+| 項目 | 仕様 |
+|------|------|
+| 通信プロトコル | Telnet |
+| 文字コード | ShiftJIS（クライアント側）/ UTF-8（内部処理） |
+| 画面装飾 | ANSIエスケープシーケンス対応 |
+| 実装言語 | Rust |
+| データベース | SQLite |
+| 想定規模 | 同時接続〜20人程度 |
+
+## 必要環境
+
+- Rust 1.70以上
+- SQLite 3.x（bundled版を使用するため個別インストール不要）
+
+## インストール
+
+### ソースからビルド
+
+```bash
+# リポジトリをクローン
+git clone https://github.com/h-o-soft/hobbs.git
+cd hobbs
+
+# リリースビルド
+cargo build --release
+
+# 実行ファイルは target/release/hobbs に生成されます
+```
+
+### 初期設定
+
+1. 設定ファイルを編集:
+
+```bash
+cp config.toml config.local.toml  # 必要に応じてコピーして編集
+```
+
+2. 必要なディレクトリを作成:
+
+```bash
+mkdir -p data/files logs
+```
+
+3. サーバーを起動:
+
+```bash
+./target/release/hobbs
+```
+
+## 設定ファイル
+
+`config.toml` でサーバーの動作を設定します。
+
+```toml
+[server]
+host = "0.0.0.0"          # バインドアドレス
+port = 2323               # ポート番号
+max_connections = 20      # 最大同時接続数
+idle_timeout_secs = 300   # アイドルタイムアウト（秒）
+
+[database]
+path = "data/hobbs.db"    # データベースファイルパス
+
+[files]
+storage_path = "data/files"   # ファイルストレージパス
+max_upload_size_mb = 10       # 最大アップロードサイズ（MB）
+
+[bbs]
+name = "HOBBS - Hobbyist BBS"   # BBS名
+description = "A retro BBS system"  # 説明
+sysop_name = "SysOp"            # SysOp名
+
+[locale]
+language = "ja"           # デフォルト言語（ja/en）
+
+[templates]
+path = "templates"        # テンプレートディレクトリ
+
+[logging]
+level = "info"            # ログレベル（debug/info/warn/error）
+file = "logs/hobbs.log"   # ログファイルパス
+```
+
+## 使い方
+
+### サーバー起動
+
+```bash
+# 通常起動
+./target/release/hobbs
+
+# 開発モード（デバッグログ有効）
+RUST_LOG=debug cargo run
+```
+
+### クライアント接続
+
+任意のTelnetクライアントで接続できます:
+
+```bash
+# macOS/Linux
+telnet localhost 2323
+
+# Windows (Windows Terminal)
+telnet localhost 2323
+
+# または専用Telnetクライアント（Tera Term, PuTTY等）を使用
+```
+
+### 初回セットアップ
+
+1. 最初に登録したユーザーが自動的にSysOp（管理者）になります
+2. 「R」キーで新規登録
+3. ユーザー名、パスワード、ニックネームを入力
+4. 登録完了後、メインメニューが表示されます
+
+### メインメニュー
+
+```
+=== Main Menu ===
+[B] 掲示板
+[C] チャット
+[M] メール
+[F] ファイル
+[P] プロフィール
+[A] 管理（管理者のみ）
+[Q] 終了
+```
+
+## ディレクトリ構成
+
+```
+hobbs/
+├── Cargo.toml          # プロジェクト設定
+├── config.toml         # サーバー設定
+├── CLAUDE.md           # 開発ガイドライン
+├── README.md           # このファイル
+├── docs/               # 設計ドキュメント
+│   ├── 01_overview.md
+│   ├── 02_architecture.md
+│   ├── 03_features/
+│   ├── 04_database.md
+│   ├── 05_protocol.md
+│   ├── 06_screens.md
+│   └── 07_security.md
+├── templates/          # 画面テンプレート
+│   ├── 80/            # 80カラム用
+│   └── 40/            # 40カラム用
+├── locales/           # 言語リソース
+│   ├── ja.toml
+│   └── en.toml
+├── data/              # ランタイムデータ（自動生成）
+│   ├── hobbs.db
+│   └── files/
+├── logs/              # ログファイル
+└── src/               # ソースコード
+```
+
+## 開発
+
+### テスト実行
+
+```bash
+# 全テスト実行
+cargo test
+
+# E2Eテストのみ
+cargo test --test e2e_connection --test e2e_auth --test e2e_board --test e2e_mail --test e2e_admin
+
+# 特定のテスト
+cargo test test_name
+```
+
+### コード品質
+
+```bash
+# フォーマット
+cargo fmt
+
+# Lint
+cargo clippy
+
+# ドキュメント生成
+cargo doc --open
+```
+
+### 開発ガイドライン
+
+詳細は [CLAUDE.md](CLAUDE.md) を参照してください。
+
+## 用語
+
+| 用語 | 説明 |
+|------|------|
+| SysOp | System Operator。システム管理者。全権限を持つ |
+| SubOp | Sub Operator。副管理者。一部管理権限を持つ |
+| ゲスト | 未登録ユーザー。閲覧のみ可能 |
+| スレッド形式 | トピックごとにレスがつく掲示板形式 |
+| フラット形式 | 時系列に記事が並ぶ従来のBBS形式 |
+
+## ライセンス
+
+MIT License
+
+Copyright (c) 2024-2025 HOBBS Project
+
+詳細は [LICENSE](LICENSE) ファイルを参照してください。
+
+## 関連リンク
+
+- [設計ドキュメント](docs/)
+- [Issue Tracker](https://github.com/h-o-soft/hobbs/issues)

--- a/docs/operation_guide.md
+++ b/docs/operation_guide.md
@@ -1,0 +1,389 @@
+# HOBBS 運用ガイド
+
+このドキュメントでは、HOBBSの運用に必要な手順とトラブルシューティングについて説明します。
+
+## 目次
+
+1. [サーバー運用手順](#サーバー運用手順)
+2. [バックアップ・リストア](#バックアップリストア)
+3. [トラブルシューティング](#トラブルシューティング)
+4. [セキュリティ](#セキュリティ)
+
+---
+
+## サーバー運用手順
+
+### 起動
+
+```bash
+# 通常起動
+./hobbs
+
+# バックグラウンド起動（Linux/macOS）
+nohup ./hobbs > /dev/null 2>&1 &
+
+# systemdサービスとして起動（推奨）
+sudo systemctl start hobbs
+```
+
+### 停止
+
+サーバーを安全に停止するには、以下の方法があります：
+
+1. **Ctrl+C**: フォアグラウンドで実行中の場合
+2. **SIGTERMシグナル**: `kill <PID>`
+3. **systemctl**: `sudo systemctl stop hobbs`
+
+### 再起動
+
+```bash
+# systemdを使用している場合
+sudo systemctl restart hobbs
+```
+
+### ステータス確認
+
+```bash
+# プロセス確認
+ps aux | grep hobbs
+
+# ポート確認
+lsof -i :2323
+
+# systemdステータス
+sudo systemctl status hobbs
+```
+
+### systemdサービス設定（例）
+
+`/etc/systemd/system/hobbs.service`:
+
+```ini
+[Unit]
+Description=HOBBS - Hobbyist Bulletin Board System
+After=network.target
+
+[Service]
+Type=simple
+User=hobbs
+Group=hobbs
+WorkingDirectory=/opt/hobbs
+ExecStart=/opt/hobbs/hobbs
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+有効化:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable hobbs
+sudo systemctl start hobbs
+```
+
+---
+
+## バックアップ・リストア
+
+### バックアップ対象
+
+| ファイル/ディレクトリ | 内容 | 重要度 |
+|----------------------|------|--------|
+| `data/hobbs.db` | データベース | 最重要 |
+| `data/files/` | アップロードファイル | 重要 |
+| `config.toml` | 設定ファイル | 重要 |
+| `locales/` | 言語リソース（カスタマイズ時） | 任意 |
+| `templates/` | テンプレート（カスタマイズ時） | 任意 |
+
+### バックアップ手順
+
+#### 手動バックアップ
+
+```bash
+#!/bin/bash
+# backup.sh
+
+BACKUP_DIR="/backup/hobbs"
+HOBBS_DIR="/opt/hobbs"
+DATE=$(date +%Y%m%d_%H%M%S)
+
+# バックアップディレクトリ作成
+mkdir -p "$BACKUP_DIR"
+
+# データベースをSQLiteのバックアップ機能でコピー
+sqlite3 "$HOBBS_DIR/data/hobbs.db" ".backup '$BACKUP_DIR/hobbs_$DATE.db'"
+
+# ファイルストレージをコピー
+tar -czf "$BACKUP_DIR/files_$DATE.tar.gz" -C "$HOBBS_DIR/data" files/
+
+# 設定ファイルをコピー
+cp "$HOBBS_DIR/config.toml" "$BACKUP_DIR/config_$DATE.toml"
+
+# 古いバックアップを削除（30日以上前）
+find "$BACKUP_DIR" -type f -mtime +30 -delete
+
+echo "Backup completed: $DATE"
+```
+
+#### cronによる定期バックアップ
+
+```bash
+# /etc/cron.d/hobbs-backup
+0 3 * * * hobbs /opt/hobbs/scripts/backup.sh >> /var/log/hobbs-backup.log 2>&1
+```
+
+### リストア手順
+
+```bash
+#!/bin/bash
+# restore.sh
+
+BACKUP_FILE="$1"
+HOBBS_DIR="/opt/hobbs"
+
+if [ -z "$BACKUP_FILE" ]; then
+    echo "Usage: restore.sh <backup_db_file>"
+    exit 1
+fi
+
+# サーバー停止
+sudo systemctl stop hobbs
+
+# 既存DBをバックアップ
+mv "$HOBBS_DIR/data/hobbs.db" "$HOBBS_DIR/data/hobbs.db.old"
+
+# リストア
+cp "$BACKUP_FILE" "$HOBBS_DIR/data/hobbs.db"
+
+# サーバー起動
+sudo systemctl start hobbs
+
+echo "Restore completed"
+```
+
+### オンラインバックアップ
+
+SQLiteのWALモードを使用しているため、サーバー稼働中でもバックアップ可能です：
+
+```bash
+sqlite3 data/hobbs.db ".backup data/hobbs_backup.db"
+```
+
+---
+
+## トラブルシューティング
+
+### 接続できない
+
+1. **サーバーが起動しているか確認**
+   ```bash
+   ps aux | grep hobbs
+   ```
+
+2. **ポートがリッスンしているか確認**
+   ```bash
+   lsof -i :2323
+   # または
+   ss -tlnp | grep 2323
+   ```
+
+3. **ファイアウォール設定を確認**
+   ```bash
+   # iptables
+   sudo iptables -L -n | grep 2323
+
+   # ufw
+   sudo ufw status
+
+   # firewalld
+   sudo firewall-cmd --list-all
+   ```
+
+4. **ログを確認**
+   ```bash
+   tail -f logs/hobbs.log
+   ```
+
+### データベースエラー
+
+1. **データベースのロック**
+   - 複数プロセスが同時にアクセスしている可能性
+   - `lsof data/hobbs.db` で確認
+
+2. **データベースの破損**
+   ```bash
+   # 整合性チェック
+   sqlite3 data/hobbs.db "PRAGMA integrity_check;"
+
+   # 修復を試みる
+   sqlite3 data/hobbs.db ".recover" | sqlite3 data/hobbs_recovered.db
+   ```
+
+3. **WALファイルの問題**
+   ```bash
+   # WALチェックポイント
+   sqlite3 data/hobbs.db "PRAGMA wal_checkpoint(TRUNCATE);"
+   ```
+
+### メモリ使用量が高い
+
+1. **接続数を確認**
+   - 管理画面でアクティブセッション数を確認
+   - `max_connections` 設定を調整
+
+2. **アイドルタイムアウトを短くする**
+   ```toml
+   [server]
+   idle_timeout_secs = 180  # 5分から3分に短縮
+   ```
+
+### 文字化け
+
+1. **クライアントの文字コード設定を確認**
+   - Tera Term: 設定 → 端末 → 漢字（受信）→ SJIS
+   - PuTTY: 設定 → ウィンドウ → 変換 → Shift_JIS
+
+2. **ターミナルタイプを確認**
+   - ANSIエスケープシーケンス対応クライアントを使用
+
+### ログの確認方法
+
+```bash
+# リアルタイム監視
+tail -f logs/hobbs.log
+
+# エラーのみ抽出
+grep -i error logs/hobbs.log
+
+# 特定ユーザーの操作を追跡
+grep "username" logs/hobbs.log
+```
+
+### デバッグモード
+
+詳細なログを出力するには：
+
+```bash
+RUST_LOG=debug ./hobbs
+```
+
+ログレベル：
+- `error`: エラーのみ
+- `warn`: 警告以上
+- `info`: 通常運用（デフォルト）
+- `debug`: 詳細情報
+- `trace`: 最大詳細
+
+---
+
+## セキュリティ
+
+### 推奨設定
+
+1. **専用ユーザーで実行**
+   ```bash
+   sudo useradd -r -s /bin/false hobbs
+   sudo chown -R hobbs:hobbs /opt/hobbs
+   ```
+
+2. **ファイル権限**
+   ```bash
+   chmod 600 config.toml     # 設定ファイル
+   chmod 600 data/hobbs.db   # データベース
+   chmod 700 data/files      # ファイルストレージ
+   ```
+
+3. **ファイアウォール**
+   ```bash
+   # 特定IPのみ許可
+   sudo ufw allow from 192.168.1.0/24 to any port 2323
+
+   # 全て許可
+   sudo ufw allow 2323/tcp
+   ```
+
+### パスワードポリシー
+
+- 最小長: 8文字
+- 最大長: 128文字
+- ハッシュ: Argon2id
+
+### セッション管理
+
+- デフォルトタイムアウト: 5分
+- 同一ユーザーの複数セッション: 許可
+- ログイン試行制限: 5回失敗で一時ロック
+
+### 定期メンテナンス
+
+1. **古いセッションの削除**（自動）
+2. **ログローテーション**
+   ```bash
+   # logrotateの設定例
+   /opt/hobbs/logs/*.log {
+       daily
+       rotate 30
+       compress
+       delaycompress
+       missingok
+       notifempty
+   }
+   ```
+
+3. **データベースの最適化**
+   ```bash
+   sqlite3 data/hobbs.db "VACUUM;"
+   sqlite3 data/hobbs.db "ANALYZE;"
+   ```
+
+---
+
+## 監視
+
+### ヘルスチェック
+
+```bash
+#!/bin/bash
+# healthcheck.sh
+
+PORT=2323
+HOST="localhost"
+
+if nc -z "$HOST" "$PORT"; then
+    echo "HOBBS is running"
+    exit 0
+else
+    echo "HOBBS is NOT running"
+    exit 1
+fi
+```
+
+### メトリクス
+
+ログから以下の情報を収集できます：
+- 接続数
+- ログイン成功/失敗数
+- エラー発生数
+
+---
+
+## 更新手順
+
+1. サーバー停止
+2. バックアップ取得
+3. 新しいバイナリをデプロイ
+4. 設定ファイル確認（新しい設定項目がないか）
+5. サーバー起動
+6. 動作確認
+
+```bash
+# 更新スクリプト例
+sudo systemctl stop hobbs
+./scripts/backup.sh
+cp hobbs-new /opt/hobbs/hobbs
+sudo systemctl start hobbs
+./scripts/healthcheck.sh
+```


### PR DESCRIPTION
## 概要

README.mdと運用ガイドを整備しました。

## 変更内容

### README.md（新規作成）

- プロジェクト概要
- 機能一覧・技術仕様
- 必要環境
- インストール方法（ソースからビルド）
- 設定ファイル（config.toml）の説明
- 使い方
  - サーバー起動
  - クライアント接続
  - 初回セットアップ
  - メインメニュー
- ディレクトリ構成
- 開発（テスト実行、コード品質）
- 用語解説
- ライセンス情報

### docs/operation_guide.md（新規作成）

- サーバー運用手順
  - 起動・停止・再起動
  - ステータス確認
  - systemdサービス設定例
- バックアップ・リストア
  - バックアップ対象
  - 手動バックアップ手順
  - cronによる定期バックアップ
  - リストア手順
  - オンラインバックアップ
- トラブルシューティング
  - 接続できない
  - データベースエラー
  - メモリ使用量が高い
  - 文字化け
  - ログの確認方法
  - デバッグモード
- セキュリティ
  - 推奨設定
  - パスワードポリシー
  - セッション管理
  - 定期メンテナンス
- 監視（ヘルスチェック）
- 更新手順

### CLAUDE.md（更新）

- E2Eテストの場所を`tests/e2e/`から`tests/e2e_*.rs`に修正
- E2Eテスト実行コマンドを追加
- 運用ガイドへの参照を追加

## チェックリスト

- [x] README.md 作成
  - [x] プロジェクト概要
  - [x] 機能一覧
  - [x] インストール方法
  - [x] 設定ファイルの説明
  - [x] 使い方
  - [x] ライセンス
- [x] 運用ガイド作成
  - [x] サーバー運用手順
  - [x] バックアップ・リストア
  - [x] トラブルシューティング
- [x] CLAUDE.md の最終更新
- [x] rustdoc の警告がないことを確認

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)