### PR TITLE
[Web UI Phase 2] コア機能API実装 - 掲示板・メール・ユーザー・RSS

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,7 +64,7 @@ max_consecutive_errors = 5
 
 [web]
 # Whether Web UI is enabled
-enabled = false
+enabled = true
 # Host address for Web API
 host = "0.0.0.0"
 # Port number for Web API

--- a/src/web/dto/request.rs
+++ b/src/web/dto/request.rs
@@ -2,6 +2,10 @@
 
 use serde::Deserialize;
 
+// ============================================================================
+// Auth DTOs
+// ============================================================================
+
 /// Login request.
 #[derive(Debug, Deserialize)]
 pub struct LoginRequest {
@@ -37,4 +41,108 @@ pub struct RegisterRequest {
     /// Email (optional).
     #[serde(default)]
     pub email: Option<String>,
+}
+
+// ============================================================================
+// Pagination DTOs
+// ============================================================================
+
+/// Pagination query parameters.
+#[derive(Debug, Deserialize)]
+pub struct PaginationQuery {
+    /// Page number (1-indexed).
+    #[serde(default = "default_page")]
+    pub page: u32,
+    /// Items per page.
+    #[serde(default = "default_per_page")]
+    pub per_page: u32,
+}
+
+fn default_page() -> u32 {
+    1
+}
+
+fn default_per_page() -> u32 {
+    20
+}
+
+impl PaginationQuery {
+    /// Convert to offset and limit.
+    pub fn to_offset_limit(&self) -> (i64, i64) {
+        let page = self.page.max(1) as i64;
+        let per_page = self.per_page.clamp(1, 100) as i64;
+        let offset = (page - 1) * per_page;
+        (offset, per_page)
+    }
+}
+
+// ============================================================================
+// Board DTOs
+// ============================================================================
+
+/// Create thread request.
+#[derive(Debug, Deserialize)]
+pub struct CreateThreadRequest {
+    /// Thread title.
+    pub title: String,
+    /// First post body.
+    pub body: String,
+}
+
+/// Create post request (for thread-based boards).
+#[derive(Debug, Deserialize)]
+pub struct CreatePostRequest {
+    /// Post body.
+    pub body: String,
+}
+
+/// Create flat post request (for flat boards).
+#[derive(Debug, Deserialize)]
+pub struct CreateFlatPostRequest {
+    /// Post title.
+    pub title: String,
+    /// Post body.
+    pub body: String,
+}
+
+// ============================================================================
+// Mail DTOs
+// ============================================================================
+
+/// Send mail request.
+#[derive(Debug, Deserialize)]
+pub struct SendMailRequest {
+    /// Recipient username or user ID.
+    pub recipient: String,
+    /// Mail subject.
+    pub subject: String,
+    /// Mail body.
+    pub body: String,
+}
+
+// ============================================================================
+// User DTOs
+// ============================================================================
+
+/// Update profile request.
+#[derive(Debug, Deserialize)]
+pub struct UpdateProfileRequest {
+    /// New nickname.
+    #[serde(default)]
+    pub nickname: Option<String>,
+    /// New email.
+    #[serde(default)]
+    pub email: Option<String>,
+    /// New profile text.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Change password request.
+#[derive(Debug, Deserialize)]
+pub struct ChangePasswordRequest {
+    /// Current password.
+    pub current_password: String,
+    /// New password.
+    pub new_password: String,
 }

--- a/src/web/dto/response.rs
+++ b/src/web/dto/response.rs
@@ -2,6 +2,10 @@
 
 use serde::Serialize;
 
+// ============================================================================
+// Generic Response Wrappers
+// ============================================================================
+
 /// Generic API response wrapper.
 #[derive(Debug, Serialize)]
 pub struct ApiResponse<T: Serialize> {
@@ -23,6 +27,20 @@ pub struct PaginatedResponse<T: Serialize> {
     pub data: Vec<T>,
     /// Pagination metadata.
     pub meta: PaginationMeta,
+}
+
+impl<T: Serialize> PaginatedResponse<T> {
+    /// Create a new paginated response.
+    pub fn new(data: Vec<T>, page: u32, per_page: u32, total: u64) -> Self {
+        Self {
+            data,
+            meta: PaginationMeta {
+                page,
+                per_page,
+                total,
+            },
+        }
+    }
 }
 
 /// Pagination metadata.
@@ -94,4 +112,216 @@ pub struct MeResponse {
     /// Last login timestamp.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_login_at: Option<String>,
+}
+
+// ============================================================================
+// Board DTOs
+// ============================================================================
+
+/// Board response.
+#[derive(Debug, Serialize)]
+pub struct BoardResponse {
+    /// Board ID.
+    pub id: i64,
+    /// Board name.
+    pub name: String,
+    /// Board description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Board type (thread or flat).
+    pub board_type: String,
+    /// Whether user can read this board.
+    pub can_read: bool,
+    /// Whether user can write to this board.
+    pub can_write: bool,
+    /// Creation timestamp.
+    pub created_at: String,
+}
+
+/// Thread response.
+#[derive(Debug, Serialize)]
+pub struct ThreadResponse {
+    /// Thread ID.
+    pub id: i64,
+    /// Board ID.
+    pub board_id: i64,
+    /// Thread title.
+    pub title: String,
+    /// Author info.
+    pub author: AuthorInfo,
+    /// Number of posts.
+    pub post_count: i32,
+    /// Creation timestamp.
+    pub created_at: String,
+    /// Last update timestamp.
+    pub updated_at: String,
+}
+
+/// Post response.
+#[derive(Debug, Serialize)]
+pub struct PostResponse {
+    /// Post ID.
+    pub id: i64,
+    /// Board ID.
+    pub board_id: i64,
+    /// Thread ID (None for flat boards).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<i64>,
+    /// Author info.
+    pub author: AuthorInfo,
+    /// Post title (for flat boards).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Post body.
+    pub body: String,
+    /// Creation timestamp.
+    pub created_at: String,
+}
+
+/// Author information.
+#[derive(Debug, Serialize)]
+pub struct AuthorInfo {
+    /// User ID.
+    pub id: i64,
+    /// Username.
+    pub username: String,
+    /// Nickname.
+    pub nickname: String,
+}
+
+// ============================================================================
+// Mail DTOs
+// ============================================================================
+
+/// Mail list item response.
+#[derive(Debug, Serialize)]
+pub struct MailListResponse {
+    /// Mail ID.
+    pub id: i64,
+    /// Sender info.
+    pub sender: AuthorInfo,
+    /// Recipient info.
+    pub recipient: AuthorInfo,
+    /// Mail subject.
+    pub subject: String,
+    /// Whether the mail has been read.
+    pub is_read: bool,
+    /// Creation timestamp.
+    pub created_at: String,
+}
+
+/// Mail detail response.
+#[derive(Debug, Serialize)]
+pub struct MailDetailResponse {
+    /// Mail ID.
+    pub id: i64,
+    /// Sender info.
+    pub sender: AuthorInfo,
+    /// Recipient info.
+    pub recipient: AuthorInfo,
+    /// Mail subject.
+    pub subject: String,
+    /// Mail body.
+    pub body: String,
+    /// Whether the mail has been read.
+    pub is_read: bool,
+    /// Creation timestamp.
+    pub created_at: String,
+}
+
+/// Unread count response.
+#[derive(Debug, Serialize)]
+pub struct UnreadCountResponse {
+    /// Unread mail count.
+    pub count: u64,
+}
+
+// ============================================================================
+// User DTOs
+// ============================================================================
+
+/// User list response.
+#[derive(Debug, Serialize)]
+pub struct UserListResponse {
+    /// User ID.
+    pub id: i64,
+    /// Username.
+    pub username: String,
+    /// Nickname.
+    pub nickname: String,
+    /// User role.
+    pub role: String,
+    /// Last login timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_login_at: Option<String>,
+}
+
+/// User detail response.
+#[derive(Debug, Serialize)]
+pub struct UserDetailResponse {
+    /// User ID.
+    pub id: i64,
+    /// Username.
+    pub username: String,
+    /// Nickname.
+    pub nickname: String,
+    /// User role.
+    pub role: String,
+    /// Profile text.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    /// Account creation timestamp.
+    pub created_at: String,
+    /// Last login timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_login_at: Option<String>,
+}
+
+// ============================================================================
+// RSS DTOs
+// ============================================================================
+
+/// RSS feed response.
+#[derive(Debug, Serialize)]
+pub struct RssFeedResponse {
+    /// Feed ID.
+    pub id: i64,
+    /// Feed URL.
+    pub url: String,
+    /// Feed title.
+    pub title: String,
+    /// Feed description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Site URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub site_url: Option<String>,
+    /// Last fetched timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_fetched_at: Option<String>,
+    /// Whether the feed is active.
+    pub is_active: bool,
+}
+
+/// RSS item response.
+#[derive(Debug, Serialize)]
+pub struct RssItemResponse {
+    /// Item ID.
+    pub id: i64,
+    /// Feed ID.
+    pub feed_id: i64,
+    /// Item title.
+    pub title: String,
+    /// Item link.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link: Option<String>,
+    /// Item description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Item author.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// Published timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<String>,
 }

--- a/src/web/handlers/board.rs
+++ b/src/web/handlers/board.rs
@@ -1,0 +1,775 @@
+//! Board handlers for Web API.
+
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use std::sync::Arc;
+
+use crate::board::{
+    BoardRepository, BoardType, NewFlatPost, NewThread, NewThreadPost, PostRepository,
+    ThreadRepository,
+};
+use crate::db::{Role, UserRepository};
+use crate::web::dto::{
+    ApiResponse, AuthorInfo, BoardResponse, CreateFlatPostRequest, CreatePostRequest,
+    CreateThreadRequest, PaginatedResponse, PaginationQuery, PostResponse, ThreadResponse,
+};
+use crate::web::error::ApiError;
+use crate::web::handlers::AppState;
+use crate::web::middleware::{AuthUser, OptionalAuthUser};
+
+/// GET /api/boards - List all accessible boards.
+pub async fn list_boards(
+    State(state): State<Arc<AppState>>,
+    OptionalAuthUser(auth): OptionalAuthUser,
+) -> Result<Json<ApiResponse<Vec<BoardResponse>>>, ApiError> {
+    let user_role = auth
+        .map(|c| Role::from_str(&c.role).unwrap_or(Role::Guest))
+        .unwrap_or(Role::Guest);
+
+    let boards = {
+        let db = state.db.lock().await;
+        let repo = BoardRepository::new(&*db);
+        repo.list_accessible(user_role)
+            .map_err(|e| {
+                tracing::error!("Failed to list boards: {}", e);
+                ApiError::internal("Failed to list boards")
+            })?
+    };
+
+    let responses: Vec<BoardResponse> = boards
+        .into_iter()
+        .map(|b| {
+            let can_read = b.can_read(user_role);
+            let can_write = b.can_write(user_role);
+            BoardResponse {
+                id: b.id,
+                name: b.name,
+                description: b.description,
+                board_type: b.board_type.as_str().to_string(),
+                can_read,
+                can_write,
+                created_at: b.created_at,
+            }
+        })
+        .collect();
+
+    Ok(Json(ApiResponse::new(responses)))
+}
+
+/// GET /api/boards/:id - Get board details.
+pub async fn get_board(
+    State(state): State<Arc<AppState>>,
+    OptionalAuthUser(auth): OptionalAuthUser,
+    Path(board_id): Path<i64>,
+) -> Result<Json<ApiResponse<BoardResponse>>, ApiError> {
+    let user_role = auth
+        .map(|c| Role::from_str(&c.role).unwrap_or(Role::Guest))
+        .unwrap_or(Role::Guest);
+
+    let board = {
+        let db = state.db.lock().await;
+        let repo = BoardRepository::new(&*db);
+        repo.get_by_id(board_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get board: {}", e);
+                ApiError::internal("Failed to get board")
+            })?
+            .ok_or_else(|| ApiError::not_found("Board not found"))?
+    };
+
+    if !board.can_read(user_role) {
+        return Err(ApiError::forbidden("Access denied"));
+    }
+
+    let can_read = board.can_read(user_role);
+    let can_write = board.can_write(user_role);
+    let response = BoardResponse {
+        id: board.id,
+        name: board.name,
+        description: board.description,
+        board_type: board.board_type.as_str().to_string(),
+        can_read,
+        can_write,
+        created_at: board.created_at,
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// GET /api/boards/:id/threads - List threads in a board.
+pub async fn list_threads(
+    State(state): State<Arc<AppState>>,
+    OptionalAuthUser(auth): OptionalAuthUser,
+    Path(board_id): Path<i64>,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<Json<PaginatedResponse<ThreadResponse>>, ApiError> {
+    let user_role = auth
+        .map(|c| Role::from_str(&c.role).unwrap_or(Role::Guest))
+        .unwrap_or(Role::Guest);
+
+    let (offset, limit) = pagination.to_offset_limit();
+
+    let (_board, threads, total) = {
+        let db = state.db.lock().await;
+        let board_repo = BoardRepository::new(&*db);
+        let thread_repo = ThreadRepository::new(&*db);
+
+        let board = board_repo
+            .get_by_id(board_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get board: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Board not found"))?;
+
+        if !board.can_read(user_role) {
+            return Err(ApiError::forbidden("Access denied"));
+        }
+
+        if board.board_type != BoardType::Thread {
+            return Err(ApiError::bad_request("This board does not support threads"));
+        }
+
+        let threads = thread_repo
+            .list_by_board_paginated(board_id, offset, limit)
+            .map_err(|e| {
+                tracing::error!("Failed to list threads: {}", e);
+                ApiError::internal("Database error")
+            })?;
+
+        let total = thread_repo.count_by_board(board_id).map_err(|e| {
+            tracing::error!("Failed to count threads: {}", e);
+            ApiError::internal("Database error")
+        })?;
+
+        (board, threads, total)
+    };
+
+    // Get author info for each thread
+    let responses = {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        threads
+            .into_iter()
+            .map(|t| {
+                let author = user_repo
+                    .get_by_id(t.author_id)
+                    .ok()
+                    .flatten()
+                    .map(|u| AuthorInfo {
+                        id: u.id,
+                        username: u.username,
+                        nickname: u.nickname,
+                    })
+                    .unwrap_or_else(|| AuthorInfo {
+                        id: t.author_id,
+                        username: "unknown".to_string(),
+                        nickname: "Unknown".to_string(),
+                    });
+
+                ThreadResponse {
+                    id: t.id,
+                    board_id: t.board_id,
+                    title: t.title,
+                    author,
+                    post_count: t.post_count,
+                    created_at: t.created_at,
+                    updated_at: t.updated_at,
+                }
+            })
+            .collect()
+    };
+
+    Ok(Json(PaginatedResponse::new(
+        responses,
+        pagination.page,
+        pagination.per_page,
+        total as u64,
+    )))
+}
+
+/// POST /api/boards/:id/threads - Create a new thread.
+pub async fn create_thread(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Path(board_id): Path<i64>,
+    Json(req): Json<CreateThreadRequest>,
+) -> Result<Json<ApiResponse<ThreadResponse>>, ApiError> {
+    let user_role = Role::from_str(&claims.role).unwrap_or(Role::Guest);
+
+    // Validate input
+    if req.title.trim().is_empty() {
+        return Err(ApiError::bad_request("Title is required"));
+    }
+    if req.body.trim().is_empty() {
+        return Err(ApiError::bad_request("Body is required"));
+    }
+
+    let (thread, author) = {
+        let db = state.db.lock().await;
+        let board_repo = BoardRepository::new(&*db);
+        let thread_repo = ThreadRepository::new(&*db);
+        let post_repo = PostRepository::new(&*db);
+        let user_repo = UserRepository::new(&*db);
+
+        // Check board access
+        let board = board_repo
+            .get_by_id(board_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get board: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Board not found"))?;
+
+        if !board.can_write(user_role) {
+            return Err(ApiError::forbidden("Write access denied"));
+        }
+
+        if board.board_type != BoardType::Thread {
+            return Err(ApiError::bad_request("This board does not support threads"));
+        }
+
+        // Create thread
+        let new_thread = NewThread::new(board_id, &req.title, claims.sub);
+        let thread = thread_repo.create(&new_thread).map_err(|e| {
+            tracing::error!("Failed to create thread: {}", e);
+            ApiError::internal("Failed to create thread")
+        })?;
+
+        // Create first post
+        let new_post = NewThreadPost::new(board_id, thread.id, claims.sub, &req.body);
+        post_repo.create_thread_post(&new_post).map_err(|e| {
+            tracing::error!("Failed to create post: {}", e);
+            ApiError::internal("Failed to create post")
+        })?;
+
+        // Update thread post count
+        let thread = thread_repo
+            .touch_and_increment(thread.id)
+            .map_err(|e| {
+                tracing::error!("Failed to update thread: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .unwrap_or(thread);
+
+        // Get author info
+        let author = user_repo
+            .get_by_id(claims.sub)
+            .ok()
+            .flatten()
+            .map(|u| AuthorInfo {
+                id: u.id,
+                username: u.username,
+                nickname: u.nickname,
+            })
+            .unwrap_or_else(|| AuthorInfo {
+                id: claims.sub,
+                username: claims.username.clone(),
+                nickname: claims.username.clone(),
+            });
+
+        (thread, author)
+    };
+
+    let response = ThreadResponse {
+        id: thread.id,
+        board_id: thread.board_id,
+        title: thread.title,
+        author,
+        post_count: thread.post_count,
+        created_at: thread.created_at,
+        updated_at: thread.updated_at,
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// GET /api/boards/:id/posts - List posts in a flat board.
+pub async fn list_flat_posts(
+    State(state): State<Arc<AppState>>,
+    OptionalAuthUser(auth): OptionalAuthUser,
+    Path(board_id): Path<i64>,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<Json<PaginatedResponse<PostResponse>>, ApiError> {
+    let user_role = auth
+        .map(|c| Role::from_str(&c.role).unwrap_or(Role::Guest))
+        .unwrap_or(Role::Guest);
+
+    let (offset, limit) = pagination.to_offset_limit();
+
+    let (posts, total) = {
+        let db = state.db.lock().await;
+        let board_repo = BoardRepository::new(&*db);
+        let post_repo = PostRepository::new(&*db);
+
+        let board = board_repo
+            .get_by_id(board_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get board: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Board not found"))?;
+
+        if !board.can_read(user_role) {
+            return Err(ApiError::forbidden("Access denied"));
+        }
+
+        if board.board_type != BoardType::Flat {
+            return Err(ApiError::bad_request("This board does not support flat posts"));
+        }
+
+        let posts = post_repo
+            .list_by_flat_board_paginated(board_id, offset, limit)
+            .map_err(|e| {
+                tracing::error!("Failed to list posts: {}", e);
+                ApiError::internal("Database error")
+            })?;
+
+        let total = post_repo.count_by_flat_board(board_id).map_err(|e| {
+            tracing::error!("Failed to count posts: {}", e);
+            ApiError::internal("Database error")
+        })?;
+
+        (posts, total)
+    };
+
+    // Get author info for each post
+    let responses = {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        posts
+            .into_iter()
+            .map(|p| {
+                let author = user_repo
+                    .get_by_id(p.author_id)
+                    .ok()
+                    .flatten()
+                    .map(|u| AuthorInfo {
+                        id: u.id,
+                        username: u.username,
+                        nickname: u.nickname,
+                    })
+                    .unwrap_or_else(|| AuthorInfo {
+                        id: p.author_id,
+                        username: "unknown".to_string(),
+                        nickname: "Unknown".to_string(),
+                    });
+
+                PostResponse {
+                    id: p.id,
+                    board_id: p.board_id,
+                    thread_id: p.thread_id,
+                    author,
+                    title: p.title,
+                    body: p.body,
+                    created_at: p.created_at,
+                }
+            })
+            .collect()
+    };
+
+    Ok(Json(PaginatedResponse::new(
+        responses,
+        pagination.page,
+        pagination.per_page,
+        total as u64,
+    )))
+}
+
+/// POST /api/boards/:id/posts - Create a post in a flat board.
+pub async fn create_flat_post(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Path(board_id): Path<i64>,
+    Json(req): Json<CreateFlatPostRequest>,
+) -> Result<Json<ApiResponse<PostResponse>>, ApiError> {
+    let user_role = Role::from_str(&claims.role).unwrap_or(Role::Guest);
+
+    // Validate input
+    if req.title.trim().is_empty() {
+        return Err(ApiError::bad_request("Title is required"));
+    }
+    if req.body.trim().is_empty() {
+        return Err(ApiError::bad_request("Body is required"));
+    }
+
+    let (post, author) = {
+        let db = state.db.lock().await;
+        let board_repo = BoardRepository::new(&*db);
+        let post_repo = PostRepository::new(&*db);
+        let user_repo = UserRepository::new(&*db);
+
+        // Check board access
+        let board = board_repo
+            .get_by_id(board_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get board: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Board not found"))?;
+
+        if !board.can_write(user_role) {
+            return Err(ApiError::forbidden("Write access denied"));
+        }
+
+        if board.board_type != BoardType::Flat {
+            return Err(ApiError::bad_request("This board does not support flat posts"));
+        }
+
+        // Create post
+        let new_post = NewFlatPost::new(board_id, claims.sub, &req.title, &req.body);
+        let post = post_repo.create_flat_post(&new_post).map_err(|e| {
+            tracing::error!("Failed to create post: {}", e);
+            ApiError::internal("Failed to create post")
+        })?;
+
+        // Get author info
+        let author = user_repo
+            .get_by_id(claims.sub)
+            .ok()
+            .flatten()
+            .map(|u| AuthorInfo {
+                id: u.id,
+                username: u.username,
+                nickname: u.nickname,
+            })
+            .unwrap_or_else(|| AuthorInfo {
+                id: claims.sub,
+                username: claims.username.clone(),
+                nickname: claims.username.clone(),
+            });
+
+        (post, author)
+    };
+
+    let response = PostResponse {
+        id: post.id,
+        board_id: post.board_id,
+        thread_id: post.thread_id,
+        author,
+        title: post.title,
+        body: post.body,
+        created_at: post.created_at,
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// GET /api/threads/:id - Get thread details.
+pub async fn get_thread(
+    State(state): State<Arc<AppState>>,
+    OptionalAuthUser(auth): OptionalAuthUser,
+    Path(thread_id): Path<i64>,
+) -> Result<Json<ApiResponse<ThreadResponse>>, ApiError> {
+    let user_role = auth
+        .map(|c| Role::from_str(&c.role).unwrap_or(Role::Guest))
+        .unwrap_or(Role::Guest);
+
+    let (thread, author) = {
+        let db = state.db.lock().await;
+        let thread_repo = ThreadRepository::new(&*db);
+        let board_repo = BoardRepository::new(&*db);
+        let user_repo = UserRepository::new(&*db);
+
+        let thread = thread_repo
+            .get_by_id(thread_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get thread: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Thread not found"))?;
+
+        // Check board access
+        let board = board_repo
+            .get_by_id(thread.board_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get board: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Board not found"))?;
+
+        if !board.can_read(user_role) {
+            return Err(ApiError::forbidden("Access denied"));
+        }
+
+        let author = user_repo
+            .get_by_id(thread.author_id)
+            .ok()
+            .flatten()
+            .map(|u| AuthorInfo {
+                id: u.id,
+                username: u.username,
+                nickname: u.nickname,
+            })
+            .unwrap_or_else(|| AuthorInfo {
+                id: thread.author_id,
+                username: "unknown".to_string(),
+                nickname: "Unknown".to_string(),
+            });
+
+        (thread, author)
+    };
+
+    let response = ThreadResponse {
+        id: thread.id,
+        board_id: thread.board_id,
+        title: thread.title,
+        author,
+        post_count: thread.post_count,
+        created_at: thread.created_at,
+        updated_at: thread.updated_at,
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// GET /api/threads/:id/posts - List posts in a thread.
+pub async fn list_thread_posts(
+    State(state): State<Arc<AppState>>,
+    OptionalAuthUser(auth): OptionalAuthUser,
+    Path(thread_id): Path<i64>,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<Json<PaginatedResponse<PostResponse>>, ApiError> {
+    let user_role = auth
+        .map(|c| Role::from_str(&c.role).unwrap_or(Role::Guest))
+        .unwrap_or(Role::Guest);
+
+    let (offset, limit) = pagination.to_offset_limit();
+
+    let (posts, total) = {
+        let db = state.db.lock().await;
+        let thread_repo = ThreadRepository::new(&*db);
+        let board_repo = BoardRepository::new(&*db);
+        let post_repo = PostRepository::new(&*db);
+
+        let thread = thread_repo
+            .get_by_id(thread_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get thread: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Thread not found"))?;
+
+        // Check board access
+        let board = board_repo
+            .get_by_id(thread.board_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get board: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Board not found"))?;
+
+        if !board.can_read(user_role) {
+            return Err(ApiError::forbidden("Access denied"));
+        }
+
+        let posts = post_repo
+            .list_by_thread_paginated(thread_id, offset, limit)
+            .map_err(|e| {
+                tracing::error!("Failed to list posts: {}", e);
+                ApiError::internal("Database error")
+            })?;
+
+        let total = post_repo.count_by_thread(thread_id).map_err(|e| {
+            tracing::error!("Failed to count posts: {}", e);
+            ApiError::internal("Database error")
+        })?;
+
+        (posts, total)
+    };
+
+    // Get author info for each post
+    let responses = {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        posts
+            .into_iter()
+            .map(|p| {
+                let author = user_repo
+                    .get_by_id(p.author_id)
+                    .ok()
+                    .flatten()
+                    .map(|u| AuthorInfo {
+                        id: u.id,
+                        username: u.username,
+                        nickname: u.nickname,
+                    })
+                    .unwrap_or_else(|| AuthorInfo {
+                        id: p.author_id,
+                        username: "unknown".to_string(),
+                        nickname: "Unknown".to_string(),
+                    });
+
+                PostResponse {
+                    id: p.id,
+                    board_id: p.board_id,
+                    thread_id: p.thread_id,
+                    author,
+                    title: p.title,
+                    body: p.body,
+                    created_at: p.created_at,
+                }
+            })
+            .collect()
+    };
+
+    Ok(Json(PaginatedResponse::new(
+        responses,
+        pagination.page,
+        pagination.per_page,
+        total as u64,
+    )))
+}
+
+/// POST /api/threads/:id/posts - Reply to a thread.
+pub async fn create_thread_post(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Path(thread_id): Path<i64>,
+    Json(req): Json<CreatePostRequest>,
+) -> Result<Json<ApiResponse<PostResponse>>, ApiError> {
+    let user_role = Role::from_str(&claims.role).unwrap_or(Role::Guest);
+
+    // Validate input
+    if req.body.trim().is_empty() {
+        return Err(ApiError::bad_request("Body is required"));
+    }
+
+    let (post, author) = {
+        let db = state.db.lock().await;
+        let thread_repo = ThreadRepository::new(&*db);
+        let board_repo = BoardRepository::new(&*db);
+        let post_repo = PostRepository::new(&*db);
+        let user_repo = UserRepository::new(&*db);
+
+        let thread = thread_repo
+            .get_by_id(thread_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get thread: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Thread not found"))?;
+
+        // Check board access
+        let board = board_repo
+            .get_by_id(thread.board_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get board: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Board not found"))?;
+
+        if !board.can_write(user_role) {
+            return Err(ApiError::forbidden("Write access denied"));
+        }
+
+        // Create post
+        let new_post = NewThreadPost::new(thread.board_id, thread_id, claims.sub, &req.body);
+        let post = post_repo.create_thread_post(&new_post).map_err(|e| {
+            tracing::error!("Failed to create post: {}", e);
+            ApiError::internal("Failed to create post")
+        })?;
+
+        // Update thread
+        thread_repo.touch_and_increment(thread_id).map_err(|e| {
+            tracing::error!("Failed to update thread: {}", e);
+            ApiError::internal("Database error")
+        })?;
+
+        // Get author info
+        let author = user_repo
+            .get_by_id(claims.sub)
+            .ok()
+            .flatten()
+            .map(|u| AuthorInfo {
+                id: u.id,
+                username: u.username,
+                nickname: u.nickname,
+            })
+            .unwrap_or_else(|| AuthorInfo {
+                id: claims.sub,
+                username: claims.username.clone(),
+                nickname: claims.username.clone(),
+            });
+
+        (post, author)
+    };
+
+    let response = PostResponse {
+        id: post.id,
+        board_id: post.board_id,
+        thread_id: post.thread_id,
+        author,
+        title: post.title,
+        body: post.body,
+        created_at: post.created_at,
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// DELETE /api/posts/:id - Delete a post.
+pub async fn delete_post(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Path(post_id): Path<i64>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    let user_role = Role::from_str(&claims.role).unwrap_or(Role::Guest);
+
+    {
+        let db = state.db.lock().await;
+        let post_repo = PostRepository::new(&*db);
+        let thread_repo = ThreadRepository::new(&*db);
+
+        let post = post_repo
+            .get_by_id(post_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get post: {}", e);
+                ApiError::internal("Database error")
+            })?
+            .ok_or_else(|| ApiError::not_found("Post not found"))?;
+
+        // Only author or admin can delete
+        if post.author_id != claims.sub && user_role < Role::SubOp {
+            return Err(ApiError::forbidden("You can only delete your own posts"));
+        }
+
+        // Delete the post
+        post_repo.delete(post_id).map_err(|e| {
+            tracing::error!("Failed to delete post: {}", e);
+            ApiError::internal("Failed to delete post")
+        })?;
+
+        // Update thread post count if it's a thread post
+        if let Some(thread_id) = post.thread_id {
+            thread_repo.decrement_post_count(thread_id).map_err(|e| {
+                tracing::error!("Failed to update thread: {}", e);
+                ApiError::internal("Database error")
+            })?;
+        }
+    }
+
+    Ok(Json(ApiResponse::new(())))
+}
+
+// Helper to parse Role from string
+trait RoleExt {
+    fn from_str(s: &str) -> Option<Role>;
+}
+
+impl RoleExt for Role {
+    fn from_str(s: &str) -> Option<Role> {
+        match s.to_lowercase().as_str() {
+            "guest" => Some(Role::Guest),
+            "member" => Some(Role::Member),
+            "subop" => Some(Role::SubOp),
+            "sysop" => Some(Role::SysOp),
+            _ => None,
+        }
+    }
+}

--- a/src/web/handlers/mail.rs
+++ b/src/web/handlers/mail.rs
@@ -1,0 +1,415 @@
+//! Mail handlers for Web API.
+
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use std::sync::Arc;
+
+use crate::db::UserRepository;
+use crate::mail::{MailRepository, MailUpdate, NewMail};
+use crate::web::dto::{
+    ApiResponse, AuthorInfo, MailDetailResponse, MailListResponse, PaginatedResponse,
+    PaginationQuery, SendMailRequest, UnreadCountResponse,
+};
+use crate::web::error::ApiError;
+use crate::web::handlers::AppState;
+use crate::web::middleware::AuthUser;
+
+/// GET /api/mail/inbox - List received mails.
+pub async fn list_inbox(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<Json<PaginatedResponse<MailListResponse>>, ApiError> {
+    let (offset, limit) = pagination.to_offset_limit();
+
+    let (mails, total) = {
+        let db = state.db.lock().await;
+        let all_mails = MailRepository::list_inbox(db.conn(), claims.sub).map_err(|e| {
+            tracing::error!("Failed to list inbox: {}", e);
+            ApiError::internal("Failed to list inbox")
+        })?;
+
+        let total = all_mails.len() as i64;
+
+        // Manual pagination
+        let mails: Vec<_> = all_mails
+            .into_iter()
+            .skip(offset as usize)
+            .take(limit as usize)
+            .collect();
+
+        (mails, total)
+    };
+
+    // Get user info for senders and recipients
+    let responses = {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        mails
+            .into_iter()
+            .map(|m| {
+                let sender = user_repo
+                    .get_by_id(m.sender_id)
+                    .ok()
+                    .flatten()
+                    .map(|u| AuthorInfo {
+                        id: u.id,
+                        username: u.username,
+                        nickname: u.nickname,
+                    })
+                    .unwrap_or_else(|| AuthorInfo {
+                        id: m.sender_id,
+                        username: "unknown".to_string(),
+                        nickname: "Unknown".to_string(),
+                    });
+
+                let recipient = user_repo
+                    .get_by_id(m.recipient_id)
+                    .ok()
+                    .flatten()
+                    .map(|u| AuthorInfo {
+                        id: u.id,
+                        username: u.username,
+                        nickname: u.nickname,
+                    })
+                    .unwrap_or_else(|| AuthorInfo {
+                        id: m.recipient_id,
+                        username: "unknown".to_string(),
+                        nickname: "Unknown".to_string(),
+                    });
+
+                MailListResponse {
+                    id: m.id,
+                    sender,
+                    recipient,
+                    subject: m.subject,
+                    is_read: m.is_read,
+                    created_at: m.created_at.to_rfc3339(),
+                }
+            })
+            .collect()
+    };
+
+    Ok(Json(PaginatedResponse::new(
+        responses,
+        pagination.page,
+        pagination.per_page,
+        total as u64,
+    )))
+}
+
+/// GET /api/mail/sent - List sent mails.
+pub async fn list_sent(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<Json<PaginatedResponse<MailListResponse>>, ApiError> {
+    let (offset, limit) = pagination.to_offset_limit();
+
+    let (mails, total) = {
+        let db = state.db.lock().await;
+        let all_mails = MailRepository::list_sent(db.conn(), claims.sub).map_err(|e| {
+            tracing::error!("Failed to list sent: {}", e);
+            ApiError::internal("Failed to list sent mails")
+        })?;
+
+        let total = all_mails.len() as i64;
+
+        // Manual pagination
+        let mails: Vec<_> = all_mails
+            .into_iter()
+            .skip(offset as usize)
+            .take(limit as usize)
+            .collect();
+
+        (mails, total)
+    };
+
+    // Get user info for senders and recipients
+    let responses = {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        mails
+            .into_iter()
+            .map(|m| {
+                let sender = user_repo
+                    .get_by_id(m.sender_id)
+                    .ok()
+                    .flatten()
+                    .map(|u| AuthorInfo {
+                        id: u.id,
+                        username: u.username,
+                        nickname: u.nickname,
+                    })
+                    .unwrap_or_else(|| AuthorInfo {
+                        id: m.sender_id,
+                        username: "unknown".to_string(),
+                        nickname: "Unknown".to_string(),
+                    });
+
+                let recipient = user_repo
+                    .get_by_id(m.recipient_id)
+                    .ok()
+                    .flatten()
+                    .map(|u| AuthorInfo {
+                        id: u.id,
+                        username: u.username,
+                        nickname: u.nickname,
+                    })
+                    .unwrap_or_else(|| AuthorInfo {
+                        id: m.recipient_id,
+                        username: "unknown".to_string(),
+                        nickname: "Unknown".to_string(),
+                    });
+
+                MailListResponse {
+                    id: m.id,
+                    sender,
+                    recipient,
+                    subject: m.subject,
+                    is_read: m.is_read,
+                    created_at: m.created_at.to_rfc3339(),
+                }
+            })
+            .collect()
+    };
+
+    Ok(Json(PaginatedResponse::new(
+        responses,
+        pagination.page,
+        pagination.per_page,
+        total as u64,
+    )))
+}
+
+/// GET /api/mail/:id - Get mail details.
+pub async fn get_mail(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Path(mail_id): Path<i64>,
+) -> Result<Json<ApiResponse<MailDetailResponse>>, ApiError> {
+    let (mail, sender, recipient) = {
+        let db = state.db.lock().await;
+
+        let mail = MailRepository::get_by_id(db.conn(), mail_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get mail: {}", e);
+                ApiError::internal("Failed to get mail")
+            })?
+            .ok_or_else(|| ApiError::not_found("Mail not found"))?;
+
+        // Check access - must be sender or recipient
+        if mail.sender_id != claims.sub && mail.recipient_id != claims.sub {
+            return Err(ApiError::forbidden("Access denied"));
+        }
+
+        // Check if deleted
+        if mail.sender_id == claims.sub && mail.is_deleted_by_sender {
+            return Err(ApiError::not_found("Mail not found"));
+        }
+        if mail.recipient_id == claims.sub && mail.is_deleted_by_recipient {
+            return Err(ApiError::not_found("Mail not found"));
+        }
+
+        // Mark as read if recipient
+        if mail.recipient_id == claims.sub && !mail.is_read {
+            MailRepository::update(db.conn(), mail_id, &MailUpdate::new().mark_as_read())
+                .map_err(|e| {
+                    tracing::error!("Failed to mark mail as read: {}", e);
+                    ApiError::internal("Database error")
+                })?;
+        }
+
+        let user_repo = UserRepository::new(&*db);
+
+        let sender = user_repo
+            .get_by_id(mail.sender_id)
+            .ok()
+            .flatten()
+            .map(|u| AuthorInfo {
+                id: u.id,
+                username: u.username,
+                nickname: u.nickname,
+            })
+            .unwrap_or_else(|| AuthorInfo {
+                id: mail.sender_id,
+                username: "unknown".to_string(),
+                nickname: "Unknown".to_string(),
+            });
+
+        let recipient = user_repo
+            .get_by_id(mail.recipient_id)
+            .ok()
+            .flatten()
+            .map(|u| AuthorInfo {
+                id: u.id,
+                username: u.username,
+                nickname: u.nickname,
+            })
+            .unwrap_or_else(|| AuthorInfo {
+                id: mail.recipient_id,
+                username: "unknown".to_string(),
+                nickname: "Unknown".to_string(),
+            });
+
+        (mail, sender, recipient)
+    };
+
+    let response = MailDetailResponse {
+        id: mail.id,
+        sender,
+        recipient,
+        subject: mail.subject,
+        body: mail.body,
+        is_read: mail.is_read,
+        created_at: mail.created_at.to_rfc3339(),
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// POST /api/mail - Send a mail.
+pub async fn send_mail(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Json(req): Json<SendMailRequest>,
+) -> Result<Json<ApiResponse<MailDetailResponse>>, ApiError> {
+    // Validate input
+    if req.subject.trim().is_empty() {
+        return Err(ApiError::bad_request("Subject is required"));
+    }
+    if req.body.trim().is_empty() {
+        return Err(ApiError::bad_request("Body is required"));
+    }
+
+    let (mail, sender, recipient_info) = {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        // Find recipient by username or ID
+        let recipient = if let Ok(id) = req.recipient.parse::<i64>() {
+            user_repo
+                .get_by_id(id)
+                .map_err(|e| {
+                    tracing::error!("Failed to find recipient: {}", e);
+                    ApiError::internal("Database error")
+                })?
+                .ok_or_else(|| ApiError::not_found("Recipient not found"))?
+        } else {
+            user_repo
+                .get_by_username(&req.recipient)
+                .map_err(|e| {
+                    tracing::error!("Failed to find recipient: {}", e);
+                    ApiError::internal("Database error")
+                })?
+                .ok_or_else(|| ApiError::not_found("Recipient not found"))?
+        };
+
+        // Cannot send to self
+        if recipient.id == claims.sub {
+            return Err(ApiError::bad_request("Cannot send mail to yourself"));
+        }
+
+        // Create mail
+        let new_mail = NewMail::new(claims.sub, recipient.id, &req.subject, &req.body);
+        let mail = MailRepository::create(db.conn(), &new_mail).map_err(|e| {
+            tracing::error!("Failed to send mail: {}", e);
+            ApiError::internal("Failed to send mail")
+        })?;
+
+        // Get sender info
+        let sender = user_repo
+            .get_by_id(claims.sub)
+            .ok()
+            .flatten()
+            .map(|u| AuthorInfo {
+                id: u.id,
+                username: u.username,
+                nickname: u.nickname,
+            })
+            .unwrap_or_else(|| AuthorInfo {
+                id: claims.sub,
+                username: claims.username.clone(),
+                nickname: claims.username.clone(),
+            });
+
+        let recipient_info = AuthorInfo {
+            id: recipient.id,
+            username: recipient.username,
+            nickname: recipient.nickname,
+        };
+
+        (mail, sender, recipient_info)
+    };
+
+    let response = MailDetailResponse {
+        id: mail.id,
+        sender,
+        recipient: recipient_info,
+        subject: mail.subject,
+        body: mail.body,
+        is_read: mail.is_read,
+        created_at: mail.created_at.to_rfc3339(),
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// DELETE /api/mail/:id - Delete a mail.
+pub async fn delete_mail(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Path(mail_id): Path<i64>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    {
+        let db = state.db.lock().await;
+
+        let mail = MailRepository::get_by_id(db.conn(), mail_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get mail: {}", e);
+                ApiError::internal("Failed to get mail")
+            })?
+            .ok_or_else(|| ApiError::not_found("Mail not found"))?;
+
+        // Check access - must be sender or recipient
+        if mail.sender_id != claims.sub && mail.recipient_id != claims.sub {
+            return Err(ApiError::forbidden("Access denied"));
+        }
+
+        // Mark as deleted for the appropriate party
+        let update = if mail.sender_id == claims.sub {
+            MailUpdate::new().delete_by_sender()
+        } else {
+            MailUpdate::new().delete_by_recipient()
+        };
+
+        MailRepository::update(db.conn(), mail_id, &update).map_err(|e| {
+            tracing::error!("Failed to delete mail: {}", e);
+            ApiError::internal("Failed to delete mail")
+        })?;
+    }
+
+    Ok(Json(ApiResponse::new(())))
+}
+
+/// GET /api/mail/unread-count - Get unread mail count.
+pub async fn get_unread_count(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+) -> Result<Json<ApiResponse<UnreadCountResponse>>, ApiError> {
+    let count = {
+        let db = state.db.lock().await;
+        MailRepository::count_unread(db.conn(), claims.sub).map_err(|e| {
+            tracing::error!("Failed to count unread: {}", e);
+            ApiError::internal("Failed to count unread mails")
+        })?
+    };
+
+    Ok(Json(ApiResponse::new(UnreadCountResponse {
+        count: count as u64,
+    })))
+}

--- a/src/web/handlers/mod.rs
+++ b/src/web/handlers/mod.rs
@@ -1,5 +1,13 @@
 //! API handlers for Web UI.
 
 pub mod auth;
+pub mod board;
+pub mod mail;
+pub mod rss;
+pub mod user;
 
 pub use auth::*;
+pub use board::*;
+pub use mail::*;
+pub use rss::*;
+pub use user::*;

--- a/src/web/handlers/rss.rs
+++ b/src/web/handlers/rss.rs
@@ -1,0 +1,234 @@
+//! RSS handlers for Web API.
+
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use std::sync::Arc;
+
+use crate::rss::{RssFeedRepository, RssItemRepository, RssReadPositionRepository};
+use crate::web::dto::{
+    ApiResponse, PaginatedResponse, PaginationQuery, RssFeedResponse, RssItemResponse,
+};
+use crate::web::error::ApiError;
+use crate::web::handlers::AppState;
+use crate::web::middleware::AuthUser;
+
+/// Response for RSS feed with unread count.
+#[derive(Debug, serde::Serialize)]
+pub struct RssFeedWithUnreadResponse {
+    /// Feed info.
+    #[serde(flatten)]
+    pub feed: RssFeedResponse,
+    /// Unread item count.
+    pub unread_count: i64,
+}
+
+/// GET /api/rss - List all active RSS feeds.
+pub async fn list_feeds(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+) -> Result<Json<ApiResponse<Vec<RssFeedWithUnreadResponse>>>, ApiError> {
+    let feeds = {
+        let db = state.db.lock().await;
+
+        RssFeedRepository::list_with_unread(db.conn(), Some(claims.sub)).map_err(|e| {
+            tracing::error!("Failed to list RSS feeds: {}", e);
+            ApiError::internal("Failed to list RSS feeds")
+        })?
+    };
+
+    let responses: Vec<_> = feeds
+        .into_iter()
+        .map(|f| RssFeedWithUnreadResponse {
+            feed: RssFeedResponse {
+                id: f.feed.id,
+                url: f.feed.url,
+                title: f.feed.title,
+                description: f.feed.description,
+                site_url: f.feed.site_url,
+                last_fetched_at: f.feed.last_fetched_at.map(|dt| dt.to_rfc3339()),
+                is_active: f.feed.is_active,
+            },
+            unread_count: f.unread_count,
+        })
+        .collect();
+
+    Ok(Json(ApiResponse::new(responses)))
+}
+
+/// GET /api/rss/:id - Get feed details.
+pub async fn get_feed(
+    State(state): State<Arc<AppState>>,
+    AuthUser(_claims): AuthUser,
+    Path(feed_id): Path<i64>,
+) -> Result<Json<ApiResponse<RssFeedResponse>>, ApiError> {
+    let feed = {
+        let db = state.db.lock().await;
+
+        RssFeedRepository::get_by_id(db.conn(), feed_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get RSS feed: {}", e);
+                ApiError::internal("Failed to get RSS feed")
+            })?
+            .ok_or_else(|| ApiError::not_found("Feed not found"))?
+    };
+
+    // Only show active feeds
+    if !feed.is_active {
+        return Err(ApiError::not_found("Feed not found"));
+    }
+
+    let response = RssFeedResponse {
+        id: feed.id,
+        url: feed.url,
+        title: feed.title,
+        description: feed.description,
+        site_url: feed.site_url,
+        last_fetched_at: feed.last_fetched_at.map(|dt| dt.to_rfc3339()),
+        is_active: feed.is_active,
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// GET /api/rss/:id/items - List items for a feed.
+pub async fn list_items(
+    State(state): State<Arc<AppState>>,
+    AuthUser(_claims): AuthUser,
+    Path(feed_id): Path<i64>,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<Json<PaginatedResponse<RssItemResponse>>, ApiError> {
+    let (offset, limit) = pagination.to_offset_limit();
+
+    let (items, total) = {
+        let db = state.db.lock().await;
+
+        // Check if feed exists and is active
+        let feed = RssFeedRepository::get_by_id(db.conn(), feed_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get RSS feed: {}", e);
+                ApiError::internal("Failed to get RSS feed")
+            })?
+            .ok_or_else(|| ApiError::not_found("Feed not found"))?;
+
+        if !feed.is_active {
+            return Err(ApiError::not_found("Feed not found"));
+        }
+
+        let total = RssItemRepository::count_by_feed(db.conn(), feed_id).map_err(|e| {
+            tracing::error!("Failed to count RSS items: {}", e);
+            ApiError::internal("Failed to count RSS items")
+        })?;
+
+        let items =
+            RssItemRepository::list_by_feed(db.conn(), feed_id, limit as usize, offset as usize)
+                .map_err(|e| {
+                    tracing::error!("Failed to list RSS items: {}", e);
+                    ApiError::internal("Failed to list RSS items")
+                })?;
+
+        (items, total)
+    };
+
+    let responses: Vec<_> = items
+        .into_iter()
+        .map(|item| RssItemResponse {
+            id: item.id,
+            feed_id: item.feed_id,
+            title: item.title,
+            link: item.link,
+            description: item.description,
+            author: item.author,
+            published_at: item.published_at.map(|dt| dt.to_rfc3339()),
+        })
+        .collect();
+
+    Ok(Json(PaginatedResponse::new(
+        responses,
+        pagination.page,
+        pagination.per_page,
+        total as u64,
+    )))
+}
+
+/// GET /api/rss/:feed_id/items/:item_id - Get item details.
+pub async fn get_item(
+    State(state): State<Arc<AppState>>,
+    AuthUser(_claims): AuthUser,
+    Path((feed_id, item_id)): Path<(i64, i64)>,
+) -> Result<Json<ApiResponse<RssItemResponse>>, ApiError> {
+    let item = {
+        let db = state.db.lock().await;
+
+        // Check if feed exists and is active
+        let feed = RssFeedRepository::get_by_id(db.conn(), feed_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get RSS feed: {}", e);
+                ApiError::internal("Failed to get RSS feed")
+            })?
+            .ok_or_else(|| ApiError::not_found("Feed not found"))?;
+
+        if !feed.is_active {
+            return Err(ApiError::not_found("Feed not found"));
+        }
+
+        let item = RssItemRepository::get_by_id(db.conn(), item_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get RSS item: {}", e);
+                ApiError::internal("Failed to get RSS item")
+            })?
+            .ok_or_else(|| ApiError::not_found("Item not found"))?;
+
+        // Verify item belongs to the feed
+        if item.feed_id != feed_id {
+            return Err(ApiError::not_found("Item not found"));
+        }
+
+        item
+    };
+
+    let response = RssItemResponse {
+        id: item.id,
+        feed_id: item.feed_id,
+        title: item.title,
+        link: item.link,
+        description: item.description,
+        author: item.author,
+        published_at: item.published_at.map(|dt| dt.to_rfc3339()),
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// POST /api/rss/:id/mark-read - Mark all items as read.
+pub async fn mark_as_read(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Path(feed_id): Path<i64>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    {
+        let db = state.db.lock().await;
+
+        // Check if feed exists and is active
+        let feed = RssFeedRepository::get_by_id(db.conn(), feed_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get RSS feed: {}", e);
+                ApiError::internal("Failed to get RSS feed")
+            })?
+            .ok_or_else(|| ApiError::not_found("Feed not found"))?;
+
+        if !feed.is_active {
+            return Err(ApiError::not_found("Feed not found"));
+        }
+
+        RssReadPositionRepository::mark_all_as_read(db.conn(), claims.sub, feed_id).map_err(
+            |e| {
+                tracing::error!("Failed to mark RSS items as read: {}", e);
+                ApiError::internal("Failed to mark items as read")
+            },
+        )?;
+    }
+
+    Ok(Json(ApiResponse::new(())))
+}

--- a/src/web/handlers/user.rs
+++ b/src/web/handlers/user.rs
@@ -1,0 +1,251 @@
+//! User handlers for Web API.
+
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use std::sync::Arc;
+
+use crate::auth::{hash_password, verify_password};
+use crate::db::{UserRepository, UserUpdate};
+use crate::web::dto::{
+    ApiResponse, ChangePasswordRequest, PaginatedResponse, PaginationQuery, UpdateProfileRequest,
+    UserDetailResponse, UserListResponse,
+};
+use crate::web::error::ApiError;
+use crate::web::handlers::AppState;
+use crate::web::middleware::AuthUser;
+
+/// GET /api/users - List all users (paginated).
+pub async fn list_users(
+    State(state): State<Arc<AppState>>,
+    AuthUser(_claims): AuthUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<Json<PaginatedResponse<UserListResponse>>, ApiError> {
+    let (offset, limit) = pagination.to_offset_limit();
+
+    let (users, total) = {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        let all_users = user_repo.list_active().map_err(|e| {
+            tracing::error!("Failed to list users: {}", e);
+            ApiError::internal("Failed to list users")
+        })?;
+
+        let total = all_users.len() as i64;
+
+        // Manual pagination
+        let users: Vec<_> = all_users
+            .into_iter()
+            .skip(offset as usize)
+            .take(limit as usize)
+            .collect();
+
+        (users, total)
+    };
+
+    let responses: Vec<_> = users
+        .into_iter()
+        .map(|u| UserListResponse {
+            id: u.id,
+            username: u.username,
+            nickname: u.nickname,
+            role: u.role.as_str().to_string(),
+            last_login_at: u.last_login,
+        })
+        .collect();
+
+    Ok(Json(PaginatedResponse::new(
+        responses,
+        pagination.page,
+        pagination.per_page,
+        total as u64,
+    )))
+}
+
+/// GET /api/users/:id - Get user profile by ID.
+pub async fn get_user(
+    State(state): State<Arc<AppState>>,
+    AuthUser(_claims): AuthUser,
+    Path(user_id): Path<i64>,
+) -> Result<Json<ApiResponse<UserDetailResponse>>, ApiError> {
+    let user = {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        user_repo
+            .get_by_id(user_id)
+            .map_err(|e| {
+                tracing::error!("Failed to get user: {}", e);
+                ApiError::internal("Failed to get user")
+            })?
+            .ok_or_else(|| ApiError::not_found("User not found"))?
+    };
+
+    // Only show active users
+    if !user.is_active {
+        return Err(ApiError::not_found("User not found"));
+    }
+
+    let response = UserDetailResponse {
+        id: user.id,
+        username: user.username,
+        nickname: user.nickname,
+        role: user.role.as_str().to_string(),
+        profile: user.profile,
+        created_at: user.created_at,
+        last_login_at: user.last_login,
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// GET /api/users/me - Get current user's profile.
+pub async fn get_my_profile(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+) -> Result<Json<ApiResponse<UserDetailResponse>>, ApiError> {
+    let user = {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        user_repo
+            .get_by_id(claims.sub)
+            .map_err(|e| {
+                tracing::error!("Failed to get user: {}", e);
+                ApiError::internal("Failed to get user")
+            })?
+            .ok_or_else(|| ApiError::not_found("User not found"))?
+    };
+
+    let response = UserDetailResponse {
+        id: user.id,
+        username: user.username,
+        nickname: user.nickname,
+        role: user.role.as_str().to_string(),
+        profile: user.profile,
+        created_at: user.created_at,
+        last_login_at: user.last_login,
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// PUT /api/users/me - Update current user's profile.
+pub async fn update_my_profile(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Json(req): Json<UpdateProfileRequest>,
+) -> Result<Json<ApiResponse<UserDetailResponse>>, ApiError> {
+    // Build update struct
+    let mut update = UserUpdate::new();
+
+    if let Some(nickname) = req.nickname {
+        if nickname.trim().is_empty() {
+            return Err(ApiError::bad_request("Nickname cannot be empty"));
+        }
+        if nickname.len() > 20 {
+            return Err(ApiError::bad_request(
+                "Nickname must be 20 characters or less",
+            ));
+        }
+        update = update.nickname(nickname);
+    }
+
+    if let Some(email) = req.email {
+        let email_opt = if email.trim().is_empty() {
+            None
+        } else {
+            Some(email)
+        };
+        update = update.email(email_opt);
+    }
+
+    if let Some(profile) = req.profile {
+        let profile_opt = if profile.trim().is_empty() {
+            None
+        } else {
+            Some(profile)
+        };
+        update = update.profile(profile_opt);
+    }
+
+    let user = {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        user_repo
+            .update(claims.sub, &update)
+            .map_err(|e| {
+                tracing::error!("Failed to update profile: {}", e);
+                ApiError::internal("Failed to update profile")
+            })?
+            .ok_or_else(|| ApiError::not_found("User not found"))?
+    };
+
+    let response = UserDetailResponse {
+        id: user.id,
+        username: user.username,
+        nickname: user.nickname,
+        role: user.role.as_str().to_string(),
+        profile: user.profile,
+        created_at: user.created_at,
+        last_login_at: user.last_login,
+    };
+
+    Ok(Json(ApiResponse::new(response)))
+}
+
+/// POST /api/users/me/password - Change current user's password.
+pub async fn change_password(
+    State(state): State<Arc<AppState>>,
+    AuthUser(claims): AuthUser,
+    Json(req): Json<ChangePasswordRequest>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    // Validate new password
+    if req.new_password.len() < 8 {
+        return Err(ApiError::bad_request(
+            "Password must be at least 8 characters",
+        ));
+    }
+    if req.new_password.len() > 128 {
+        return Err(ApiError::bad_request(
+            "Password must be 128 characters or less",
+        ));
+    }
+
+    {
+        let db = state.db.lock().await;
+        let user_repo = UserRepository::new(&*db);
+
+        // Get current user
+        let user = user_repo
+            .get_by_id(claims.sub)
+            .map_err(|e| {
+                tracing::error!("Failed to get user: {}", e);
+                ApiError::internal("Failed to get user")
+            })?
+            .ok_or_else(|| ApiError::not_found("User not found"))?;
+
+        // Verify current password
+        verify_password(&req.current_password, &user.password).map_err(|_| {
+            ApiError::unauthorized("Current password is incorrect")
+        })?;
+
+        // Hash new password
+        let new_hash = hash_password(&req.new_password).map_err(|e| {
+            tracing::error!("Failed to hash password: {}", e);
+            ApiError::internal("Failed to update password")
+        })?;
+
+        // Update password
+        let update = UserUpdate::new().password(new_hash);
+        user_repo.update(claims.sub, &update).map_err(|e| {
+            tracing::error!("Failed to update password: {}", e);
+            ApiError::internal("Failed to update password")
+        })?;
+    }
+
+    Ok(Json(ApiResponse::new(())))
+}

--- a/src/web/router.rs
+++ b/src/web/router.rs
@@ -2,14 +2,28 @@
 
 use axum::{
     middleware,
-    routing::{get, post},
+    routing::{delete, get, post, put},
     Router,
 };
 use std::sync::Arc;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 
-use super::handlers::{login, logout, me, refresh, register, AppState};
+use super::handlers::{
+    // Auth handlers
+    login, logout, me, refresh, register,
+    // Board handlers
+    create_flat_post, create_thread, create_thread_post, delete_post, get_board, get_thread,
+    list_boards, list_flat_posts, list_thread_posts, list_threads,
+    // Mail handlers
+    delete_mail, get_mail, get_unread_count, list_inbox, list_sent, send_mail,
+    // RSS handlers
+    get_feed, get_item, list_feeds, list_items, mark_as_read,
+    // User handlers
+    change_password, get_my_profile, get_user, list_users, update_my_profile,
+    // State
+    AppState,
+};
 use super::middleware::{create_cors_layer, jwt_auth, JwtState};
 
 /// Create the main API router.
@@ -26,17 +40,67 @@ pub fn create_router(
         .route("/register", post(register));
 
     // Auth routes (authentication required)
-    let auth_protected_routes = Router::new()
-        .route("/me", get(me));
+    let auth_protected_routes = Router::new().route("/me", get(me));
 
     // Combine auth routes
     let auth_routes = Router::new()
         .merge(auth_public_routes)
         .merge(auth_protected_routes);
 
+    // Board routes
+    let board_routes = Router::new()
+        .route("/", get(list_boards))
+        .route("/{id}", get(get_board))
+        // Thread-based board routes
+        .route("/{id}/threads", get(list_threads))
+        .route("/{id}/threads", post(create_thread))
+        // Flat board routes
+        .route("/{id}/posts", get(list_flat_posts))
+        .route("/{id}/posts", post(create_flat_post));
+
+    // Thread routes
+    let thread_routes = Router::new()
+        .route("/{id}", get(get_thread))
+        .route("/{id}/posts", get(list_thread_posts))
+        .route("/{id}/posts", post(create_thread_post));
+
+    // Post routes
+    let post_routes = Router::new().route("/{id}", delete(delete_post));
+
+    // Mail routes
+    let mail_routes = Router::new()
+        .route("/inbox", get(list_inbox))
+        .route("/sent", get(list_sent))
+        .route("/unread-count", get(get_unread_count))
+        .route("/", post(send_mail))
+        .route("/{id}", get(get_mail))
+        .route("/{id}", delete(delete_mail));
+
+    // User routes
+    let user_routes = Router::new()
+        .route("/", get(list_users))
+        .route("/me", get(get_my_profile))
+        .route("/me", put(update_my_profile))
+        .route("/me/password", post(change_password))
+        .route("/{id}", get(get_user));
+
+    // RSS routes
+    let rss_routes = Router::new()
+        .route("/", get(list_feeds))
+        .route("/{id}", get(get_feed))
+        .route("/{id}/items", get(list_items))
+        .route("/{feed_id}/items/{item_id}", get(get_item))
+        .route("/{id}/mark-read", post(mark_as_read));
+
     // API routes
     let api_routes = Router::new()
-        .nest("/auth", auth_routes);
+        .nest("/auth", auth_routes)
+        .nest("/boards", board_routes)
+        .nest("/threads", thread_routes)
+        .nest("/posts", post_routes)
+        .nest("/mail", mail_routes)
+        .nest("/users", user_routes)
+        .nest("/rss", rss_routes);
 
     // Clone jwt_state for the middleware closure
     let jwt_state_for_middleware = jwt_state.clone();


### PR DESCRIPTION
## Summary

Web UI Phase 2として、コア機能のREST APIを実装しました。

### 実装内容

#### 掲示板API (`/api/boards`, `/api/threads`, `/api/posts`)
- 掲示板一覧・詳細取得
- スレッド一覧・作成・詳細取得
- フラット投稿一覧・作成
- スレッド投稿一覧・作成・削除
- ロールベースのアクセス制御（read_role, write_role）

#### メールAPI (`/api/mail`)
- 受信トレイ・送信済み一覧（ページネーション付き）
- メール詳細取得（開くと既読マーク）
- メール送信（ユーザー名またはIDで宛先指定）
- メール削除（送信者/受信者で個別に削除フラグ管理）
- 未読カウント取得

#### ユーザーAPI (`/api/users`)
- ユーザー一覧（ページネーション付き）
- ユーザープロフィール取得
- 自分のプロフィール取得・更新
- パスワード変更（現在のパスワード確認付き）

#### RSS API (`/api/rss`)
- フィード一覧（未読カウント付き）
- フィード詳細取得
- アイテム一覧・詳細取得（ページネーション付き）
- 既読マーク

#### その他
- `config.toml` の `web.enabled` デフォルトを `true` に変更
- 共通DTOの拡張（PaginationQuery等）

## Test plan
- [x] `cargo build` でビルド成功
- [x] `cargo test web` でWeb関連テスト11件すべて成功
- [x] `cargo clippy` で新規エラーなし

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)