### PR TITLE
fix: サーバーが起動するようにmain.rsを修正

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,11 @@
-use tracing::info;
+use std::sync::Arc;
 
-use hobbs::Config;
+use tracing::{error, info};
+
+use hobbs::{
+    Application, Config, Database, I18nManager, TelnetServer, TelnetSession, TemplateLoader,
+};
+use hobbs::server::SessionManager;
 
 fn main() {
     // Load configuration
@@ -22,7 +27,86 @@ fn main() {
 
     info!("HOBBS - Hobbyist Bulletin Board System");
     info!(
-        "Server configured on {}:{}",
+        "Server starting on {}:{}",
         config.server.host, config.server.port
     );
+
+    // Create tokio runtime
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create tokio runtime");
+
+    // Run the server
+    if let Err(e) = rt.block_on(run_server(config)) {
+        error!("Server error: {e}");
+        std::process::exit(1);
+    }
+}
+
+async fn run_server(config: Config) -> Result<(), Box<dyn std::error::Error>> {
+    // Ensure data directory exists
+    std::fs::create_dir_all("data")?;
+
+    // Open database
+    let db = Arc::new(Database::open(&config.database.path)?);
+    info!("Database opened: {}", config.database.path);
+
+    // Load I18n
+    let i18n_manager = Arc::new(I18nManager::load_all("locales")?);
+    info!("I18n loaded");
+
+    // Load templates
+    let template_loader = Arc::new(TemplateLoader::new(&config.templates.path));
+    info!("Templates loaded from: {}", config.templates.path);
+
+    // Create session manager
+    let session_manager = Arc::new(SessionManager::new(config.server.idle_timeout_secs));
+
+    // Create application
+    let app = Application::new(
+        db,
+        Arc::new(config.clone()),
+        i18n_manager,
+        template_loader,
+        session_manager,
+    );
+
+    // Bind server
+    let server = TelnetServer::bind(&config.server).await?;
+    info!(
+        "Server listening on {}:{}",
+        config.server.host, config.server.port
+    );
+    info!("Press Ctrl+C to stop");
+
+    // Create LocalSet for non-Send futures (rusqlite is not Send)
+    let local = tokio::task::LocalSet::new();
+
+    local
+        .run_until(async move {
+            loop {
+                match server.accept().await {
+                    Ok((stream, addr, permit)) => {
+                        info!("New connection from {}", addr);
+                        let app = app.clone();
+                        tokio::task::spawn_local(async move {
+                            let mut session = TelnetSession::new(stream, addr);
+                            if let Err(e) = app.run_session(&mut session).await {
+                                error!("Session error for {}: {}", addr, e);
+                            }
+                            info!("Connection closed: {}", addr);
+                            drop(permit);
+                        });
+                    }
+                    Err(e) => {
+                        error!("Accept error: {}", e);
+                        break;
+                    }
+                }
+            }
+        })
+        .await;
+
+    Ok(())
 }

--- a/tests/e2e_admin.rs
+++ b/tests/e2e_admin.rs
@@ -25,12 +25,14 @@ async fn test_admin_requires_admin_role() {
     let response = client.recv_timeout(Duration::from_secs(2)).await.unwrap();
 
     // Should be denied (A might not even show in menu for non-admin)
-    // Or should show permission denied message
+    // Or should show permission denied message or invalid selection
     assert!(
         response.contains("permission")
             || response.contains("denied")
             || response.contains("権限")
             || response.contains("admin")
+            || response.contains("Invalid")
+            || response.contains("無効")
             || response.contains("B")
             || response.contains("Menu")
             || response.contains("Select"),


### PR DESCRIPTION
## 問題

`cargo run` または `./target/release/hobbs` を実行すると、すぐに終了してしまう。

## 原因

`main.rs` には設定ファイルの読み込みとログの初期化のみが実装されており、**サーバーを実際に起動するコードが欠けていた**。

## 修正内容

### main.rs

- tokioランタイムを作成
- `run_server()` async関数を追加
  - データベースを開く
  - I18nマネージャーをロード
  - テンプレートローダーをロード
  - SessionManagerを作成
  - Applicationを作成
  - TelnetServerをバインド
  - 接続を受け付けるループ
  - LocalSetでnon-Send futures（rusqlite）を処理

### tests/e2e_admin.rs

- メンバーユーザーへのAdmin拒否テストで "Invalid selection" も正しい応答として許容
  - 管理者でないユーザーにはAオプションが表示されないため、"Invalid selection: A" は正しい動作

## 動作確認

```
$ cargo run
2025-12-31T15:34:57.701784Z  INFO hobbs: HOBBS - Hobbyist Bulletin Board System
2025-12-31T15:34:57.702097Z  INFO hobbs: Server starting on 0.0.0.0:2323
2025-12-31T15:34:57.702832Z  INFO hobbs::db: Opening database at "data/hobbs.db"
...
2025-12-31T15:34:57.717625Z  INFO hobbs::server::listener: Telnet server listening on 0.0.0.0:2323
2025-12-31T15:34:57.717640Z  INFO hobbs: Server listening on 0.0.0.0:2323
2025-12-31T15:34:57.717648Z  INFO hobbs: Press Ctrl+C to stop
```

サーバーが起動し、Ctrl+Cで停止するまで動作し続けるようになりました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)