### PR TITLE
feat: 全掲示板の未読一気読み機能を実装

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -170,6 +170,10 @@ unread_complete = "All unread posts have been read"
 mark_all_read = "Mark All Read"
 mark_all_read_confirm = "Mark all posts as read? [Y/N]: "
 marked_all_read = "All posts marked as read"
+read_all_unread = "Read All Unread"
+no_unread_all = "No unread posts in any board"
+unread_all_count = "Showing {{count}} unread posts from all boards"
+unread_all_complete = "All unread posts have been read"
 
 [chat]
 room_list = "Chat Rooms"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -170,6 +170,10 @@ unread_complete = "未読をすべて読みました"
 mark_all_read = "全て既読"
 mark_all_read_confirm = "全ての投稿を既読にしますか？ [Y/N]: "
 marked_all_read = "全ての投稿を既読にしました"
+read_all_unread = "全未読一気読み"
+no_unread_all = "全掲示板に未読がありません"
+unread_all_count = "全掲示板から未読{{count}}件を表示します"
+unread_all_complete = "全ての未読を読みました"
 
 [chat]
 room_list = "チャットルーム一覧"

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -24,4 +24,4 @@ pub use service::{BoardService, PaginatedResult, Pagination};
 pub use thread::{NewThread, Thread, ThreadUpdate};
 pub use thread_repository::ThreadRepository;
 pub use types::{Board, BoardType, BoardUpdate, NewBoard};
-pub use unread::{ReadPosition, UnreadRepository};
+pub use unread::{ReadPosition, UnreadPostWithBoard, UnreadRepository};


### PR DESCRIPTION
## Summary

掲示板一覧画面から、複数の掲示板をまたがって全ての未読投稿を一気読みする機能を実装しました。

- 掲示板一覧画面に `[U]=全未読一気読み` オプションを追加（ログインユーザーのみ）
- `UnreadRepository` に `get_all_unread_posts()` メソッドを追加
  - 全掲示板から未読投稿を取得
  - アクセス権限を考慮（`min_read_role` でフィルタリング）
- `UnreadRepository` に `get_total_unread_count()` メソッドを追加
- `UnreadPostWithBoard` 構造体を追加（投稿 + 掲示板名）
- 各投稿表示時に掲示板名を表示
- 閲覧した投稿は即座に既読マーク
- 新規メソッドの単体テストを7件追加
- ローカライズメッセージを追加

## 画面イメージ

```
選択してください: [U]=全未読一気読み [Q=戻る]: u

全掲示板から未読3件を表示します

=== [1/3] [一般] 新機能について ===
投稿者: admin (2024-01-15 10:30:00)
----------------------------------------
こんにちは、新機能についてお知らせします。
----------------------------------------
[N]=次へ [Q]=終了: 
```

Closes #124

## Test plan

- [x] cargo test がすべて成功することを確認
- [x] 掲示板一覧画面で [U] オプションが表示される（ログインユーザーのみ）
- [x] [U] 選択時、全掲示板の未読投稿が順番に表示される
- [x] 各投稿に掲示板名が表示される
- [x] 表示した投稿が既読としてマークされる
- [x] [Q] で途中終了できる
- [x] ゲストユーザーには [U] オプションが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)