### PR TITLE
feat: ユーザー名の大文字小文字を区別しない (Issue #254)

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -363,11 +363,11 @@ mod tests {
     fn test_users_table_indexes() {
         let db = Database::open_in_memory().unwrap();
 
-        // Check indexes exist
+        // Check indexes exist (username index was renamed to idx_users_username_nocase in v21)
         let idx_username: i64 = db
             .conn()
             .query_row(
-                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_users_username'",
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_users_username_nocase'",
                 [],
                 |row| row.get(0),
             )

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -318,6 +318,35 @@ CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens(user_id);
 CREATE INDEX idx_refresh_tokens_token ON refresh_tokens(token);
 CREATE INDEX idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);
 "#,
+    // v21: Make username case-insensitive
+    // First, rename duplicates by appending _1, _2, etc. to later entries
+    // Then add a unique case-insensitive index
+    r#"
+-- Rename duplicate usernames (case-insensitive) by appending suffix
+-- Keep the first one (lowest id), rename others with _1, _2, etc.
+UPDATE users
+SET username = username || '_' || (
+    SELECT COUNT(*)
+    FROM users u2
+    WHERE LOWER(u2.username) = LOWER(users.username)
+      AND u2.id < users.id
+)
+WHERE id IN (
+    SELECT u1.id
+    FROM users u1
+    WHERE EXISTS (
+        SELECT 1 FROM users u2
+        WHERE LOWER(u2.username) = LOWER(u1.username)
+          AND u2.id < u1.id
+    )
+);
+
+-- Drop the old case-sensitive index
+DROP INDEX IF EXISTS idx_users_username;
+
+-- Create new case-insensitive unique index
+CREATE UNIQUE INDEX idx_users_username_nocase ON users(username COLLATE NOCASE);
+"#,
 ];
 
 #[cfg(test)]
@@ -347,6 +376,8 @@ mod tests {
                 migration.contains("CREATE TABLE")
                     || migration.contains("ALTER TABLE")
                     || migration.contains("CREATE INDEX")
+                    || migration.contains("UPDATE ")
+                    || migration.contains("DROP INDEX")
             );
         }
     }


### PR DESCRIPTION
## Summary

- ユーザー名検索・重複チェックをcase-insensitiveに修正
- 既存の重複ユーザー名（例: `hiroshi`と`HIROSHI`）を自動マイグレーションでリネーム
- 表示時は登録時の大文字小文字を保持

## Changes

### データベースマイグレーション (v21)
- 既存の重複ユーザー名を検出し、後から登録された方に`_1`, `_2`等のサフィックスを付加
- 古い`idx_users_username`インデックスを削除
- 新しいcase-insensitive UNIQUEインデックス `idx_users_username_nocase`を作成

### リポジトリ修正
- `get_by_username()`: `COLLATE NOCASE`を使用してcase-insensitive検索
- `username_exists()`: `COLLATE NOCASE`を使用してcase-insensitive重複チェック

### テスト追加
- `test_get_by_username_case_insensitive`: 異なる大文字小文字でユーザーを検索できることを確認
- `test_username_exists_case_insensitive`: 異なる大文字小文字で重複検出できることを確認
- `test_create_duplicate_username_different_case`: 異なる大文字小文字でのユーザー作成が拒否されることを確認

## Test plan

- [x] 単体テストがパス
- [x] `cargo test --lib`が全てパス
- [x] 手動テスト: 大文字小文字の異なるユーザー名でログイン可能なこと
- [x] 手動テスト: 大文字小文字の異なるユーザー名で重複登録が拒否されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)