### PR TITLE
feat: 投稿閲覧時の自動既読マーク機能を実装

### DIFF
--- a/src/app/screens/board.rs
+++ b/src/app/screens/board.rs
@@ -488,6 +488,14 @@ impl BoardScreen {
                     ctx.send_line(session, &post.body).await?;
                     ctx.send_line(session, "").await?;
                 }
+
+                // Mark the last displayed post as read for logged-in users
+                if let Some(user_id) = session.user_id() {
+                    if let Some(last_post) = result.items.last() {
+                        let unread_repo = UnreadRepository::new(&ctx.db);
+                        unread_repo.mark_as_read(user_id, thread.board_id, last_post.id)?;
+                    }
+                }
             }
 
             // Show pagination
@@ -571,6 +579,12 @@ impl BoardScreen {
         ctx.send_line(session, &"-".repeat(40)).await?;
         ctx.send_line(session, &post.body).await?;
         ctx.send_line(session, &"-".repeat(40)).await?;
+
+        // Mark this post as read for logged-in users
+        if let Some(user_id) = session.user_id() {
+            let unread_repo = UnreadRepository::new(&ctx.db);
+            unread_repo.mark_as_read(user_id, post.board_id, post_id)?;
+        }
 
         ctx.wait_for_enter(session).await?;
         Ok(ScreenResult::Back)


### PR DESCRIPTION
## Summary

- スレッド表示時: 表示したページの最後の投稿IDで既読マーク
- フラット形式: 投稿を表示したら即座に既読マーク
- ページ送り(N/P)で新しい投稿を見た際も自動的に既読マーク
- ゲストユーザーはスキップ（user_id が None の場合）

## Test plan

- [x] cargo build 通過
- [x] cargo test 全テスト通過
- [x] 実機テスト: スレッド表示後に未読数が減ることを確認
- [x] 実機テスト: フラット投稿表示後に未読数が減ることを確認
- [x] 実機テスト: ページ送りで次ページ表示後に既読マークされることを確認

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)