### PR TITLE
fix: 最初のユーザーのSysOp化と未実装機能の修正

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -167,6 +167,7 @@ mark_all_read = "Mark all as read"
 
 [chat]
 room_list = "Chat Rooms"
+room_name = "Room Name"
 enter_room = "Enter"
 leave_room = "Leave"
 current_room = "Current Room"
@@ -274,6 +275,14 @@ guest = "Guest"
 member = "Member"
 subop = "Sub-Op"
 sysop = "SysOp"
+
+[member]
+list = "Member List"
+username = "Username"
+nickname = "Nickname"
+role = "Role"
+no_members = "No members found"
+total = "Total: {{count}} members"
 
 [time]
 now = "now"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -167,6 +167,7 @@ mark_all_read = "すべて既読にする"
 
 [chat]
 room_list = "チャットルーム一覧"
+room_name = "部屋名"
 enter_room = "入室"
 leave_room = "退室"
 current_room = "現在の部屋"
@@ -274,6 +275,14 @@ guest = "ゲスト"
 member = "一般会員"
 subop = "副管理者"
 sysop = "システム管理者"
+
+[member]
+list = "会員一覧"
+username = "ユーザーID"
+nickname = "ニックネーム"
+role = "権限"
+no_members = "会員がいません"
+total = "合計: {{count}}人"
 
 [time]
 now = "今"

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -17,6 +17,8 @@ pub enum MenuAction {
     File,
     /// Go to user profile.
     Profile,
+    /// Go to member list.
+    MemberList,
     /// Go to admin menu.
     Admin,
     /// Show help.
@@ -54,6 +56,7 @@ impl MenuAction {
             "M" | "3" if is_logged_in => MenuAction::Mail,
             "F" | "4" => MenuAction::File,
             "P" | "5" if is_logged_in => MenuAction::Profile,
+            "W" | "7" => MenuAction::MemberList,
             "A" | "6" if is_admin => MenuAction::Admin,
             "H" | "?" => MenuAction::Help,
             "L" if is_logged_in => MenuAction::Logout,
@@ -96,6 +99,7 @@ impl MenuAction {
             MenuAction::Mail => "M",
             MenuAction::File => "F",
             MenuAction::Profile => "P",
+            MenuAction::MemberList => "W",
             MenuAction::Admin => "A",
             MenuAction::Help => "H",
             MenuAction::Logout => "L",
@@ -136,6 +140,8 @@ pub struct MenuItems {
     pub file: bool,
     /// Whether profile menu is available.
     pub profile: bool,
+    /// Whether member list is available.
+    pub member_list: bool,
     /// Whether admin menu is available.
     pub admin: bool,
     /// Whether help is available.
@@ -159,6 +165,7 @@ impl MenuItems {
             mail: true,
             file: true,
             profile: true,
+            member_list: true,
             admin: is_admin,
             help: true,
             logout: true,
@@ -176,6 +183,7 @@ impl MenuItems {
             mail: false,
             file: true,
             profile: false,
+            member_list: true,
             admin: false,
             help: true,
             logout: false,

--- a/src/app/screens/member.rs
+++ b/src/app/screens/member.rs
@@ -1,0 +1,95 @@
+//! Member list screen handler.
+
+use super::common::ScreenContext;
+use super::ScreenResult;
+use crate::db::UserRepository;
+use crate::error::Result;
+use crate::server::TelnetSession;
+
+/// Member list screen handler.
+pub struct MemberScreen;
+
+impl MemberScreen {
+    /// Run the member list screen.
+    pub async fn run(ctx: &mut ScreenContext, session: &mut TelnetSession) -> Result<ScreenResult> {
+        loop {
+            // Display member list header
+            ctx.send_line(session, "").await?;
+            ctx.send_line(
+                session,
+                &format!("=== {} ===", ctx.i18n.t("member.list")),
+            )
+            .await?;
+            ctx.send_line(session, "").await?;
+
+            // Get member list from database
+            let user_repo = UserRepository::new(&ctx.db);
+            let users = user_repo.list_active()?;
+
+            if users.is_empty() {
+                ctx.send_line(session, ctx.i18n.t("member.no_members"))
+                    .await?;
+            } else {
+                // Header
+                ctx.send_line(
+                    session,
+                    &format!(
+                        "  {:<16} {:<20} {:<10}",
+                        ctx.i18n.t("member.username"),
+                        ctx.i18n.t("member.nickname"),
+                        ctx.i18n.t("member.role")
+                    ),
+                )
+                .await?;
+                ctx.send_line(session, &"-".repeat(50)).await?;
+
+                // List users
+                for user in &users {
+                    let role_str = match user.role {
+                        crate::db::Role::Guest => ctx.i18n.t("role.guest"),
+                        crate::db::Role::Member => ctx.i18n.t("role.member"),
+                        crate::db::Role::SubOp => ctx.i18n.t("role.subop"),
+                        crate::db::Role::SysOp => ctx.i18n.t("role.sysop"),
+                    };
+                    ctx.send_line(
+                        session,
+                        &format!("  {:<16} {:<20} {:<10}", user.username, user.nickname, role_str),
+                    )
+                    .await?;
+                }
+
+                ctx.send_line(session, "").await?;
+                ctx.send_line(
+                    session,
+                    &ctx.i18n
+                        .t_with("member.total", &[("count", &users.len().to_string())]),
+                )
+                .await?;
+            }
+
+            ctx.send_line(session, "").await?;
+            ctx.send(
+                session,
+                &format!("[Q={}]: ", ctx.i18n.t("common.back")),
+            )
+            .await?;
+
+            let input = ctx.read_line(session).await?;
+            let input = input.trim();
+
+            if input.eq_ignore_ascii_case("q") || input.is_empty() {
+                return Ok(ScreenResult::Back);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_member_screen_exists() {
+        let _ = MemberScreen;
+    }
+}

--- a/src/app/screens/mod.rs
+++ b/src/app/screens/mod.rs
@@ -9,6 +9,7 @@ mod common;
 mod file;
 mod help;
 mod mail;
+mod member;
 mod profile;
 
 pub use admin::AdminScreen;
@@ -18,6 +19,7 @@ pub use common::ScreenContext;
 pub use file::FileScreen;
 pub use help::HelpScreen;
 pub use mail::MailScreen;
+pub use member::MemberScreen;
 pub use profile::ProfileScreen;
 
 use crate::server::CharacterEncoding;


### PR DESCRIPTION
## Summary
- 最初に登録したユーザーが自動的にSysOpになるように修正
- Chatコマンドが "not implemented" と表示されていた問題を修正
- 会員一覧[W]コマンドを新規追加

## Changes

### 1. 最初のユーザーをSysOpにする
- `handle_registration()` でユーザー数をチェック
- 最初のユーザーは `register_with_role()` で SysOp として登録

### 2. Chat画面の修正
- session_handler で直接 "not implemented" を表示していたのを修正
- `ChatScreen::run_list()` を呼び出すように変更
- `chat.room_name` ロケールキーを追加

### 3. 会員一覧[W]コマンドを追加
- `MenuAction::MemberList` を追加
- `MemberScreen` を新規作成
- ユーザー一覧を表示（ユーザー名、ニックネーム、権限）
- `member.*` ロケールキーを追加

## Test plan
- [x] `cargo test` - 全934テストがパス
- [x] 最初のユーザー登録でSysOpになることを確認
- [x] Chatコマンドでルーム一覧が表示されることを確認
- [x] 会員一覧[W]でメンバーリストが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)