### PR TITLE
feat: XMODEM受信にファイルサイズ制限を追加

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -248,6 +248,7 @@ xmodem_complete = "Transfer complete"
 xmodem_failed = "Transfer failed"
 xmodem_cancelled = "Transfer cancelled"
 xmodem_timeout = "Transfer timed out"
+xmodem_file_too_large = "File exceeds size limit"
 
 [profile]
 title = "Profile"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -252,6 +252,7 @@ xmodem_complete = "転送が完了しました"
 xmodem_failed = "転送に失敗しました"
 xmodem_cancelled = "転送がキャンセルされました"
 xmodem_timeout = "転送がタイムアウトしました"
+xmodem_file_too_large = "ファイルサイズが制限を超えています"
 
 [profile]
 title = "プロフィール"


### PR DESCRIPTION
## Summary

- XMODEM受信時にファイルサイズ制限を適用
- 設定の `max_upload_size_mb`（デフォルト10MB）を使用

## Changes

- `xmodem_receive()` に `max_size` パラメータを追加
- 受信中にサイズ制限を超えた場合：
  - CAN を2回送信して転送を中止
  - `TransferError::FileTooLarge` エラーを返す
- ファイル画面でサイズ超過時のエラーメッセージを表示
- ローカライズメッセージ `xmodem_file_too_large` を追加

## Security Impact

悪意のあるクライアントが無限にデータを送信してメモリを枯渇させる攻撃を防止。

## Test plan

- [x] `test_transfer_error_display` テストで FileTooLarge エラーを確認
- [x] ビルド成功

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)