### PR TITLE
fix: auto_paging機能追加に伴うテスト修正

### DIFF
--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -94,6 +94,7 @@ pub enum AdminError {
 ///     created_at: "2024-01-01".to_string(),
 ///     last_login: None,
 ///     is_active: true,
+///     auto_paging: false,
 /// };
 ///
 /// assert!(require_admin(Some(&subop)).is_ok());

--- a/tests/e2e_profile_settings.rs
+++ b/tests/e2e_profile_settings.rs
@@ -171,6 +171,15 @@ async fn test_change_language_en_to_ja() {
     // Keep terminal profile as default
     client.send_line("").await.unwrap();
 
+    // Wait for auto paging prompt (added in Issue #224)
+    let _ = client
+        .recv_timeout(Duration::from_secs(1))
+        .await
+        .unwrap_or_default();
+
+    // Keep auto paging as default
+    client.send_line("").await.unwrap();
+
     // Wait for settings saved message and return to main menu
     // After SettingsChanged, we go back to main menu (not profile)
     let mut response = client.recv_timeout(Duration::from_secs(2)).await.unwrap();
@@ -270,6 +279,15 @@ async fn test_change_encoding_utf8_to_shiftjis() {
     // Keep terminal profile as default
     client.send_line("").await.unwrap();
 
+    // Wait for auto paging prompt (added in Issue #224)
+    let _ = client
+        .recv_timeout(Duration::from_secs(1))
+        .await
+        .unwrap_or_default();
+
+    // Keep auto paging as default
+    client.send_line("").await.unwrap();
+
     // Wait for settings saved message
     let mut response = client.recv_timeout(Duration::from_secs(2)).await.unwrap();
 
@@ -361,6 +379,15 @@ async fn test_settings_persist_on_main_menu() {
         .unwrap_or_default();
 
     // Keep terminal profile as default
+    client.send_line("").await.unwrap();
+
+    // Wait for auto paging prompt (added in Issue #224)
+    let _ = client
+        .recv_timeout(Duration::from_secs(1))
+        .await
+        .unwrap_or_default();
+
+    // Keep auto paging as default
     client.send_line("").await.unwrap();
 
     // After SettingsChanged, we go back to main menu (not profile)


### PR DESCRIPTION
## Summary
- Issue #224 で追加された自動ページング機能により失敗していたテストを修正

## Changes
- `tests/e2e_profile_settings.rs`: 設定画面フローに自動ページングプロンプトの処理を追加
- `src/admin/mod.rs`: doctestのUser構造体にauto_pagingフィールドを追加

## Test plan
- [x] `cargo test --test e2e_profile_settings` - 6 tests passed
- [x] `cargo test` - 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)