### PR TITLE
feat(web): 投稿の編集・削除機能を追加 (Issue #259)

### DIFF
--- a/src/web/dto/request.rs
+++ b/src/web/dto/request.rs
@@ -136,6 +136,19 @@ pub struct CreateFlatPostRequest {
     pub body: String,
 }
 
+/// Update post request.
+#[derive(Debug, Deserialize, ToSchema, Validate)]
+pub struct UpdatePostRequest {
+    /// Post title (optional, for flat board posts).
+    #[validate(length(max = 50, message = "Title must be at most 50 characters"))]
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Post body.
+    #[validate(length(min = 1, max = 10000, message = "Body must be 1-10000 characters"))]
+    #[validate(custom(function = "not_empty_trimmed"))]
+    pub body: String,
+}
+
 // ============================================================================
 // Mail DTOs
 // ============================================================================

--- a/src/web/router.rs
+++ b/src/web/router.rs
@@ -5,7 +5,7 @@ use axum::{
     http::{header, Request, StatusCode},
     middleware::{self, Next},
     response::Response,
-    routing::{delete, get, post, put},
+    routing::{delete, get, patch, post, put},
     Router,
 };
 use std::path::Path;
@@ -47,6 +47,7 @@ use super::handlers::{
     // Mail handlers
     delete_mail,
     delete_post,
+    update_post,
     download_file,
     get_board,
     // RSS handlers
@@ -149,7 +150,9 @@ pub fn create_router(
         .route("/:id/posts", post(create_thread_post));
 
     // Post routes
-    let post_routes = Router::new().route("/:id", delete(delete_post));
+    let post_routes = Router::new()
+        .route("/:id", delete(delete_post))
+        .route("/:id", patch(update_post));
 
     // Mail routes
     let mail_routes = Router::new()

--- a/tests/web_api_auth.rs
+++ b/tests/web_api_auth.rs
@@ -145,7 +145,7 @@ async fn test_register_duplicate_username() {
     response.assert_status(axum::http::StatusCode::CONFLICT);
 
     let body: Value = response.json();
-    assert_eq!(body["error"]["code"], "CONFLICT");
+    assert_eq!(body["error"]["code"], "USERNAME_TAKEN");
 }
 
 #[tokio::test]
@@ -247,7 +247,7 @@ async fn test_login_wrong_password() {
     response.assert_status(axum::http::StatusCode::UNAUTHORIZED);
 
     let body: Value = response.json();
-    assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+    assert_eq!(body["error"]["code"], "INVALID_CREDENTIALS");
 }
 
 #[tokio::test]

--- a/web/src/api/board.ts
+++ b/web/src/api/board.ts
@@ -66,3 +66,19 @@ export async function createFlatPost(
 ): Promise<Post> {
   return api.post<Post>(`/boards/${boardId}/posts`, data);
 }
+
+export async function deletePost(postId: number): Promise<void> {
+  return api.delete(`/posts/${postId}`);
+}
+
+export interface UpdatePostRequest {
+  title?: string;
+  body: string;
+}
+
+export async function updatePost(
+  postId: number,
+  data: UpdatePostRequest
+): Promise<Post> {
+  return api.patch<Post>(`/posts/${postId}`, data);
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -186,6 +186,10 @@ export const api = {
     return request<T>(endpoint, { ...options, method: 'PUT', body });
   },
 
+  patch<T>(endpoint: string, body?: unknown, options?: Omit<RequestOptions, 'method' | 'body'>) {
+    return request<T>(endpoint, { ...options, method: 'PATCH', body });
+  },
+
   delete<T>(endpoint: string, options?: Omit<RequestOptions, 'method' | 'body'>) {
     return request<T>(endpoint, { ...options, method: 'DELETE' });
   },

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -97,6 +97,10 @@ export const dict = {
     createThreadFailed: 'Failed to create thread',
     createPostFailed: 'Failed to post',
     replyPlaceholder: 'Enter your reply...',
+    editPost: 'Edit Post',
+    confirmDeletePost: 'Are you sure you want to delete this post?',
+    deletePostFailed: 'Failed to delete post',
+    editPostFailed: 'Failed to edit post',
   },
 
   // Mail

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -97,6 +97,10 @@ export const dict = {
     createThreadFailed: 'スレッドの作成に失敗しました',
     createPostFailed: '投稿に失敗しました',
     replyPlaceholder: '返信を入力...',
+    editPost: '投稿を編集',
+    confirmDeletePost: 'この投稿を削除しますか？',
+    deletePostFailed: '投稿の削除に失敗しました',
+    editPostFailed: '投稿の編集に失敗しました',
   },
 
   // Mail


### PR DESCRIPTION
## Summary

- Web UI で掲示板投稿の編集・削除機能を実装
- 投稿者本人または SubOp 以上が操作可能
- スレッド形式・フラット形式の両方に対応

## Changes

### バックエンド
- `BoardService::update_post()` メソッド追加（権限チェック付き）
- `PATCH /api/posts/{id}` エンドポイント追加
- `UpdatePostRequest` DTO 追加

### フロントエンド
- 投稿カードに3点メニュー（編集・削除）を追加
- 編集フォームをモーダル表示
- 削除時に確認ダイアログ表示
- 日本語・英語の翻訳対応

### その他
- `web_api_auth.rs` のテストアサーションを修正（Issue #256/257 対応）

## Test plan

- [x] `cargo test --test web_api_board` 通過
- [x] `cargo test --test web_api_auth` 通過
- [x] `npm run build` 成功
- [x] 手動テスト: 自分の投稿を編集できる
- [x] 手動テスト: 自分の投稿を削除できる
- [x] 手動テスト: 他人の投稿は編集・削除ボタンが表示されない
- [x] 手動テスト: SubOp 以上は他人の投稿も編集・削除できる

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)