### PR TITLE
feat: スクリプトメタデータの多言語対応

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rusqlite",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
@@ -381,6 +382,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
@@ -775,6 +782,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.148"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1311,3 +1331,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317f17ff091ac4515f17cc7a190d2769a8c9a96d227de5d64b500b01cda8f2cd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ argon2 = { version = "0.5", features = ["std"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/examples/scripts/dice.lua
+++ b/examples/scripts/dice.lua
@@ -1,5 +1,7 @@
 -- @name Dice Roller
+-- @name.ja サイコロ
 -- @description Roll dice with customizable sides
+-- @description.ja 様々な面数のサイコロを振ろう
 -- @author HOBBS Sample
 -- @min_role 0
 

--- a/examples/scripts/fortune.lua
+++ b/examples/scripts/fortune.lua
@@ -1,5 +1,7 @@
 -- @name Daily Fortune
+-- @name.ja 今日の運勢
 -- @description Get a random fortune message
+-- @description.ja ランダムな運勢メッセージ
 -- @author HOBBS Sample
 -- @min_role 0
 

--- a/examples/scripts/hello.lua
+++ b/examples/scripts/hello.lua
@@ -1,5 +1,7 @@
 -- @name Hello World
+-- @name.ja ハローワールド
 -- @description Simple greeting script that demonstrates BBS API
+-- @description.ja BBS APIのデモンストレーション
 -- @author HOBBS Sample
 -- @min_role 0
 

--- a/examples/scripts/janken.lua
+++ b/examples/scripts/janken.lua
@@ -1,5 +1,7 @@
 -- @name Janken
+-- @name.ja じゃんけん
 -- @description Rock-Paper-Scissors game with win/loss tracking
+-- @description.ja じゃんけんゲーム（勝敗記録付き）
 -- @author HOBBS Sample
 -- @min_role 0
 

--- a/examples/scripts/number_guess.lua
+++ b/examples/scripts/number_guess.lua
@@ -1,5 +1,7 @@
 -- @name Number Guess
+-- @name.ja 数当てゲーム
 -- @description Guess a number between 1-100. High score tracking included.
+-- @description.ja 1〜100の数を当てよう（ハイスコア記録付き）
 -- @author HOBBS Sample
 -- @min_role 0
 

--- a/examples/scripts/omikuji.lua
+++ b/examples/scripts/omikuji.lua
@@ -1,5 +1,7 @@
 -- @name Omikuji
+-- @name.ja おみくじ
 -- @description Daily fortune drawing. Can only draw once per day.
+-- @description.ja 一日一回のおみくじ
 -- @author HOBBS Sample
 -- @min_role 0
 

--- a/examples/scripts/quiz.lua
+++ b/examples/scripts/quiz.lua
@@ -1,5 +1,7 @@
 -- @name Quiz Game
+-- @name.ja クイズゲーム
 -- @description Test your knowledge with trivia questions
+-- @description.ja トリビアクイズに挑戦
 -- @author HOBBS Sample
 -- @min_role 0
 

--- a/src/app/screens/script.rs
+++ b/src/app/screens/script.rs
@@ -36,17 +36,19 @@ impl ScriptScreen {
             let service = ScriptService::new(&ctx.db).with_scripts_dir(&scripts_dir);
             let scripts = service.list_scripts(user_role)?;
 
-            // Display scripts
+            // Display scripts with localized names/descriptions
+            let lang = ctx.i18n.locale();
             if scripts.is_empty() {
                 ctx.send_line(session, &ctx.i18n.t("script.no_scripts"))
                     .await?;
             } else {
                 for (i, script) in scripts.iter().enumerate() {
-                    let description = script.description.as_deref().unwrap_or("");
+                    let name = script.get_name(lang);
+                    let description = script.get_description(lang).unwrap_or("");
                     let line = format!(
                         "  [{:>2}] {}{}",
                         i + 1,
-                        script.name,
+                        name,
                         if description.is_empty() {
                             String::new()
                         } else {
@@ -124,8 +126,12 @@ impl ScriptScreen {
         // Create script context
         let script_context = Self::create_script_context(ctx, session);
 
+        // Display script header with localized name
+        let lang = ctx.i18n.locale();
+        let name = script.get_name(lang);
+
         ctx.send_line(session, "").await?;
-        ctx.send_line(session, &format!("--- {} ---", script.name))
+        ctx.send_line(session, &format!("--- {} ---", name))
             .await?;
         ctx.send_line(session, "").await?;
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -232,6 +232,13 @@ CREATE INDEX idx_script_logs_script ON script_logs(script_id);
 CREATE INDEX idx_script_logs_user ON script_logs(user_id);
 CREATE INDEX idx_script_logs_executed_at ON script_logs(executed_at);
 "#,
+    // v15: Script metadata localization
+    r#"
+-- Add i18n columns for script metadata localization
+-- Stored as JSON: {"ja": "日本語名", "de": "Deutscher Name"}
+ALTER TABLE scripts ADD COLUMN name_i18n TEXT;
+ALTER TABLE scripts ADD COLUMN description_i18n TEXT;
+"#,
 ];
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

スクリプトのメタデータ（名前・説明）を多言語化する機能を実装しました。

- `@name.ja`, `@description.ja` 形式のメタデータアノテーションをサポート
- ScriptScreen でユーザーの言語設定に応じたローカライズ表示
- DBに JSON 形式で i18n データを永続化
- サンプルスクリプト全7種に日本語メタデータを追加

### 使用例

```lua
-- @name Janken
-- @name.ja じゃんけん
-- @description Rock-Paper-Scissors game
-- @description.ja じゃんけんゲーム（勝敗記録付き）
-- @author HOBBS Sample
```

### 言語コード形式

- 基本: `ja`, `en`, `de` など (2文字)
- 拡張: `zh_CN`, `pt-BR` など (最大10文字)

## Test plan

- [x] Script 構造体の i18n フィールドテスト
- [x] メタデータパーサーの i18n パーステスト
- [x] リポジトリの i18n 永続化テスト
- [x] 全1115件のテストがパス

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)