### PR TITLE
feat: 管理画面に掲示板削除機能を追加

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -323,6 +323,12 @@ folder_created = "Folder '{{name}}' created"
 folder_deleted = "Folder '{{name}}' deleted"
 folder_not_found = "Folder not found"
 folder_has_files = "This folder contains {{count}} files. Delete anyway?"
+board_list = "Board List"
+sysop_required = "SysOp permission is required for this operation"
+board_number_to_delete = "Board number to delete"
+board_delete_confirm = "Delete board '{{name}}'? This will delete {{threads}} threads and {{posts}} posts."
+board_deleted = "Board '{{name}}' deleted"
+board_not_found = "Board not found"
 
 [role]
 guest = "Guest"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -327,6 +327,12 @@ folder_created = "フォルダ「{{name}}」を作成しました"
 folder_deleted = "フォルダ「{{name}}」を削除しました"
 folder_not_found = "フォルダが見つかりません"
 folder_has_files = "このフォルダには{{count}}件のファイルがあります。削除しますか？"
+board_list = "掲示板一覧"
+sysop_required = "この操作にはシステム管理者権限が必要です"
+board_number_to_delete = "削除する掲示板番号"
+board_delete_confirm = "掲示板「{{name}}」を削除します。スレッド{{threads}}件、投稿{{posts}}件が削除されます。本当に削除しますか？"
+board_deleted = "掲示板「{{name}}」を削除しました"
+board_not_found = "掲示板が見つかりません"
 
 [role]
 guest = "ゲスト"

--- a/src/board/post_repository.rs
+++ b/src/board/post_repository.rs
@@ -219,6 +219,16 @@ impl<'a> PostRepository<'a> {
         Ok(count)
     }
 
+    /// Count all posts in a board (both flat and thread posts).
+    pub fn count_by_board(&self, board_id: i64) -> Result<i64> {
+        let count: i64 = self.db.conn().query_row(
+            "SELECT COUNT(*) FROM posts WHERE board_id = ?",
+            [board_id],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
     /// Get the latest post in a thread.
     pub fn get_latest_in_thread(&self, thread_id: i64) -> Result<Option<Post>> {
         let result = self.db.conn().query_row(


### PR DESCRIPTION
## Summary
- 管理画面に[3]掲示板削除メニューを追加（SysOp専用）
- 削除前にスレッド数と投稿数を確認表示して二重確認
- 外部キー制約 (ON DELETE CASCADE) による関連データ自動削除

## Changes
- `src/app/screens/admin.rs`: 掲示板削除機能のUI実装
- `src/board/post_repository.rs`: `count_by_board()` メソッド追加
- `locales/ja.toml`, `locales/en.toml`: ローカライズメッセージ追加

## Test plan
- [x] SysOpで管理画面 > 掲示板管理 > 掲示板削除を開く
- [x] 掲示板一覧にスレッド/投稿数が表示されることを確認
- [x] SubOpでは権限エラーになることを確認
- [x] 削除確認でNを選択すると中止されることを確認
- [x] 削除確認でYを選択すると掲示板と関連データが削除されることを確認

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)