### PR TITLE
feat: 複数行入力のキャンセル機能を追加

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -30,7 +30,8 @@ user = "User"
 current = "Online"
 people = ""
 only = " only"
-end_with_dot = "End with . on a new line"
+end_with_dot = "End with . on a new line, /c to cancel"
+input_cancelled = "Input cancelled"
 
 [system]
 name = "HOBBS"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -30,7 +30,8 @@ user = "ユーザー"
 current = "現在"
 people = "人"
 only = "のみ"
-end_with_dot = "終了は . のみの行で"
+end_with_dot = "終了は . のみの行で、中止は /c"
+input_cancelled = "入力を中止しました"
 
 [system]
 name = "HOBBS"

--- a/src/app/screens/board.rs
+++ b/src/app/screens/board.rs
@@ -736,7 +736,10 @@ impl BoardScreen {
             ),
         )
         .await?;
-        let body = Self::read_multiline(ctx, session).await?;
+        let body = match ctx.read_multiline(session).await? {
+            Some(text) => text,
+            None => return Ok(()), // Cancelled
+        };
 
         if body.is_empty() {
             return Ok(());
@@ -795,7 +798,10 @@ impl BoardScreen {
             ),
         )
         .await?;
-        let body = Self::read_multiline(ctx, session).await?;
+        let body = match ctx.read_multiline(session).await? {
+            Some(text) => text,
+            None => return Ok(()), // Cancelled
+        };
 
         if body.is_empty() {
             return Ok(());
@@ -1086,27 +1092,6 @@ impl BoardScreen {
         }
 
         Ok(ScreenResult::Back)
-    }
-
-    /// Read multiline input (ends with a line containing only ".").
-    async fn read_multiline(
-        ctx: &mut ScreenContext,
-        session: &mut TelnetSession,
-    ) -> Result<String> {
-        let mut lines = Vec::new();
-
-        loop {
-            ctx.send(session, "> ").await?;
-            let line = ctx.read_line(session).await?;
-
-            if line.trim() == "." {
-                break;
-            }
-
-            lines.push(line);
-        }
-
-        Ok(lines.join("\n"))
     }
 
     /// Get user role from session.

--- a/src/app/screens/mail.rs
+++ b/src/app/screens/mail.rs
@@ -265,7 +265,10 @@ impl MailScreen {
             ),
         )
         .await?;
-        let body = Self::read_multiline(ctx, session).await?;
+        let body = match ctx.read_multiline(session).await? {
+            Some(text) => text,
+            None => return Ok(()), // Cancelled
+        };
 
         if body.is_empty() {
             return Ok(());
@@ -323,7 +326,10 @@ impl MailScreen {
             ),
         )
         .await?;
-        let body = Self::read_multiline(ctx, session).await?;
+        let body = match ctx.read_multiline(session).await? {
+            Some(text) => text,
+            None => return Ok(()), // Cancelled
+        };
 
         if body.is_empty() {
             return Ok(());
@@ -346,26 +352,6 @@ impl MailScreen {
         Ok(())
     }
 
-    /// Read multiline input.
-    async fn read_multiline(
-        ctx: &mut ScreenContext,
-        session: &mut TelnetSession,
-    ) -> Result<String> {
-        let mut lines = Vec::new();
-
-        loop {
-            ctx.send(session, "> ").await?;
-            let line = ctx.read_line(session).await?;
-
-            if line.trim() == "." {
-                break;
-            }
-
-            lines.push(line);
-        }
-
-        Ok(lines.join("\n"))
-    }
 }
 
 #[cfg(test)]

--- a/src/app/screens/profile.rs
+++ b/src/app/screens/profile.rs
@@ -194,11 +194,10 @@ impl ProfileScreen {
             ),
         )
         .await?;
-        let profile_text = Self::read_multiline(ctx, session).await?;
-        let new_profile = if profile_text.is_empty() {
-            None
-        } else {
-            Some(Some(profile_text))
+        let new_profile = match ctx.read_multiline(session).await? {
+            Some(text) if !text.is_empty() => Some(Some(text)),
+            Some(_) => None, // Empty input, no change
+            None => return Ok(()), // Cancelled
         };
 
         // Build update request
@@ -511,27 +510,6 @@ impl ProfileScreen {
             "c64_ansi" => ctx.i18n.t("terminal.profile_c64_ansi").to_string(),
             _ => ctx.i18n.t("terminal.profile_standard").to_string(),
         }
-    }
-
-    /// Read multiline input.
-    async fn read_multiline(
-        ctx: &mut ScreenContext,
-        session: &mut TelnetSession,
-    ) -> Result<String> {
-        let mut lines = Vec::new();
-
-        loop {
-            ctx.send(session, "> ").await?;
-            let line = ctx.read_line(session).await?;
-
-            if line.trim() == "." {
-                break;
-            }
-
-            lines.push(line);
-        }
-
-        Ok(lines.join("\n"))
     }
 }
 


### PR DESCRIPTION
## Summary
- 掲示板投稿・メール作成・プロフィール編集時の複数行入力で `/c` または `/cancel` を入力するとキャンセル可能に
- `ScreenContext::read_multiline` を共通メソッドとして追加し、3つのファイルに重複していた実装を統合
- キャンセル時に確認メッセージを表示

## 変更内容
- `src/app/screens/common.rs`: `read_multiline` メソッド追加 (Option<String>を返す)
- `src/app/screens/board.rs`: 新規スレッド・返信投稿でキャンセル対応
- `src/app/screens/mail.rs`: メール作成・返信でキャンセル対応
- `src/app/screens/profile.rs`: 自己紹介編集でキャンセル対応
- `locales/ja.toml`, `locales/en.toml`: メッセージ追加

## Test plan
- [x] `cargo build` 成功
- [x] `cargo test` 全テスト通過
- [x] 実機テスト: 掲示板投稿中に `/c` でキャンセルできることを確認
- [x] 実機テスト: メール作成中に `/cancel` でキャンセルできることを確認

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)