### PR TITLE
feat: 管理メニューにユーザーロール変更機能を追加

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -352,6 +352,11 @@ select_permission = "Select permission level"
 new_name = "New name"
 new_description = "New description"
 keep_current = "Keep current"
+user_number_to_change_role = "User number to change role"
+select_new_role = "Select new role"
+role_changed = "User '{{name}}' role changed to {{role}}"
+cannot_change_own_role = "Cannot change your own role"
+cannot_demote_last_sysop = "Cannot demote the last SysOp"
 
 [role]
 guest = "Guest"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -356,6 +356,11 @@ select_permission = "権限を選択してください"
 new_name = "新しい名前"
 new_description = "新しい説明"
 keep_current = "現在のまま"
+user_number_to_change_role = "ロールを変更するユーザー番号"
+select_new_role = "新しいロールを選択"
+role_changed = "ユーザー「{{name}}」のロールを{{role}}に変更しました"
+cannot_change_own_role = "自分自身のロールは変更できません"
+cannot_demote_last_sysop = "最後のSysOpを降格できません"
 
 [role]
 guest = "ゲスト"


### PR DESCRIPTION
## Summary

- 管理メニューに [6] ユーザーロール変更 を追加（SysOp専用）
- ユーザー一覧からロール変更対象を選択
- Guest/Member/SubOp/SysOp の4ロールから選択可能
- 自分自身のロール変更・最後のSysOp降格を防止
- i18nメッセージを日英で追加

## Test plan

- [x] SysOpでログイン後、管理メニューで [6] が表示されることを確認
- [x] SubOpでは [6] が表示されないことを確認
- [x] ユーザー一覧からロール変更できることを確認
- [x] 自分自身のロール変更がエラーになることを確認

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)