### PR TITLE
feat: チャットメッセージに文字数制限を追加

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -195,6 +195,7 @@ private_message = "Private Message"
 whisper_to = "To {{nickname}}: "
 whisper_from = "From {{nickname}}: "
 command_help = "Type /help for commands"
+message_too_long = "Message too long (max {{max}} chars)"
 
 [mail]
 inbox = "Inbox"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -199,6 +199,7 @@ private_message = "プライベートメッセージ"
 whisper_to = "{{nickname}}さんへ: "
 whisper_from = "{{nickname}}さんから: "
 command_help = "/help でコマンド一覧を表示"
+message_too_long = "メッセージが長すぎます（{{max}}文字以内）"
 
 [mail]
 inbox = "受信箱"


### PR DESCRIPTION
## Summary

- チャットメッセージにメモリ枯渇防止のための文字数制限を追加
- 最大500文字（CLAUDE.mdの仕様に準拠）
- 通常メッセージと `/me` アクションメッセージの両方に適用

## 変更内容

- `MAX_CHAT_MESSAGE_LENGTH = 500` 定数を追加
- `chat_loop` 内でメッセージ送信前にバリデーション
- Unicode文字対応（`.chars().count()` で計測）
- 超過時にエラーメッセージを表示
- ローカライズメッセージを追加 (ja/en)
- 5件のテストを追加

## Test plan

- [x] `cargo test chat::tests` - 5件パス
- [x] `cargo build` - ビルド成功

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)