### PR TITLE
feat(web): BBS名をconfig.tomlから取得して表示

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,8 +99,9 @@ async fn run_server(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     if config.web.enabled {
         let web_db = Database::open(&config.database.path)?;
         let web_chat_manager = Arc::clone(&chat_manager);
-        let web_server = WebServer::from_database_with_files(&config.web, web_db, &config.files)
-            .with_chat_manager(web_chat_manager);
+        let web_server =
+            WebServer::from_database_with_configs(&config.web, web_db, &config.files, &config.bbs)
+                .with_chat_manager(web_chat_manager);
         let web_addr = web_server.addr();
 
         tokio::spawn(async move {

--- a/src/web/handlers/auth.rs
+++ b/src/web/handlers/auth.rs
@@ -38,6 +38,12 @@ pub struct AppState {
     pub max_upload_size: u64,
     /// Chat room manager.
     pub chat_manager: Option<Arc<ChatRoomManager>>,
+    /// BBS name (from config).
+    pub bbs_name: String,
+    /// BBS description (from config).
+    pub bbs_description: String,
+    /// SysOp name (from config).
+    pub sysop_name: String,
 }
 
 impl AppState {
@@ -56,7 +62,23 @@ impl AppState {
             file_storage: None,
             max_upload_size: 10 * 1024 * 1024, // 10MB default
             chat_manager: None,
+            bbs_name: "HOBBS".to_string(),
+            bbs_description: "A retro BBS system".to_string(),
+            sysop_name: "SysOp".to_string(),
         }
+    }
+
+    /// Set BBS configuration.
+    pub fn with_bbs_config(
+        mut self,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        sysop_name: impl Into<String>,
+    ) -> Self {
+        self.bbs_name = name.into();
+        self.bbs_description = description.into();
+        self.sysop_name = sysop_name.into();
+        self
     }
 
     /// Set file storage.

--- a/src/web/handlers/config.rs
+++ b/src/web/handlers/config.rs
@@ -1,0 +1,59 @@
+//! Configuration handlers.
+
+use axum::{extract::State, Json};
+use serde::Serialize;
+use std::sync::Arc;
+use utoipa::ToSchema;
+
+use super::AppState;
+use crate::web::dto::ApiResponse;
+
+/// Public site configuration response.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct SiteConfigResponse {
+    /// BBS name.
+    pub name: String,
+    /// BBS description.
+    pub description: String,
+    /// SysOp name.
+    pub sysop_name: String,
+}
+
+/// Get public site configuration.
+///
+/// Returns publicly accessible site configuration such as BBS name.
+/// This endpoint does not require authentication.
+#[utoipa::path(
+    get,
+    path = "/api/config/public",
+    tag = "Config",
+    responses(
+        (status = 200, description = "Site configuration", body = ApiResponse<SiteConfigResponse>)
+    )
+)]
+pub async fn get_public_config(
+    State(state): State<Arc<AppState>>,
+) -> Json<ApiResponse<SiteConfigResponse>> {
+    let config = SiteConfigResponse {
+        name: state.bbs_name.clone(),
+        description: state.bbs_description.clone(),
+        sysop_name: state.sysop_name.clone(),
+    };
+    Json(ApiResponse::new(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_site_config_response_serialize() {
+        let config = SiteConfigResponse {
+            name: "Test BBS".to_string(),
+            description: "A test BBS".to_string(),
+            sysop_name: "Admin".to_string(),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("Test BBS"));
+    }
+}

--- a/src/web/handlers/mod.rs
+++ b/src/web/handlers/mod.rs
@@ -3,6 +3,7 @@
 pub mod admin;
 pub mod auth;
 pub mod board;
+pub mod config;
 pub mod file;
 pub mod mail;
 pub mod rss;
@@ -11,6 +12,7 @@ pub mod user;
 pub use admin::*;
 pub use auth::*;
 pub use board::*;
+pub use config::*;
 pub use file::*;
 pub use mail::*;
 pub use rss::*;

--- a/src/web/router.rs
+++ b/src/web/router.rs
@@ -40,6 +40,8 @@ use super::handlers::{
     create_flat_post,
     create_thread,
     create_thread_post,
+    // Config handlers
+    get_public_config,
     // File handlers
     delete_file,
     // Mail handlers
@@ -231,6 +233,9 @@ pub fn create_router(
         Router::new()
     };
 
+    // Config routes (public, no auth required)
+    let config_routes = Router::new().route("/public", get(get_public_config));
+
     // API routes
     let api_routes = Router::new()
         .nest("/auth", auth_routes)
@@ -243,7 +248,8 @@ pub fn create_router(
         .nest("/folders", folder_routes)
         .nest("/files", file_routes)
         .nest("/admin", admin_routes)
-        .nest("/chat", chat_routes);
+        .nest("/chat", chat_routes)
+        .nest("/config", config_routes);
 
     // Clone for middleware closures
     let jwt_state_for_middleware = jwt_state.clone();

--- a/web/index.html
+++ b/web/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#050508" />
-    <meta name="description" content="HOBBS - Hobbyist Bulletin Board System" />
-    <title>HOBBS</title>
+    <meta name="description" content="Bulletin Board System" />
+    <title>BBS</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { type Component, Show, lazy, Suspense } from 'solid-js';
 import { Router, Route, Navigate } from '@solidjs/router';
 import { AuthProvider, useAuth } from './stores/auth';
+import { SiteConfigProvider } from './stores/siteConfig';
 import { I18nProvider } from './stores/i18n';
 import { Layout, PageLoading } from './components';
 
@@ -91,9 +92,10 @@ const PublicRoute: Component<{ children: any }> = (props) => {
 
 const App: Component = () => {
   return (
-    <I18nProvider>
-      <AuthProvider>
-        <Router>
+    <SiteConfigProvider>
+      <I18nProvider>
+        <AuthProvider>
+          <Router>
         {/* Public Routes */}
         <Route path="/login" component={() => (
           <PublicRoute>
@@ -184,9 +186,10 @@ const App: Component = () => {
 
         {/* Fallback */}
         <Route path="*" component={() => <Navigate href="/" />} />
-        </Router>
-      </AuthProvider>
-    </I18nProvider>
+          </Router>
+        </AuthProvider>
+      </I18nProvider>
+    </SiteConfigProvider>
   );
 };
 

--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -1,0 +1,15 @@
+import { api } from './client';
+
+export interface SiteConfig {
+  name: string;
+  description: string;
+  sysop_name: string;
+}
+
+/**
+ * Get public site configuration.
+ * This endpoint does not require authentication.
+ */
+export async function getPublicConfig(): Promise<SiteConfig> {
+  return api.get<SiteConfig>('/config/public', { skipAuth: true });
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,11 +1,13 @@
 import { type ParentComponent, Show } from 'solid-js';
 import { A, useLocation } from '@solidjs/router';
 import { useAuth } from '../stores/auth';
+import { useSiteConfig } from '../stores/siteConfig';
 import { useI18n } from '../stores/i18n';
 
 export const Layout: ParentComponent = (props) => {
   const { t, locale, setLocale } = useI18n();
   const [auth, { logout }] = useAuth();
+  const [siteConfig] = useSiteConfig();
   const location = useLocation();
 
   const isActive = (path: string) => location.pathname === path;
@@ -26,7 +28,7 @@ export const Layout: ParentComponent = (props) => {
           <div class="flex items-center justify-between h-16">
             {/* Logo */}
             <A href="/" class="font-display text-2xl font-bold text-neon-cyan text-neon-glow">
-              HOBBS
+              {siteConfig.config.name.split(' - ')[0] || siteConfig.config.name}
             </A>
 
             {/* Navigation */}
@@ -106,8 +108,7 @@ export const Layout: ParentComponent = (props) => {
       {/* Footer */}
       <footer class="border-t border-neon-cyan/10 py-4">
         <div class="container mx-auto px-4 text-center text-xs text-gray-600">
-          <span class="text-neon-purple/60">HOBBS</span>
-          {' '}- Hobbyist Bulletin Board System
+          <span class="text-neon-purple/60">{siteConfig.config.name}</span>
         </div>
       </footer>
     </div>

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -65,7 +65,8 @@ export const dict = {
 
   // Home
   home: {
-    welcome: 'Welcome to HOBBS',
+    welcome: 'Welcome',
+    welcomeTo: 'Welcome to ',
     welcomePrefix: 'Welcome, ',
     welcomeSuffix: '',
     boardList: 'Board List',

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -65,7 +65,8 @@ export const dict = {
 
   // Home
   home: {
-    welcome: 'Welcome to HOBBS',
+    welcome: 'ようこそ',
+    welcomeTo: 'ようこそ ',
     welcomePrefix: 'ようこそ、',
     welcomeSuffix: ' さん',
     boardList: '掲示板一覧',

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { type Component, createResource, For, Show } from 'solid-js';
 import { A } from '@solidjs/router';
 import { useAuth } from '../stores/auth';
+import { useSiteConfig } from '../stores/siteConfig';
 import { useI18n } from '../stores/i18n';
 import { PageLoading } from '../components';
 import * as boardApi from '../api/board';
@@ -9,6 +10,7 @@ import type { Board } from '../types';
 export const HomePage: Component = () => {
   const { t } = useI18n();
   const [auth] = useAuth();
+  const [siteConfig] = useSiteConfig();
 
   const [boards] = createResource(async () => {
     try {
@@ -25,7 +27,7 @@ export const HomePage: Component = () => {
         <div class="absolute inset-0 bg-gradient-to-r from-neon-purple/5 to-neon-cyan/5" />
         <div class="relative">
           <h1 class="font-display text-3xl font-bold text-neon-cyan mb-2">
-            {t('home.welcome')}
+            {t('home.welcomeTo')}{siteConfig.config.name}
           </h1>
           <p class="text-gray-400">
             {t('home.welcomePrefix')}{auth.user?.nickname || ''}{t('home.welcomeSuffix')}

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { type Component, createSignal } from 'solid-js';
 import { A, useNavigate } from '@solidjs/router';
 import { useAuth } from '../stores/auth';
+import { useSiteConfig } from '../stores/siteConfig';
 import { useI18n } from '../stores/i18n';
 import { Input, Button, Alert } from '../components';
 import { ApiError } from '../api/client';
@@ -8,6 +9,7 @@ import { ApiError } from '../api/client';
 export const LoginPage: Component = () => {
   const { t, translateError } = useI18n();
   const [, { login }] = useAuth();
+  const [siteConfig] = useSiteConfig();
   const navigate = useNavigate();
 
   const [username, setUsername] = createSignal('');
@@ -40,9 +42,9 @@ export const LoginPage: Component = () => {
         {/* Logo */}
         <div class="text-center mb-8">
           <h1 class="font-display text-4xl font-bold text-neon-cyan text-neon-glow-intense animate-pulse-neon">
-            HOBBS
+            {siteConfig.config.name.split(' - ')[0] || siteConfig.config.name}
           </h1>
-          <p class="text-gray-500 mt-2">{t('auth.subtitle')}</p>
+          <p class="text-gray-500 mt-2">{siteConfig.config.description || t('auth.subtitle')}</p>
         </div>
 
         {/* Login Form */}

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -1,6 +1,7 @@
 import { type Component, createSignal } from 'solid-js';
 import { A, useNavigate } from '@solidjs/router';
 import { useAuth } from '../stores/auth';
+import { useSiteConfig } from '../stores/siteConfig';
 import { useI18n } from '../stores/i18n';
 import { Input, Button, Alert } from '../components';
 import { ApiError } from '../api/client';
@@ -8,6 +9,7 @@ import { ApiError } from '../api/client';
 export const RegisterPage: Component = () => {
   const { t, translateError } = useI18n();
   const [, { register }] = useAuth();
+  const [siteConfig] = useSiteConfig();
   const navigate = useNavigate();
 
   const [username, setUsername] = createSignal('');
@@ -54,7 +56,7 @@ export const RegisterPage: Component = () => {
         {/* Logo */}
         <div class="text-center mb-8">
           <h1 class="font-display text-4xl font-bold text-neon-cyan text-neon-glow-intense animate-pulse-neon">
-            HOBBS
+            {siteConfig.config.name.split(' - ')[0] || siteConfig.config.name}
           </h1>
           <p class="text-gray-500 mt-2">{t('auth.register')}</p>
         </div>

--- a/web/src/stores/index.ts
+++ b/web/src/stores/index.ts
@@ -1,1 +1,2 @@
 export { AuthProvider, useAuth } from './auth.tsx';
+export { SiteConfigProvider, useSiteConfig } from './siteConfig.tsx';

--- a/web/src/stores/siteConfig.tsx
+++ b/web/src/stores/siteConfig.tsx
@@ -1,0 +1,68 @@
+import { createSignal, createContext, useContext, createEffect, type ParentComponent } from 'solid-js';
+import type { SiteConfig } from '../api/config';
+import * as configApi from '../api/config';
+
+interface SiteConfigState {
+  config: SiteConfig;
+  isLoading: boolean;
+}
+
+interface SiteConfigActions {
+  loadConfig: () => Promise<void>;
+}
+
+type SiteConfigContextValue = [SiteConfigState, SiteConfigActions];
+
+const SiteConfigContext = createContext<SiteConfigContextValue>();
+
+const DEFAULT_CONFIG: SiteConfig = {
+  name: 'HOBBS',
+  description: 'A retro BBS system',
+  sysop_name: 'SysOp',
+};
+
+export const SiteConfigProvider: ParentComponent = (props) => {
+  const [config, setConfig] = createSignal<SiteConfig | null>(null);
+  const [isLoading, setIsLoading] = createSignal(true);
+
+  const state = {
+    get config() { return config() ?? DEFAULT_CONFIG; },
+    get isLoading() { return isLoading(); },
+  };
+
+  const actions: SiteConfigActions = {
+    async loadConfig() {
+      try {
+        const siteConfig = await configApi.getPublicConfig();
+        setConfig(siteConfig);
+        // Update document title
+        document.title = siteConfig.name;
+      } catch (e) {
+        console.error('Failed to load site config:', e);
+        // Use default config on error
+        setConfig(DEFAULT_CONFIG);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+  };
+
+  // Load config on mount
+  createEffect(() => {
+    actions.loadConfig();
+  });
+
+  return (
+    <SiteConfigContext.Provider value={[state, actions]}>
+      {props.children}
+    </SiteConfigContext.Provider>
+  );
+};
+
+export function useSiteConfig(): SiteConfigContextValue {
+  const context = useContext(SiteConfigContext);
+  if (!context) {
+    throw new Error('useSiteConfig must be used within a SiteConfigProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- Web UIのタイトルやヘッダーに表示されるBBS名を`config.toml`の`[bbs]`セクションから取得するように変更
- これにより、Beryl BBSなど派生プロジェクトでconfig.tomlを変更するだけでBBS名をカスタマイズ可能に

## 変更内容

### バックエンド
- `/api/config/public` エンドポイントを追加（認証不要）
- `AppState`にBBS設定（name, description, sysop_name）を追加
- `WebServer::from_database_with_configs()`でBbsConfigを渡せるように

### フロントエンド
- `SiteConfigProvider`/`useSiteConfig`ストアを作成
- 起動時に設定を取得して`document.title`を動的に更新
- `Layout.tsx`: ヘッダー/フッターのBBS名を動的に
- `Login.tsx`/`Register.tsx`: ロゴ部分のBBS名を動的に
- `Home.tsx`: ウェルカムメッセージにBBS名を使用
- `index.html`: デフォルトタイトルを汎用的に変更

## Test plan
- [x] バックエンドビルド確認済み (cargo build)
- [x] フロントエンドビルド確認済み (npm run build)
- [x] `config.toml`のBBS名を変更してWeb UIに反映されることを確認
- [x] ログイン画面、登録画面、ホーム画面、ヘッダー、フッターにBBS名が表示されることを確認

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)