### PR TITLE
feat: 管理メニューにパスワードリセット機能を追加

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -381,6 +381,11 @@ session_state_mail = "Mail"
 session_state_files = "Files"
 session_state_admin = "Admin"
 session_state_closing = "Closing"
+user_number_to_reset_password = "User number to reset password"
+confirm_reset_password = "Reset password for '{{name}}'? [Y/N]"
+password_reset_success = "Password has been reset"
+new_password_is = "New password: {{password}}"
+password_reset_note = "* This password will only be shown once. Please share it with the user."
 
 [role]
 guest = "Guest"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -385,6 +385,11 @@ session_state_mail = "メール"
 session_state_files = "ファイル"
 session_state_admin = "管理メニュー"
 session_state_closing = "切断中"
+user_number_to_reset_password = "パスワードをリセットするユーザー番号"
+confirm_reset_password = "ユーザー「{{name}}」のパスワードをリセットしますか？ [Y/N]"
+password_reset_success = "パスワードをリセットしました"
+new_password_is = "新しいパスワード: {{password}}"
+password_reset_note = "※ このパスワードは一度しか表示されません。ユーザーに伝えてください。"
 
 [role]
 guest = "ゲスト"


### PR DESCRIPTION
## Summary

- 管理メニューに [10] パスワードリセット を追加
- ユーザー一覧からリセット対象を選択
- 確認ダイアログで Y/N 確認
- リセット後に新パスワードを表示（ランダム12文字）
- 権限チェック（SubOpはSubOp以上のユーザーを操作不可）
- i18nメッセージを日英で追加

## Test plan

- [x] SubOp/SysOpでログイン後、管理メニューで [10] パスワードリセット を選択
- [x] ユーザー一覧が表示されることを確認
- [x] ユーザーを選択してリセットできることを確認
- [x] 新パスワードが表示されることを確認
- [x] SubOpがSubOp以上のユーザーをリセットしようとするとエラーになることを確認

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)