### PR TITLE
feat: チャット中の自動ページングを無効化 (Issue #249)

### DIFF
--- a/src/app/screens/chat.rs
+++ b/src/app/screens/chat.rs
@@ -134,6 +134,11 @@ impl ChatScreen {
             }
         }
 
+        // Disable auto-paging during chat to prevent "More" prompts
+        // from interrupting the message flow
+        let saved_auto_paging = ctx.auto_paging_enabled();
+        ctx.set_auto_paging(false);
+
         // Subscribe to messages
         let mut receiver = room.subscribe();
 
@@ -159,6 +164,9 @@ impl ChatScreen {
             &nickname,
         )
         .await;
+
+        // Restore auto-paging setting
+        ctx.set_auto_paging(saved_auto_paging);
 
         // Leave the room
         room.leave(&session_id).await;


### PR DESCRIPTION
## Summary
- チャットルーム入室時に自動ページングを無効化
- チャットルーム退室時にユーザー設定を復元

## Changes
- `src/app/screens/chat.rs`: `run_room`関数で自動ページングの一時無効化を実装
  - 入室時: `ctx.set_auto_paging(false)`
  - 退室時: 元の設定を復元

## Why
自動ページング機能（Issue #224）がチャット中にも動作し、一定行数ごとに「More」プロンプトで待ちが入っていた。チャットはリアルタイムでメッセージが流れるため、この動作は不適切。

## Test plan
- [x] `cargo build` - ビルド成功
- [x] `cargo test` - 全テストパス

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)