### PR TITLE
[RSS Phase 1] 基盤（データ層）の実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,10 +51,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ec5f6c2f8bc326c994cb9e241cc257ddaba9afa8555a43cffbb5dd86efaa37"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -119,6 +150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +180,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7ac3e5b97fdce45e8922fb05cae2c37f7bbd63d30dd94821dacfd8f3f2bf2"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +209,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -179,6 +242,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +266,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -239,16 +319,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "feed-rs"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c0591d23efd0d595099af69a31863ac1823046b1b021e3b06ba3aae7e00991"
+dependencies = [
+ "chrono",
+ "mediatype",
+ "quick-xml",
+ "regex",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -286,8 +417,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -297,9 +430,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -334,19 +469,122 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "encoding_rs",
+ "feed-rs",
  "mlua",
  "rand",
  "rand_core 0.6.4",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -374,6 +612,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +721,22 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -429,6 +785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +806,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lua-src"
+version = "547.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.5.12+a4f56a4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,10 +840,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mediatype"
+version = "0.19.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -496,6 +902,8 @@ checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
 dependencies = [
  "cc",
  "cfg-if",
+ "lua-src",
+ "luajit-src",
  "pkg-config",
 ]
 
@@ -567,6 +975,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +1017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +1041,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -683,10 +1171,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.4.9"
+name = "regex"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -698,6 +1198,58 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rusqlite"
@@ -733,10 +1285,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "scopeguard"
@@ -807,6 +1400,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +1435,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "siphasher"
@@ -860,6 +1471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +1491,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -895,7 +1532,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -910,6 +1556,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +1574,31 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -944,6 +1626,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -986,6 +1691,56 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1049,6 +1804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1826,30 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -1096,6 +1881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1915,19 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1153,6 +1960,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -1216,11 +2064,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1234,20 +2091,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1257,9 +2136,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1269,9 +2160,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1281,15 +2184,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1307,10 +2228,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1326,6 +2282,66 @@ name = "zerocopy-derive"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ uuid = { version = "1", features = ["v4"] }
 thiserror = "1"
 rand = "0.9.2"
 mlua = { version = "0.10", features = ["lua54", "async", "serialize", "vendored"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip", "deflate"] }
+feed-rs = "2.3"
 # xmodem = "0.4" # Using custom async implementation instead
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod file;
 pub mod i18n;
 pub mod logging;
 pub mod mail;
+pub mod rss;
 pub mod screen;
 pub mod script;
 pub mod server;
@@ -60,6 +61,12 @@ pub use mail::{
     Mail, MailRepository, MailService, MailUpdate, NewMail, SendMailRequest, SystemMailService,
     MAX_BODY_LENGTH as MAX_MAIL_BODY_LENGTH, MAX_SUBJECT_LENGTH as MAX_MAIL_SUBJECT_LENGTH,
     WELCOME_MAIL_BODY, WELCOME_MAIL_SUBJECT,
+};
+pub use rss::{
+    NewRssFeed, NewRssItem, ParsedFeed, ParsedItem, RssFeed, RssFeedRepository, RssFeedUpdate,
+    RssFeedWithUnread, RssItem, RssItemRepository, RssReadPosition, RssReadPositionRepository,
+    DEFAULT_FETCH_INTERVAL, MAX_CONSECUTIVE_ERRORS, MAX_DESCRIPTION_LENGTH as MAX_RSS_DESCRIPTION_LENGTH,
+    MAX_FEED_SIZE, MAX_ITEMS_PER_FEED,
 };
 pub use screen::{
     create_screen, create_screen_from_profile, AnsiScreen, Color, PlainScreen, Screen,

--- a/src/rss/mod.rs
+++ b/src/rss/mod.rs
@@ -1,0 +1,13 @@
+//! RSS reader module for HOBBS.
+//!
+//! This module provides RSS feed subscription and reading functionality.
+
+pub mod repository;
+pub mod types;
+
+pub use repository::{RssFeedRepository, RssItemRepository, RssReadPositionRepository};
+pub use types::{
+    NewRssFeed, NewRssItem, ParsedFeed, ParsedItem, RssFeed, RssFeedUpdate, RssFeedWithUnread,
+    RssItem, RssReadPosition, DEFAULT_FETCH_INTERVAL, MAX_CONSECUTIVE_ERRORS,
+    MAX_DESCRIPTION_LENGTH, MAX_FEED_SIZE, MAX_ITEMS_PER_FEED,
+};

--- a/src/rss/repository.rs
+++ b/src/rss/repository.rs
@@ -1,0 +1,897 @@
+//! RSS repositories for HOBBS.
+
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, OptionalExtension};
+
+use super::types::{
+    NewRssFeed, NewRssItem, RssFeed, RssFeedUpdate, RssFeedWithUnread, RssItem, RssReadPosition,
+    MAX_ITEMS_PER_FEED,
+};
+
+/// Repository for RSS feed operations.
+pub struct RssFeedRepository;
+
+impl RssFeedRepository {
+    /// Create a new feed.
+    pub fn create(conn: &Connection, feed: &NewRssFeed) -> rusqlite::Result<RssFeed> {
+        conn.execute(
+            r#"
+            INSERT INTO rss_feeds (url, title, description, site_url, created_by)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+            params![
+                feed.url,
+                feed.title,
+                feed.description,
+                feed.site_url,
+                feed.created_by
+            ],
+        )?;
+
+        let id = conn.last_insert_rowid();
+        Self::get_by_id(conn, id)?.ok_or_else(|| rusqlite::Error::QueryReturnedNoRows)
+    }
+
+    /// Get a feed by ID.
+    pub fn get_by_id(conn: &Connection, id: i64) -> rusqlite::Result<Option<RssFeed>> {
+        conn.query_row(
+            r#"
+            SELECT id, url, title, description, site_url, last_fetched_at, last_item_at,
+                   fetch_interval, is_active, error_count, last_error, created_by,
+                   created_at, updated_at
+            FROM rss_feeds
+            WHERE id = ?1
+            "#,
+            [id],
+            Self::map_row,
+        )
+        .optional()
+    }
+
+    /// Get a feed by URL.
+    pub fn get_by_url(conn: &Connection, url: &str) -> rusqlite::Result<Option<RssFeed>> {
+        conn.query_row(
+            r#"
+            SELECT id, url, title, description, site_url, last_fetched_at, last_item_at,
+                   fetch_interval, is_active, error_count, last_error, created_by,
+                   created_at, updated_at
+            FROM rss_feeds
+            WHERE url = ?1
+            "#,
+            [url],
+            Self::map_row,
+        )
+        .optional()
+    }
+
+    /// List all active feeds.
+    pub fn list_active(conn: &Connection) -> rusqlite::Result<Vec<RssFeed>> {
+        let mut stmt = conn.prepare(
+            r#"
+            SELECT id, url, title, description, site_url, last_fetched_at, last_item_at,
+                   fetch_interval, is_active, error_count, last_error, created_by,
+                   created_at, updated_at
+            FROM rss_feeds
+            WHERE is_active = 1
+            ORDER BY title ASC
+            "#,
+        )?;
+
+        let feeds = stmt
+            .query_map([], Self::map_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(feeds)
+    }
+
+    /// List all feeds (including inactive).
+    pub fn list_all(conn: &Connection) -> rusqlite::Result<Vec<RssFeed>> {
+        let mut stmt = conn.prepare(
+            r#"
+            SELECT id, url, title, description, site_url, last_fetched_at, last_item_at,
+                   fetch_interval, is_active, error_count, last_error, created_by,
+                   created_at, updated_at
+            FROM rss_feeds
+            ORDER BY title ASC
+            "#,
+        )?;
+
+        let feeds = stmt
+            .query_map([], Self::map_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(feeds)
+    }
+
+    /// List feeds that are due for fetching.
+    pub fn list_due_for_fetch(conn: &Connection) -> rusqlite::Result<Vec<RssFeed>> {
+        let mut stmt = conn.prepare(
+            r#"
+            SELECT id, url, title, description, site_url, last_fetched_at, last_item_at,
+                   fetch_interval, is_active, error_count, last_error, created_by,
+                   created_at, updated_at
+            FROM rss_feeds
+            WHERE is_active = 1
+              AND (last_fetched_at IS NULL
+                   OR datetime(last_fetched_at, '+' || fetch_interval || ' seconds') <= datetime('now'))
+            ORDER BY last_fetched_at ASC NULLS FIRST
+            "#,
+        )?;
+
+        let feeds = stmt
+            .query_map([], Self::map_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(feeds)
+    }
+
+    /// List active feeds with unread counts for a user.
+    pub fn list_with_unread(
+        conn: &Connection,
+        user_id: Option<i64>,
+    ) -> rusqlite::Result<Vec<RssFeedWithUnread>> {
+        let mut stmt = conn.prepare(
+            r#"
+            SELECT f.id, f.url, f.title, f.description, f.site_url, f.last_fetched_at, f.last_item_at,
+                   f.fetch_interval, f.is_active, f.error_count, f.last_error, f.created_by,
+                   f.created_at, f.updated_at,
+                   CASE WHEN ?1 IS NULL THEN 0
+                        ELSE (SELECT COUNT(*) FROM rss_items i
+                              WHERE i.feed_id = f.id
+                              AND i.id > COALESCE(
+                                  (SELECT last_read_item_id FROM rss_read_positions
+                                   WHERE user_id = ?1 AND feed_id = f.id),
+                                  0))
+                   END as unread_count
+            FROM rss_feeds f
+            WHERE f.is_active = 1
+            ORDER BY f.title ASC
+            "#,
+        )?;
+
+        let feeds = stmt
+            .query_map([user_id], |row| {
+                let feed = Self::map_row(row)?;
+                let unread_count: i64 = row.get(14)?;
+                Ok(RssFeedWithUnread { feed, unread_count })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(feeds)
+    }
+
+    /// Update a feed.
+    pub fn update(conn: &Connection, id: i64, update: &RssFeedUpdate) -> rusqlite::Result<bool> {
+        if update.is_empty() {
+            return Ok(false);
+        }
+
+        let mut sets = Vec::new();
+        let mut values: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+        if let Some(ref title) = update.title {
+            sets.push("title = ?");
+            values.push(Box::new(title.clone()));
+        }
+
+        if let Some(ref description) = update.description {
+            sets.push("description = ?");
+            values.push(Box::new(description.clone()));
+        }
+
+        if let Some(interval) = update.fetch_interval {
+            sets.push("fetch_interval = ?");
+            values.push(Box::new(interval));
+        }
+
+        if let Some(is_active) = update.is_active {
+            sets.push("is_active = ?");
+            values.push(Box::new(is_active as i32));
+        }
+
+        sets.push("updated_at = datetime('now')");
+        values.push(Box::new(id));
+
+        let sql = format!("UPDATE rss_feeds SET {} WHERE id = ?", sets.join(", "));
+
+        let params: Vec<&dyn rusqlite::ToSql> = values.iter().map(|v| v.as_ref()).collect();
+        let rows = conn.execute(&sql, params.as_slice())?;
+        Ok(rows > 0)
+    }
+
+    /// Update last fetched timestamp.
+    pub fn update_last_fetched(conn: &Connection, id: i64) -> rusqlite::Result<bool> {
+        let rows = conn.execute(
+            "UPDATE rss_feeds SET last_fetched_at = datetime('now'), updated_at = datetime('now') WHERE id = ?1",
+            [id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Update last item timestamp.
+    pub fn update_last_item_at(
+        conn: &Connection,
+        id: i64,
+        last_item_at: DateTime<Utc>,
+    ) -> rusqlite::Result<bool> {
+        let rows = conn.execute(
+            "UPDATE rss_feeds SET last_item_at = ?2, updated_at = datetime('now') WHERE id = ?1",
+            params![id, last_item_at.to_rfc3339()],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Increment error count and set error message.
+    pub fn increment_error(conn: &Connection, id: i64, error: &str) -> rusqlite::Result<bool> {
+        let rows = conn.execute(
+            r#"
+            UPDATE rss_feeds
+            SET error_count = error_count + 1,
+                last_error = ?2,
+                updated_at = datetime('now')
+            WHERE id = ?1
+            "#,
+            params![id, error],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Clear error count.
+    pub fn clear_error(conn: &Connection, id: i64) -> rusqlite::Result<bool> {
+        let rows = conn.execute(
+            r#"
+            UPDATE rss_feeds
+            SET error_count = 0,
+                last_error = NULL,
+                updated_at = datetime('now')
+            WHERE id = ?1
+            "#,
+            [id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Disable feeds that have exceeded the error threshold.
+    pub fn disable_failed_feeds(conn: &Connection, max_errors: i32) -> rusqlite::Result<usize> {
+        conn.execute(
+            r#"
+            UPDATE rss_feeds
+            SET is_active = 0, updated_at = datetime('now')
+            WHERE error_count >= ?1 AND is_active = 1
+            "#,
+            [max_errors],
+        )
+    }
+
+    /// Delete a feed.
+    pub fn delete(conn: &Connection, id: i64) -> rusqlite::Result<bool> {
+        let rows = conn.execute("DELETE FROM rss_feeds WHERE id = ?1", [id])?;
+        Ok(rows > 0)
+    }
+
+    /// Count all feeds.
+    pub fn count(conn: &Connection) -> rusqlite::Result<i64> {
+        conn.query_row("SELECT COUNT(*) FROM rss_feeds", [], |row| row.get(0))
+    }
+
+    /// Map a database row to an RssFeed.
+    fn map_row(row: &rusqlite::Row) -> rusqlite::Result<RssFeed> {
+        let last_fetched_at: Option<String> = row.get(5)?;
+        let last_item_at: Option<String> = row.get(6)?;
+        let created_at_str: String = row.get(12)?;
+        let updated_at_str: String = row.get(13)?;
+
+        Ok(RssFeed {
+            id: row.get(0)?,
+            url: row.get(1)?,
+            title: row.get(2)?,
+            description: row.get(3)?,
+            site_url: row.get(4)?,
+            last_fetched_at: last_fetched_at.and_then(|s| parse_datetime(&s)),
+            last_item_at: last_item_at.and_then(|s| parse_datetime(&s)),
+            fetch_interval: row.get(7)?,
+            is_active: row.get::<_, i32>(8)? != 0,
+            error_count: row.get(9)?,
+            last_error: row.get(10)?,
+            created_by: row.get(11)?,
+            created_at: parse_datetime(&created_at_str).unwrap_or_else(Utc::now),
+            updated_at: parse_datetime(&updated_at_str).unwrap_or_else(Utc::now),
+        })
+    }
+}
+
+/// Repository for RSS item operations.
+pub struct RssItemRepository;
+
+impl RssItemRepository {
+    /// Create a new item, ignoring if duplicate (same feed_id + guid).
+    pub fn create_or_ignore(conn: &Connection, item: &NewRssItem) -> rusqlite::Result<Option<i64>> {
+        let published_at = item.published_at.map(|dt| dt.to_rfc3339());
+
+        let rows = conn.execute(
+            r#"
+            INSERT OR IGNORE INTO rss_items (feed_id, guid, title, link, description, author, published_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            "#,
+            params![
+                item.feed_id,
+                item.guid,
+                item.title,
+                item.link,
+                item.description,
+                item.author,
+                published_at
+            ],
+        )?;
+
+        if rows > 0 {
+            Ok(Some(conn.last_insert_rowid()))
+        } else {
+            Ok(None) // Already existed
+        }
+    }
+
+    /// Get an item by ID.
+    pub fn get_by_id(conn: &Connection, id: i64) -> rusqlite::Result<Option<RssItem>> {
+        conn.query_row(
+            r#"
+            SELECT id, feed_id, guid, title, link, description, author, published_at, fetched_at
+            FROM rss_items
+            WHERE id = ?1
+            "#,
+            [id],
+            Self::map_row,
+        )
+        .optional()
+    }
+
+    /// Get an item by feed ID and guid.
+    pub fn get_by_guid(
+        conn: &Connection,
+        feed_id: i64,
+        guid: &str,
+    ) -> rusqlite::Result<Option<RssItem>> {
+        conn.query_row(
+            r#"
+            SELECT id, feed_id, guid, title, link, description, author, published_at, fetched_at
+            FROM rss_items
+            WHERE feed_id = ?1 AND guid = ?2
+            "#,
+            params![feed_id, guid],
+            Self::map_row,
+        )
+        .optional()
+    }
+
+    /// List items for a feed (newest first).
+    pub fn list_by_feed(
+        conn: &Connection,
+        feed_id: i64,
+        limit: usize,
+        offset: usize,
+    ) -> rusqlite::Result<Vec<RssItem>> {
+        let mut stmt = conn.prepare(
+            r#"
+            SELECT id, feed_id, guid, title, link, description, author, published_at, fetched_at
+            FROM rss_items
+            WHERE feed_id = ?1
+            ORDER BY COALESCE(published_at, fetched_at) DESC, id DESC
+            LIMIT ?2 OFFSET ?3
+            "#,
+        )?;
+
+        let items = stmt
+            .query_map(params![feed_id, limit as i64, offset as i64], Self::map_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(items)
+    }
+
+    /// Count items for a feed.
+    pub fn count_by_feed(conn: &Connection, feed_id: i64) -> rusqlite::Result<i64> {
+        conn.query_row(
+            "SELECT COUNT(*) FROM rss_items WHERE feed_id = ?1",
+            [feed_id],
+            |row| row.get(0),
+        )
+    }
+
+    /// Count unread items for a user and feed.
+    pub fn count_unread(
+        conn: &Connection,
+        feed_id: i64,
+        user_id: i64,
+    ) -> rusqlite::Result<i64> {
+        conn.query_row(
+            r#"
+            SELECT COUNT(*) FROM rss_items
+            WHERE feed_id = ?1
+            AND id > COALESCE(
+                (SELECT last_read_item_id FROM rss_read_positions
+                 WHERE user_id = ?2 AND feed_id = ?1),
+                0)
+            "#,
+            params![feed_id, user_id],
+            |row| row.get(0),
+        )
+    }
+
+    /// Get the newest item ID for a feed.
+    pub fn get_newest_item_id(conn: &Connection, feed_id: i64) -> rusqlite::Result<Option<i64>> {
+        conn.query_row(
+            r#"
+            SELECT id FROM rss_items
+            WHERE feed_id = ?1
+            ORDER BY COALESCE(published_at, fetched_at) DESC, id DESC
+            LIMIT 1
+            "#,
+            [feed_id],
+            |row| row.get(0),
+        )
+        .optional()
+    }
+
+    /// Delete old items for a feed, keeping only the most recent.
+    pub fn prune_old_items(conn: &Connection, feed_id: i64) -> rusqlite::Result<usize> {
+        conn.execute(
+            r#"
+            DELETE FROM rss_items
+            WHERE feed_id = ?1
+            AND id NOT IN (
+                SELECT id FROM rss_items
+                WHERE feed_id = ?1
+                ORDER BY COALESCE(published_at, fetched_at) DESC, id DESC
+                LIMIT ?2
+            )
+            "#,
+            params![feed_id, MAX_ITEMS_PER_FEED as i64],
+        )
+    }
+
+    /// Delete all items for a feed.
+    pub fn delete_by_feed(conn: &Connection, feed_id: i64) -> rusqlite::Result<usize> {
+        conn.execute("DELETE FROM rss_items WHERE feed_id = ?1", [feed_id])
+    }
+
+    /// Map a database row to an RssItem.
+    fn map_row(row: &rusqlite::Row) -> rusqlite::Result<RssItem> {
+        let published_at: Option<String> = row.get(7)?;
+        let fetched_at_str: String = row.get(8)?;
+
+        Ok(RssItem {
+            id: row.get(0)?,
+            feed_id: row.get(1)?,
+            guid: row.get(2)?,
+            title: row.get(3)?,
+            link: row.get(4)?,
+            description: row.get(5)?,
+            author: row.get(6)?,
+            published_at: published_at.and_then(|s| parse_datetime(&s)),
+            fetched_at: parse_datetime(&fetched_at_str).unwrap_or_else(Utc::now),
+        })
+    }
+}
+
+/// Repository for RSS read position operations.
+pub struct RssReadPositionRepository;
+
+impl RssReadPositionRepository {
+    /// Get read position for a user and feed.
+    pub fn get(
+        conn: &Connection,
+        user_id: i64,
+        feed_id: i64,
+    ) -> rusqlite::Result<Option<RssReadPosition>> {
+        conn.query_row(
+            r#"
+            SELECT id, user_id, feed_id, last_read_item_id, last_read_at
+            FROM rss_read_positions
+            WHERE user_id = ?1 AND feed_id = ?2
+            "#,
+            params![user_id, feed_id],
+            Self::map_row,
+        )
+        .optional()
+    }
+
+    /// Update or insert read position.
+    pub fn upsert(
+        conn: &Connection,
+        user_id: i64,
+        feed_id: i64,
+        last_read_item_id: i64,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            r#"
+            INSERT INTO rss_read_positions (user_id, feed_id, last_read_item_id, last_read_at)
+            VALUES (?1, ?2, ?3, datetime('now'))
+            ON CONFLICT(user_id, feed_id) DO UPDATE SET
+                last_read_item_id = ?3,
+                last_read_at = datetime('now')
+            "#,
+            params![user_id, feed_id, last_read_item_id],
+        )?;
+        Ok(())
+    }
+
+    /// Mark all items as read (set to newest item ID).
+    pub fn mark_all_as_read(conn: &Connection, user_id: i64, feed_id: i64) -> rusqlite::Result<bool> {
+        let newest_id = RssItemRepository::get_newest_item_id(conn, feed_id)?;
+        match newest_id {
+            Some(id) => {
+                Self::upsert(conn, user_id, feed_id, id)?;
+                Ok(true)
+            }
+            None => Ok(false), // No items to mark as read
+        }
+    }
+
+    /// Delete read position for a user and feed.
+    pub fn delete(conn: &Connection, user_id: i64, feed_id: i64) -> rusqlite::Result<bool> {
+        let rows = conn.execute(
+            "DELETE FROM rss_read_positions WHERE user_id = ?1 AND feed_id = ?2",
+            params![user_id, feed_id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Delete all read positions for a user.
+    pub fn delete_by_user(conn: &Connection, user_id: i64) -> rusqlite::Result<usize> {
+        conn.execute(
+            "DELETE FROM rss_read_positions WHERE user_id = ?1",
+            [user_id],
+        )
+    }
+
+    /// Map a database row to an RssReadPosition.
+    fn map_row(row: &rusqlite::Row) -> rusqlite::Result<RssReadPosition> {
+        let last_read_at_str: String = row.get(4)?;
+
+        Ok(RssReadPosition {
+            id: row.get(0)?,
+            user_id: row.get(1)?,
+            feed_id: row.get(2)?,
+            last_read_item_id: row.get(3)?,
+            last_read_at: parse_datetime(&last_read_at_str).unwrap_or_else(Utc::now),
+        })
+    }
+}
+
+/// Parse a datetime string to DateTime<Utc>.
+fn parse_datetime(s: &str) -> Option<DateTime<Utc>> {
+    // Try RFC3339 first
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    // Try SQLite datetime format
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+        return Some(DateTime::from_naive_utc_and_offset(naive, Utc));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{Database, NewUser, UserRepository};
+
+    fn setup_db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    fn create_test_user(db: &Database) -> i64 {
+        let repo = UserRepository::new(db);
+        let user = NewUser::new("testuser", "password123", "Test User");
+        repo.create(&user).unwrap().id
+    }
+
+    #[test]
+    fn test_create_feed() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        assert!(feed.id > 0);
+        assert_eq!(feed.url, "https://example.com/feed.xml");
+        assert_eq!(feed.title, "Test Feed");
+        assert_eq!(feed.created_by, user_id);
+        assert!(feed.is_active);
+        assert_eq!(feed.error_count, 0);
+    }
+
+    #[test]
+    fn test_get_feed_by_id() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let created = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        let retrieved = RssFeedRepository::get_by_id(db.conn(), created.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(retrieved.id, created.id);
+        assert_eq!(retrieved.title, "Test Feed");
+    }
+
+    #[test]
+    fn test_get_feed_by_url() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let url = "https://example.com/feed.xml";
+        let new_feed = NewRssFeed::new(url, "Test Feed", user_id);
+        RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        let retrieved = RssFeedRepository::get_by_url(db.conn(), url)
+            .unwrap()
+            .unwrap();
+        assert_eq!(retrieved.url, url);
+    }
+
+    #[test]
+    fn test_list_active_feeds() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        // Create active and inactive feeds
+        let feed1 = NewRssFeed::new("https://example1.com/feed.xml", "Feed 1", user_id);
+        let feed2 = NewRssFeed::new("https://example2.com/feed.xml", "Feed 2", user_id);
+        RssFeedRepository::create(db.conn(), &feed1).unwrap();
+        let created2 = RssFeedRepository::create(db.conn(), &feed2).unwrap();
+
+        // Disable feed2
+        RssFeedRepository::update(db.conn(), created2.id, &RssFeedUpdate::new().disable()).unwrap();
+
+        let active = RssFeedRepository::list_active(db.conn()).unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].title, "Feed 1");
+    }
+
+    #[test]
+    fn test_update_feed() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        let update = RssFeedUpdate::new()
+            .with_title("Updated Title")
+            .with_fetch_interval(7200);
+        RssFeedRepository::update(db.conn(), feed.id, &update).unwrap();
+
+        let updated = RssFeedRepository::get_by_id(db.conn(), feed.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.title, "Updated Title");
+        assert_eq!(updated.fetch_interval, 7200);
+    }
+
+    #[test]
+    fn test_increment_and_clear_error() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        // Increment error
+        RssFeedRepository::increment_error(db.conn(), feed.id, "Connection timeout").unwrap();
+        let updated = RssFeedRepository::get_by_id(db.conn(), feed.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.error_count, 1);
+        assert_eq!(updated.last_error, Some("Connection timeout".to_string()));
+
+        // Clear error
+        RssFeedRepository::clear_error(db.conn(), feed.id).unwrap();
+        let cleared = RssFeedRepository::get_by_id(db.conn(), feed.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cleared.error_count, 0);
+        assert!(cleared.last_error.is_none());
+    }
+
+    #[test]
+    fn test_delete_feed() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        RssFeedRepository::delete(db.conn(), feed.id).unwrap();
+
+        let result = RssFeedRepository::get_by_id(db.conn(), feed.id).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_create_item() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        let new_item = NewRssItem::new(feed.id, "guid-123", "Test Article")
+            .with_link("https://example.com/article")
+            .with_description("Article summary");
+
+        let item_id = RssItemRepository::create_or_ignore(db.conn(), &new_item)
+            .unwrap()
+            .unwrap();
+
+        let item = RssItemRepository::get_by_id(db.conn(), item_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(item.guid, "guid-123");
+        assert_eq!(item.title, "Test Article");
+        assert_eq!(item.link, Some("https://example.com/article".to_string()));
+    }
+
+    #[test]
+    fn test_create_item_ignores_duplicate() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        let new_item = NewRssItem::new(feed.id, "guid-123", "Test Article");
+
+        // First insert
+        let id1 = RssItemRepository::create_or_ignore(db.conn(), &new_item).unwrap();
+        assert!(id1.is_some());
+
+        // Second insert (duplicate) should be ignored
+        let id2 = RssItemRepository::create_or_ignore(db.conn(), &new_item).unwrap();
+        assert!(id2.is_none());
+
+        // Should still have only one item
+        assert_eq!(RssItemRepository::count_by_feed(db.conn(), feed.id).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_list_items_by_feed() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        // Create items
+        for i in 1..=5 {
+            let item = NewRssItem::new(feed.id, format!("guid-{}", i), format!("Article {}", i));
+            RssItemRepository::create_or_ignore(db.conn(), &item).unwrap();
+        }
+
+        let items = RssItemRepository::list_by_feed(db.conn(), feed.id, 3, 0).unwrap();
+        assert_eq!(items.len(), 3);
+
+        let items_page2 = RssItemRepository::list_by_feed(db.conn(), feed.id, 3, 3).unwrap();
+        assert_eq!(items_page2.len(), 2);
+    }
+
+    #[test]
+    fn test_prune_old_items() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        // Create more items than MAX_ITEMS_PER_FEED
+        for i in 1..=150 {
+            let item = NewRssItem::new(feed.id, format!("guid-{}", i), format!("Article {}", i));
+            RssItemRepository::create_or_ignore(db.conn(), &item).unwrap();
+        }
+
+        assert_eq!(RssItemRepository::count_by_feed(db.conn(), feed.id).unwrap(), 150);
+
+        RssItemRepository::prune_old_items(db.conn(), feed.id).unwrap();
+
+        assert_eq!(
+            RssItemRepository::count_by_feed(db.conn(), feed.id).unwrap(),
+            MAX_ITEMS_PER_FEED as i64
+        );
+    }
+
+    #[test]
+    fn test_read_position_upsert() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        let item = NewRssItem::new(feed.id, "guid-1", "Article 1");
+        let item_id = RssItemRepository::create_or_ignore(db.conn(), &item)
+            .unwrap()
+            .unwrap();
+
+        // Insert
+        RssReadPositionRepository::upsert(db.conn(), user_id, feed.id, item_id).unwrap();
+
+        let pos = RssReadPositionRepository::get(db.conn(), user_id, feed.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(pos.last_read_item_id, Some(item_id));
+
+        // Update
+        let item2 = NewRssItem::new(feed.id, "guid-2", "Article 2");
+        let item_id2 = RssItemRepository::create_or_ignore(db.conn(), &item2)
+            .unwrap()
+            .unwrap();
+
+        RssReadPositionRepository::upsert(db.conn(), user_id, feed.id, item_id2).unwrap();
+
+        let pos2 = RssReadPositionRepository::get(db.conn(), user_id, feed.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(pos2.last_read_item_id, Some(item_id2));
+    }
+
+    #[test]
+    fn test_count_unread() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        // Create 5 items
+        for i in 1..=5 {
+            let item = NewRssItem::new(feed.id, format!("guid-{}", i), format!("Article {}", i));
+            RssItemRepository::create_or_ignore(db.conn(), &item).unwrap();
+        }
+
+        // All should be unread
+        assert_eq!(RssItemRepository::count_unread(db.conn(), feed.id, user_id).unwrap(), 5);
+
+        // Mark item 3 as read
+        let item3 = RssItemRepository::get_by_guid(db.conn(), feed.id, "guid-3")
+            .unwrap()
+            .unwrap();
+        RssReadPositionRepository::upsert(db.conn(), user_id, feed.id, item3.id).unwrap();
+
+        // Items 4, 5 should be unread
+        assert_eq!(RssItemRepository::count_unread(db.conn(), feed.id, user_id).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_mark_all_as_read() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        // Create items
+        for i in 1..=5 {
+            let item = NewRssItem::new(feed.id, format!("guid-{}", i), format!("Article {}", i));
+            RssItemRepository::create_or_ignore(db.conn(), &item).unwrap();
+        }
+
+        RssReadPositionRepository::mark_all_as_read(db.conn(), user_id, feed.id).unwrap();
+
+        assert_eq!(RssItemRepository::count_unread(db.conn(), feed.id, user_id).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_list_with_unread() {
+        let db = setup_db();
+        let user_id = create_test_user(&db);
+
+        let new_feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", user_id);
+        let feed = RssFeedRepository::create(db.conn(), &new_feed).unwrap();
+
+        // Create items
+        for i in 1..=3 {
+            let item = NewRssItem::new(feed.id, format!("guid-{}", i), format!("Article {}", i));
+            RssItemRepository::create_or_ignore(db.conn(), &item).unwrap();
+        }
+
+        let feeds_with_unread = RssFeedRepository::list_with_unread(db.conn(), Some(user_id)).unwrap();
+        assert_eq!(feeds_with_unread.len(), 1);
+        assert_eq!(feeds_with_unread[0].unread_count, 3);
+    }
+}

--- a/src/rss/types.rs
+++ b/src/rss/types.rs
@@ -1,0 +1,451 @@
+//! RSS types for HOBBS.
+
+use chrono::{DateTime, Utc};
+
+/// Maximum length for RSS item description.
+pub const MAX_DESCRIPTION_LENGTH: usize = 10000;
+
+/// Maximum number of items to store per feed.
+pub const MAX_ITEMS_PER_FEED: usize = 100;
+
+/// Maximum feed size in bytes (5MB).
+pub const MAX_FEED_SIZE: u64 = 5 * 1024 * 1024;
+
+/// Default fetch interval in seconds (1 hour).
+pub const DEFAULT_FETCH_INTERVAL: i64 = 3600;
+
+/// Maximum consecutive errors before disabling a feed.
+pub const MAX_CONSECUTIVE_ERRORS: i32 = 5;
+
+/// An RSS feed.
+#[derive(Debug, Clone)]
+pub struct RssFeed {
+    /// Feed ID.
+    pub id: i64,
+    /// Feed URL.
+    pub url: String,
+    /// Feed title.
+    pub title: String,
+    /// Feed description.
+    pub description: Option<String>,
+    /// Site URL (the website the feed belongs to).
+    pub site_url: Option<String>,
+    /// Last time the feed was fetched.
+    pub last_fetched_at: Option<DateTime<Utc>>,
+    /// Timestamp of the newest item.
+    pub last_item_at: Option<DateTime<Utc>>,
+    /// Fetch interval in seconds.
+    pub fetch_interval: i64,
+    /// Whether the feed is active.
+    pub is_active: bool,
+    /// Number of consecutive fetch errors.
+    pub error_count: i32,
+    /// Last error message.
+    pub last_error: Option<String>,
+    /// User ID who created the feed.
+    pub created_by: i64,
+    /// When the feed was created.
+    pub created_at: DateTime<Utc>,
+    /// When the feed was last updated.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl RssFeed {
+    /// Check if the feed should be fetched based on the interval.
+    pub fn is_due_for_fetch(&self) -> bool {
+        if !self.is_active {
+            return false;
+        }
+        match self.last_fetched_at {
+            None => true,
+            Some(last) => {
+                let elapsed = Utc::now().signed_duration_since(last);
+                elapsed.num_seconds() >= self.fetch_interval
+            }
+        }
+    }
+
+    /// Check if the feed has exceeded the error threshold.
+    pub fn has_exceeded_error_threshold(&self) -> bool {
+        self.error_count >= MAX_CONSECUTIVE_ERRORS
+    }
+}
+
+/// New RSS feed for creation.
+#[derive(Debug, Clone)]
+pub struct NewRssFeed {
+    /// Feed URL.
+    pub url: String,
+    /// Feed title.
+    pub title: String,
+    /// Feed description.
+    pub description: Option<String>,
+    /// Site URL.
+    pub site_url: Option<String>,
+    /// User ID who created the feed.
+    pub created_by: i64,
+}
+
+impl NewRssFeed {
+    /// Create a new feed.
+    pub fn new(
+        url: impl Into<String>,
+        title: impl Into<String>,
+        created_by: i64,
+    ) -> Self {
+        Self {
+            url: url.into(),
+            title: title.into(),
+            description: None,
+            site_url: None,
+            created_by,
+        }
+    }
+
+    /// Set the description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the site URL.
+    pub fn with_site_url(mut self, site_url: impl Into<String>) -> Self {
+        self.site_url = Some(site_url.into());
+        self
+    }
+}
+
+/// RSS feed update request.
+#[derive(Debug, Clone, Default)]
+pub struct RssFeedUpdate {
+    /// New title.
+    pub title: Option<String>,
+    /// New description.
+    pub description: Option<Option<String>>,
+    /// New fetch interval.
+    pub fetch_interval: Option<i64>,
+    /// Whether the feed is active.
+    pub is_active: Option<bool>,
+}
+
+impl RssFeedUpdate {
+    /// Create a new update request.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the title.
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Set the fetch interval.
+    pub fn with_fetch_interval(mut self, interval: i64) -> Self {
+        self.fetch_interval = Some(interval);
+        self
+    }
+
+    /// Enable the feed.
+    pub fn enable(mut self) -> Self {
+        self.is_active = Some(true);
+        self
+    }
+
+    /// Disable the feed.
+    pub fn disable(mut self) -> Self {
+        self.is_active = Some(false);
+        self
+    }
+
+    /// Check if the update is empty.
+    pub fn is_empty(&self) -> bool {
+        self.title.is_none()
+            && self.description.is_none()
+            && self.fetch_interval.is_none()
+            && self.is_active.is_none()
+    }
+}
+
+/// An RSS item (article).
+#[derive(Debug, Clone)]
+pub struct RssItem {
+    /// Item ID.
+    pub id: i64,
+    /// Feed ID this item belongs to.
+    pub feed_id: i64,
+    /// Unique identifier for the item (RSS guid or Atom id).
+    pub guid: String,
+    /// Item title.
+    pub title: String,
+    /// Link to the original article.
+    pub link: Option<String>,
+    /// Item description/summary (HTML tags stripped).
+    pub description: Option<String>,
+    /// Author name.
+    pub author: Option<String>,
+    /// When the item was published.
+    pub published_at: Option<DateTime<Utc>>,
+    /// When the item was fetched.
+    pub fetched_at: DateTime<Utc>,
+}
+
+/// New RSS item for creation.
+#[derive(Debug, Clone)]
+pub struct NewRssItem {
+    /// Feed ID.
+    pub feed_id: i64,
+    /// Unique identifier.
+    pub guid: String,
+    /// Item title.
+    pub title: String,
+    /// Link to the original article.
+    pub link: Option<String>,
+    /// Item description.
+    pub description: Option<String>,
+    /// Author name.
+    pub author: Option<String>,
+    /// When the item was published.
+    pub published_at: Option<DateTime<Utc>>,
+}
+
+impl NewRssItem {
+    /// Create a new item.
+    pub fn new(
+        feed_id: i64,
+        guid: impl Into<String>,
+        title: impl Into<String>,
+    ) -> Self {
+        Self {
+            feed_id,
+            guid: guid.into(),
+            title: title.into(),
+            link: None,
+            description: None,
+            author: None,
+            published_at: None,
+        }
+    }
+
+    /// Set the link.
+    pub fn with_link(mut self, link: impl Into<String>) -> Self {
+        self.link = Some(link.into());
+        self
+    }
+
+    /// Set the description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        let desc = description.into();
+        // Truncate if too long
+        if desc.len() > MAX_DESCRIPTION_LENGTH {
+            self.description = Some(desc.chars().take(MAX_DESCRIPTION_LENGTH).collect());
+        } else {
+            self.description = Some(desc);
+        }
+        self
+    }
+
+    /// Set the author.
+    pub fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.author = Some(author.into());
+        self
+    }
+
+    /// Set the published date.
+    pub fn with_published_at(mut self, published_at: DateTime<Utc>) -> Self {
+        self.published_at = Some(published_at);
+        self
+    }
+}
+
+/// RSS read position for tracking user's last read item.
+#[derive(Debug, Clone)]
+pub struct RssReadPosition {
+    /// Read position ID.
+    pub id: i64,
+    /// User ID.
+    pub user_id: i64,
+    /// Feed ID.
+    pub feed_id: i64,
+    /// Last read item ID.
+    pub last_read_item_id: Option<i64>,
+    /// When the position was last updated.
+    pub last_read_at: DateTime<Utc>,
+}
+
+/// Parsed feed data from external source.
+#[derive(Debug, Clone)]
+pub struct ParsedFeed {
+    /// Feed title.
+    pub title: String,
+    /// Feed description.
+    pub description: Option<String>,
+    /// Site URL.
+    pub site_url: Option<String>,
+    /// Parsed items.
+    pub items: Vec<ParsedItem>,
+}
+
+/// Parsed item data from external source.
+#[derive(Debug, Clone)]
+pub struct ParsedItem {
+    /// Unique identifier.
+    pub guid: String,
+    /// Item title.
+    pub title: String,
+    /// Link to the original article.
+    pub link: Option<String>,
+    /// Item description (HTML tags stripped).
+    pub description: Option<String>,
+    /// Author name.
+    pub author: Option<String>,
+    /// When the item was published.
+    pub published_at: Option<DateTime<Utc>>,
+}
+
+/// Feed with unread count for display.
+#[derive(Debug, Clone)]
+pub struct RssFeedWithUnread {
+    /// The feed.
+    pub feed: RssFeed,
+    /// Number of unread items for the current user.
+    pub unread_count: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_rss_feed() {
+        let feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", 1);
+        assert_eq!(feed.url, "https://example.com/feed.xml");
+        assert_eq!(feed.title, "Test Feed");
+        assert_eq!(feed.created_by, 1);
+        assert!(feed.description.is_none());
+    }
+
+    #[test]
+    fn test_new_rss_feed_with_description() {
+        let feed = NewRssFeed::new("https://example.com/feed.xml", "Test Feed", 1)
+            .with_description("A test feed")
+            .with_site_url("https://example.com");
+        assert_eq!(feed.description, Some("A test feed".to_string()));
+        assert_eq!(feed.site_url, Some("https://example.com".to_string()));
+    }
+
+    #[test]
+    fn test_rss_feed_is_due_for_fetch() {
+        let feed = RssFeed {
+            id: 1,
+            url: "https://example.com/feed.xml".to_string(),
+            title: "Test".to_string(),
+            description: None,
+            site_url: None,
+            last_fetched_at: None,
+            last_item_at: None,
+            fetch_interval: 3600,
+            is_active: true,
+            error_count: 0,
+            last_error: None,
+            created_by: 1,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        // Never fetched, should be due
+        assert!(feed.is_due_for_fetch());
+
+        // Inactive feed should not be due
+        let inactive = RssFeed {
+            is_active: false,
+            ..feed.clone()
+        };
+        assert!(!inactive.is_due_for_fetch());
+
+        // Recently fetched should not be due
+        let recent = RssFeed {
+            last_fetched_at: Some(Utc::now()),
+            ..feed.clone()
+        };
+        assert!(!recent.is_due_for_fetch());
+    }
+
+    #[test]
+    fn test_rss_feed_error_threshold() {
+        let feed = RssFeed {
+            id: 1,
+            url: "https://example.com/feed.xml".to_string(),
+            title: "Test".to_string(),
+            description: None,
+            site_url: None,
+            last_fetched_at: None,
+            last_item_at: None,
+            fetch_interval: 3600,
+            is_active: true,
+            error_count: 0,
+            last_error: None,
+            created_by: 1,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        assert!(!feed.has_exceeded_error_threshold());
+
+        let errored = RssFeed {
+            error_count: MAX_CONSECUTIVE_ERRORS,
+            ..feed
+        };
+        assert!(errored.has_exceeded_error_threshold());
+    }
+
+    #[test]
+    fn test_new_rss_item() {
+        let item = NewRssItem::new(1, "guid-123", "Test Article");
+        assert_eq!(item.feed_id, 1);
+        assert_eq!(item.guid, "guid-123");
+        assert_eq!(item.title, "Test Article");
+    }
+
+    #[test]
+    fn test_new_rss_item_with_fields() {
+        let now = Utc::now();
+        let item = NewRssItem::new(1, "guid-123", "Test Article")
+            .with_link("https://example.com/article")
+            .with_description("Summary text")
+            .with_author("Author Name")
+            .with_published_at(now);
+        assert_eq!(item.link, Some("https://example.com/article".to_string()));
+        assert_eq!(item.description, Some("Summary text".to_string()));
+        assert_eq!(item.author, Some("Author Name".to_string()));
+        assert_eq!(item.published_at, Some(now));
+    }
+
+    #[test]
+    fn test_new_rss_item_truncates_long_description() {
+        let long_desc = "a".repeat(MAX_DESCRIPTION_LENGTH + 100);
+        let item = NewRssItem::new(1, "guid-123", "Test")
+            .with_description(long_desc);
+        assert_eq!(item.description.as_ref().unwrap().len(), MAX_DESCRIPTION_LENGTH);
+    }
+
+    #[test]
+    fn test_rss_feed_update_empty() {
+        let update = RssFeedUpdate::new();
+        assert!(update.is_empty());
+    }
+
+    #[test]
+    fn test_rss_feed_update_with_title() {
+        let update = RssFeedUpdate::new().with_title("New Title");
+        assert_eq!(update.title, Some("New Title".to_string()));
+        assert!(!update.is_empty());
+    }
+
+    #[test]
+    fn test_rss_feed_update_enable_disable() {
+        let enable = RssFeedUpdate::new().enable();
+        assert_eq!(enable.is_active, Some(true));
+
+        let disable = RssFeedUpdate::new().disable();
+        assert_eq!(disable.is_active, Some(false));
+    }
+}


### PR DESCRIPTION
## Summary

- RSSリーダー機能のデータ層（Phase 1）を実装
- 依存関係として reqwest, feed-rs を追加
- DBマイグレーション（v16-v18）でRSS関連テーブルを追加
- Repository層でCRUD操作を提供

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `Cargo.toml` | reqwest, feed-rs 依存関係追加 |
| `src/db/schema.rs` | rss_feeds, rss_items, rss_read_positions テーブル |
| `src/rss/types.rs` | RssFeed, RssItem, RssReadPosition 型定義 |
| `src/rss/repository.rs` | CRUD操作リポジトリ |
| `src/rss/mod.rs` | モジュール公開API |
| `src/lib.rs` | rssモジュール統合 |

## Test plan

- [x] `cargo build` 成功
- [x] `cargo test --lib rss::` 25テスト全て成功
- [x] 既存テストに影響なし

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)