### PR TITLE
feat: 端末プロファイル選択機能を実装 (Phase 10.8)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,3 +27,7 @@ path = "templates"
 [logging]
 level = "info"
 file = "logs/hobbs.log"
+
+[terminal]
+# Default terminal profile: standard (80x24), c64 (40x25, no ANSI), c64_ansi (40x25)
+default_profile = "standard"

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -29,7 +29,8 @@
 | 10.5 | 言語・エンコーディング動的選択 | 接続時の言語選択、ユーザー設定適用 | Phase 10 | ✅ |
 | 10.6 | チャット画面統合 | ChatScreenからルーム入室・発言 | Phase 5, 10 | 未着手 |
 | 10.7 | エンコーディング変換修正 | ScreenContextのエンコーディング引き継ぎ | Phase 10.5 | 未着手 |
-| 11+ | 将来拡張 | SSH対応, WebSocket等 | Phase 10.7 |
+| 10.8 | 端末プロファイル選択 | 40/80カラム切り替え、ログイン時適用 | Phase 10 | 進行中 |
+| 11+ | 将来拡張 | SSH対応, WebSocket等 | Phase 10.8 |
 
 ---
 
@@ -986,6 +987,67 @@ Select language / 言語選択:
 
 **関連ファイル**:
 - `tests/e2e_encoding.rs`
+
+---
+
+## Phase 10.8: 端末プロファイル選択
+
+### 10.8-1. config.tomlにデフォルト端末プロファイル設定を追加
+
+**概要**: システム全体のデフォルト端末プロファイルをconfig.tomlで設定可能にする
+
+**完了条件**:
+- [ ] `TerminalConfig` 構造体を追加（default_profile: "standard" | "c64" | "c64_ansi"）
+- [ ] `Config` 構造体に `terminal` フィールドを追加
+- [ ] デフォルト値（"standard"）を設定
+- [ ] 単体テスト
+
+**関連ファイル**:
+- `src/config.rs`
+- `config.toml`
+
+---
+
+### 10.8-2. SessionHandlerでの端末プロファイル適用
+
+**概要**: SessionHandlerで端末プロファイルを管理し、画面表示に反映する
+
+**完了条件**:
+- [ ] SessionHandlerに`terminal_profile`フィールドを追加
+- [ ] ログイン時にユーザーのterminal設定を読み込みプロファイル適用
+- [ ] ScreenContextへのプロファイル引き継ぎ
+- [ ] ゲストユーザーはconfig.tomlのデフォルトを使用
+- [ ] 統合テスト
+
+**関連ファイル**:
+- `src/app/session_handler.rs`
+- `src/app/screens/common.rs`
+
+---
+
+### 10.8-3. 設定画面での端末プロファイル変更
+
+**概要**: ユーザー設定画面で端末プロファイルを選択・保存できるようにする
+
+**画面イメージ**:
+```
+端末プロファイル:
+[S] Standard (80x24)
+[C] C64 (40x25, ANSI無効)
+[A] C64 ANSI (40x25)
+```
+
+**完了条件**:
+- [ ] プロフィール編集画面または設定画面に端末選択項目を追加
+- [ ] DBへの保存処理
+- [ ] 即時反映（セッション更新）
+- [ ] ローカライズメッセージ追加
+- [ ] 統合テスト
+
+**関連ファイル**:
+- `src/app/screens/profile.rs`
+- `locales/en.toml`
+- `locales/ja.toml`
 
 ---
 

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -241,6 +241,7 @@ nickname = "Nickname"
 
 [settings]
 terminal = "Terminal"
+terminal_profile = "Terminal Profile"
 language = "Language"
 encoding = "Encoding"
 width = "Width"
@@ -249,6 +250,14 @@ ansi_color = "ANSI Color"
 enabled = "Enabled"
 disabled = "Disabled"
 settings_saved = "Settings saved"
+
+[terminal]
+select_profile = "Select terminal profile"
+profile_standard = "Standard (80x24)"
+profile_c64 = "C64 (40x25, no ANSI)"
+profile_c64_ansi = "C64 ANSI (40x25)"
+profile_changed = "Terminal profile changed to {{profile}}"
+current_profile = "Current: {{profile}}"
 
 [admin]
 user_management = "User Management"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -241,6 +241,7 @@ nickname = "ニックネーム"
 
 [settings]
 terminal = "端末設定"
+terminal_profile = "端末プロファイル"
 language = "言語設定"
 encoding = "文字コード"
 width = "画面幅"
@@ -249,6 +250,14 @@ ansi_color = "ANSIカラー"
 enabled = "有効"
 disabled = "無効"
 settings_saved = "設定を保存しました"
+
+[terminal]
+select_profile = "端末プロファイルを選択してください"
+profile_standard = "Standard (80x24)"
+profile_c64 = "C64 (40x25, ANSI無効)"
+profile_c64_ansi = "C64 ANSI (40x25)"
+profile_changed = "端末プロファイルを{{profile}}に変更しました"
+current_profile = "現在: {{profile}}"
 
 [admin]
 user_management = "ユーザー管理"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -88,8 +88,22 @@ impl Application {
     }
 
     /// Create a session handler for a new connection.
-    pub fn create_session_handler(&self, profile: TerminalProfile) -> SessionHandler {
+    ///
+    /// Uses the default terminal profile from config.
+    pub fn create_session_handler(&self) -> SessionHandler {
         SessionHandler::new(
+            Arc::clone(&self.db),
+            Arc::clone(&self.config),
+            Arc::clone(&self.i18n_manager),
+            Arc::clone(&self.template_loader),
+            Arc::clone(&self.session_manager),
+            Arc::clone(&self.chat_manager),
+        )
+    }
+
+    /// Create a session handler with a specific terminal profile.
+    pub fn create_session_handler_with_profile(&self, profile: TerminalProfile) -> SessionHandler {
+        SessionHandler::with_profile(
             Arc::clone(&self.db),
             Arc::clone(&self.config),
             Arc::clone(&self.i18n_manager),
@@ -103,9 +117,9 @@ impl Application {
     /// Run a session.
     ///
     /// This is the main entry point for handling a connected client.
+    /// Uses the default terminal profile from config.
     pub async fn run_session(&self, session: &mut TelnetSession) -> Result<()> {
-        let profile = TerminalProfile::standard(); // TODO: Allow profile selection
-        let mut handler = self.create_session_handler(profile);
+        let mut handler = self.create_session_handler();
         handler.run(session).await
     }
 }

--- a/src/app/screens/mod.rs
+++ b/src/app/screens/mod.rs
@@ -35,12 +35,14 @@ pub enum ScreenResult {
     Logout,
     /// User wants to quit.
     Quit,
-    /// User changed language/encoding settings.
+    /// User changed language/encoding/terminal settings.
     SettingsChanged {
         /// New language setting (e.g., "en", "ja").
         language: String,
         /// New character encoding setting.
         encoding: CharacterEncoding,
+        /// New terminal profile (if changed).
+        terminal_profile: Option<String>,
     },
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,6 +201,26 @@ impl Default for LoggingConfig {
     }
 }
 
+/// Terminal configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TerminalConfig {
+    /// Default terminal profile (standard, c64, c64_ansi).
+    #[serde(default = "default_terminal_profile")]
+    pub default_profile: String,
+}
+
+fn default_terminal_profile() -> String {
+    "standard".to_string()
+}
+
+impl Default for TerminalConfig {
+    fn default() -> Self {
+        Self {
+            default_profile: default_terminal_profile(),
+        }
+    }
+}
+
 /// Main configuration structure.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
@@ -225,6 +245,9 @@ pub struct Config {
     /// Logging configuration.
     #[serde(default)]
     pub logging: LoggingConfig,
+    /// Terminal configuration.
+    #[serde(default)]
+    pub terminal: TerminalConfig,
 }
 
 impl Config {
@@ -267,6 +290,8 @@ mod tests {
 
         assert_eq!(config.logging.level, "info");
         assert_eq!(config.logging.file, "logs/hobbs.log");
+
+        assert_eq!(config.terminal.default_profile, "standard");
     }
 
     #[test]
@@ -299,6 +324,9 @@ path = "custom/templates"
 [logging]
 level = "debug"
 file = "custom/logs/app.log"
+
+[terminal]
+default_profile = "c64"
 "#;
 
         let config = Config::parse(toml).unwrap();
@@ -323,6 +351,8 @@ file = "custom/logs/app.log"
 
         assert_eq!(config.logging.level, "debug");
         assert_eq!(config.logging.file, "custom/logs/app.log");
+
+        assert_eq!(config.terminal.default_profile, "c64");
     }
 
     #[test]

--- a/src/terminal/profile.rs
+++ b/src/terminal/profile.rs
@@ -225,6 +225,37 @@ impl Default for TerminalProfile {
     }
 }
 
+impl TerminalProfile {
+    /// Create a terminal profile from a profile name string.
+    ///
+    /// Returns the matching preset profile, or the standard profile for unknown names.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Profile name ("standard", "c64", "c64_ansi")
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hobbs::terminal::TerminalProfile;
+    ///
+    /// let profile = TerminalProfile::from_name("c64");
+    /// assert_eq!(profile.width, 40);
+    /// ```
+    pub fn from_name(name: &str) -> Self {
+        match name.to_lowercase().as_str() {
+            "c64" => Self::c64(),
+            "c64_ansi" => Self::c64_ansi(),
+            _ => Self::standard(),
+        }
+    }
+
+    /// Get all available profile names.
+    pub fn available_profiles() -> &'static [&'static str] {
+        &["standard", "c64", "c64_ansi"]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -393,6 +424,45 @@ mod tests {
         let p1 = TerminalProfile::standard();
         let p2 = p1.clone();
         assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn test_from_name_standard() {
+        let profile = TerminalProfile::from_name("standard");
+        assert_eq!(profile, TerminalProfile::standard());
+    }
+
+    #[test]
+    fn test_from_name_c64() {
+        let profile = TerminalProfile::from_name("c64");
+        assert_eq!(profile, TerminalProfile::c64());
+    }
+
+    #[test]
+    fn test_from_name_c64_ansi() {
+        let profile = TerminalProfile::from_name("c64_ansi");
+        assert_eq!(profile, TerminalProfile::c64_ansi());
+    }
+
+    #[test]
+    fn test_from_name_case_insensitive() {
+        assert_eq!(TerminalProfile::from_name("C64"), TerminalProfile::c64());
+        assert_eq!(TerminalProfile::from_name("C64_ANSI"), TerminalProfile::c64_ansi());
+        assert_eq!(TerminalProfile::from_name("STANDARD"), TerminalProfile::standard());
+    }
+
+    #[test]
+    fn test_from_name_unknown() {
+        let profile = TerminalProfile::from_name("unknown");
+        assert_eq!(profile, TerminalProfile::standard());
+    }
+
+    #[test]
+    fn test_available_profiles() {
+        let profiles = TerminalProfile::available_profiles();
+        assert!(profiles.contains(&"standard"));
+        assert!(profiles.contains(&"c64"));
+        assert!(profiles.contains(&"c64_ansi"));
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -525,6 +525,7 @@ pub fn test_config() -> Config {
         },
         files: Default::default(),
         templates: Default::default(),
+        terminal: Default::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

- config.tomlに`[terminal]`セクションを追加し、デフォルト端末プロファイルを設定可能に
- ログイン時にユーザーの保存済み端末プロファイル（standard/c64/c64_ansi）を自動適用
- 設定画面から端末プロファイルを変更・保存できるUIを追加

## 変更内容

### 新機能
- `TerminalProfile::from_name()` - 文字列からプロファイルを生成
- `TerminalProfile::available_profiles()` - 利用可能なプロファイル一覧を取得
- `SessionHandler::set_terminal_profile()` - 端末プロファイルを動的に変更
- 設定画面に端末プロファイル選択オプションを追加

### 設定
```toml
[terminal]
default_profile = "standard"  # standard, c64, c64_ansi
```

### 端末プロファイル
| プロファイル | サイズ | ANSI |
|-------------|--------|------|
| standard | 80x24 | 有効 |
| c64 | 40x25 | 無効 |
| c64_ansi | 40x25 | 有効 |

## Test plan

- [x] 全テストがパス (`cargo test`)
- [x] E2Eプロファイル設定テストが端末プロファイル選択ステップに対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)