### PR TITLE
feat: 複数行入力に行数制限を追加

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -32,6 +32,7 @@ people = ""
 only = " only"
 end_with_dot = "End with . on a new line, /c to cancel"
 input_cancelled = "Input cancelled"
+too_many_lines = "Too many lines (max {{max}})"
 
 [system]
 name = "HOBBS"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -32,6 +32,7 @@ people = "人"
 only = "のみ"
 end_with_dot = "終了は . のみの行で、中止は /c"
 input_cancelled = "入力を中止しました"
+too_many_lines = "行数が多すぎます（{{max}}行以内）"
 
 [system]
 name = "HOBBS"


### PR DESCRIPTION
## Summary

- `read_multiline()`に行数制限（`MAX_MULTILINE_LINES = 1000`）を追加
- 制限を超えた場合はエラーメッセージを表示して入力をキャンセル
- メモリ枯渇攻撃（DoS）を防止

## Changes

- `src/app/screens/common.rs`: `MAX_MULTILINE_LINES`定数を追加、`read_multiline()`に行数チェックを追加
- `locales/ja.toml`: エラーメッセージ `common.too_many_lines` を追加
- `locales/en.toml`: 英語版エラーメッセージを追加
- 単体テストを追加

## Test plan

- [x] `cargo test screens::common` - 全テストパス
- [x] `cargo check` - コンパイル成功

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)