### PR TITLE
feat: プロフィール画面のテンプレート化

### DIFF
--- a/src/app/session_handler.rs
+++ b/src/app/session_handler.rs
@@ -841,50 +841,6 @@ Select language / Gengo sentaku:
         Ok(())
     }
 
-    /// Show profile screen.
-    async fn show_profile(&self, session: &mut TelnetSession) -> Result<()> {
-        if let Some(user_id) = session.user_id() {
-            let user_repo = UserRepository::new(&self.db);
-
-            if let Ok(Some(user)) = user_repo.get_by_id(user_id) {
-                let mut context = self.create_context();
-                context.set("user.id", Value::number(user.id));
-                context.set("user.username", Value::string(user.username.clone()));
-                context.set("user.nickname", Value::string(user.nickname.clone()));
-                context.set(
-                    "user.email",
-                    Value::string(user.email.clone().unwrap_or_default()),
-                );
-                context.set("user.role", Value::string(format!("{:?}", user.role)));
-
-                // TODO: Use profile template when available
-                self.send_line(
-                    session,
-                    &format!("=== {} ===", self.i18n.t("profile.title")),
-                )
-                .await?;
-                self.send_line(
-                    session,
-                    &format!("{}: {}", self.i18n.t("profile.username"), user.username),
-                )
-                .await?;
-                self.send_line(
-                    session,
-                    &format!("{}: {}", self.i18n.t("profile.nickname"), user.nickname),
-                )
-                .await?;
-            }
-        }
-
-        // Wait for key press
-        self.send(session, self.i18n.t("common.press_enter"))
-            .await?;
-        let mut buf = [0u8; 1];
-        let _ = session.stream_mut().read(&mut buf).await;
-
-        Ok(())
-    }
-
     /// Check if the user is an admin.
     async fn is_admin(&self, session: &TelnetSession) -> bool {
         if let Some(user_id) = session.user_id() {

--- a/templates/40/profile.txt
+++ b/templates/40/profile.txt
@@ -1,0 +1,16 @@
+========================================
+  {{t "profile.title"}}
+========================================
+
+ {{t "profile.username"}}  : {{user.username}}
+ {{t "profile.nickname"}}  : {{user.nickname}}
+ {{t "auth.email"}}        : {{user.email}}
+ {{t "member.role"}}       : {{user.role_name}}
+ {{t "profile.member_since"}}: {{user.created_at}}
+ {{t "profile.last_login_short"}}: {{user.last_login}}
+{{#if user.bio}}
+
+ --- {{t "profile.bio"}} ---
+ {{user.bio}}
+{{/if}}
+

--- a/templates/80/profile.txt
+++ b/templates/80/profile.txt
@@ -1,0 +1,16 @@
+================================================================================
+    {{t "profile.title"}}
+================================================================================
+
+    {{t "profile.username"}}    : {{user.username}}
+    {{t "profile.nickname"}}    : {{user.nickname}}
+    {{t "auth.email"}}          : {{user.email}}
+    {{t "member.role"}}         : {{user.role_name}}
+    {{t "profile.member_since"}}: {{user.created_at}}
+    {{t "profile.last_login"}}  : {{user.last_login}}
+{{#if user.bio}}
+
+    --- {{t "profile.bio"}} ---
+    {{user.bio}}
+{{/if}}
+


### PR DESCRIPTION
## Summary
- 80カラム・40カラム用のプロフィールテンプレートを作成
- ProfileScreen をテンプレート描画方式に変更
- session_handler.rs の未使用メソッド `show_profile` を削除

## 変更内容
- `templates/80/profile.txt`: 新規作成
- `templates/40/profile.txt`: 新規作成
- `src/app/screens/profile.rs`: テンプレート描画に変更
- `src/app/session_handler.rs`: 未使用メソッド削除

## 対応Issue
Closes #132

## Test plan
- [x] `cargo build` が成功することを確認
- [x] プロフィール画面が正しく表示されることを確認
- [x] 80カラム・40カラムの両方でレイアウトが適切であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)