### PR TITLE
feat: 未読一気読み機能を実装

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -164,6 +164,10 @@ page_of = "Page {{current}} of {{total}}"
 unread = "Unread"
 mark_read = "Mark as read"
 mark_all_read = "Mark all as read"
+read_unread = "Read Unread"
+no_unread = "No unread posts"
+unread_count = "Showing {{count}} unread posts"
+unread_complete = "All unread posts have been read"
 
 [chat]
 room_list = "Chat Rooms"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -164,6 +164,10 @@ page_of = "{{current}} / {{total}} ページ"
 unread = "未読"
 mark_read = "既読にする"
 mark_all_read = "すべて既読にする"
+read_unread = "未読を読む"
+no_unread = "未読がありません"
+unread_count = "未読{{count}}件を表示します"
+unread_complete = "未読をすべて読みました"
 
 [chat]
 room_list = "チャットルーム一覧"


### PR DESCRIPTION
## Summary

- スレッド形式・フラット形式の掲示板に[U]オプションを追加
- ログインユーザーのみ[U]オプションが表示される
- 未読投稿を順番に表示し、各投稿後に[N]次へ/[Q]終了のプロンプト
- 表示した投稿は自動的に既読としてマーク
- ローカライズ対応（日英）

## Test plan

- [x] cargo build 通過
- [x] cargo test (掲示板関連テスト全て通過)
- [x] 実機テスト: スレッド形式掲示板で[U]を押して未読一気読み
- [x] 実機テスト: フラット形式掲示板で[U]を押して未読一気読み
- [x] 実機テスト: 未読がない場合のメッセージ確認
- [x] 実機テスト: 途中で[Q]を押して中断できることを確認

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)