### PR TITLE
feat: チャットルームに最大参加者数制限を追加

### DIFF
--- a/src/app/screens/chat.rs
+++ b/src/app/screens/chat.rs
@@ -8,7 +8,7 @@ use super::common::ScreenContext;
 use super::ScreenResult;
 use crate::chat::{
     format_help, format_who, parse_input, ChatCommand, ChatInput, ChatLogRepository, ChatMessage,
-    ChatParticipant, ChatRoom, NewChatLog,
+    ChatParticipant, ChatRoom, JoinResult, NewChatLog,
 };
 use crate::error::Result;
 use crate::server::TelnetSession;
@@ -122,7 +122,14 @@ impl ChatScreen {
 
         // Join the room
         let participant = ChatParticipant::new(&session_id, user_id, &nickname);
-        room.join(participant).await;
+        match room.join(participant).await {
+            JoinResult::Joined => {}
+            JoinResult::AlreadyJoined => {}
+            JoinResult::RoomFull => {
+                ctx.send_line(session, ctx.i18n.t("chat.room_full")).await?;
+                return Ok(ScreenResult::Back);
+            }
+        }
 
         // Subscribe to messages
         let mut receiver = room.subscribe();

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -18,4 +18,6 @@ pub use command::{
 };
 pub use log::{ChatLog, ChatLogRepository, NewChatLog, DEFAULT_RECENT_LOG_COUNT};
 pub use manager::{ChatRoomManager, DeleteRoomError, RoomInfo};
-pub use room::{ChatMessage, ChatParticipant, ChatRoom, MessageType};
+pub use room::{
+    ChatMessage, ChatParticipant, ChatRoom, JoinResult, MessageType, MAX_PARTICIPANTS_PER_ROOM,
+};


### PR DESCRIPTION
## Summary

- チャットルームへの参加者数を最大100人に制限
- 満員の場合は入室を拒否してメッセージを表示

## Changes

- `MAX_PARTICIPANTS_PER_ROOM` (100) 定数を追加
- `ChatRoom::join()` が `JoinResult` を返すように変更
  - `Joined`: 成功
  - `AlreadyJoined`: 既に参加中
  - `RoomFull`: 満員
- `ChatRoomManager::join_room()` を `Result<Arc<ChatRoom>, JoinResult>` に変更
- チャット画面で満員時に `chat.room_full` メッセージを表示

## Test plan

- [x] `test_chat_room_join_full` テストを追加
- [x] 既存のチャット関連テストがすべて通ること

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)