### PR TITLE
feat: 投稿本文での ^[ → ESC 変換対応 (Issue #271)

### DIFF
--- a/src/app/screens/board.rs
+++ b/src/app/screens/board.rs
@@ -11,7 +11,7 @@ use crate::board::{
 use crate::db::{Role, UserRepository};
 use crate::error::Result;
 use crate::rate_limit::RateLimitResult;
-use crate::server::TelnetSession;
+use crate::server::{convert_caret_escape, TelnetSession};
 
 /// Board screen handler.
 pub struct BoardScreen;
@@ -565,7 +565,7 @@ impl BoardScreen {
                         &format!("--- {} ({}) ---", author, post.created_at),
                     )
                     .await?;
-                    ctx.send_line(session, &post.body).await?;
+                    ctx.send_line(session, &convert_caret_escape(&post.body)).await?;
                     ctx.send_line(session, "").await?;
                 }
 
@@ -657,7 +657,7 @@ impl BoardScreen {
         )
         .await?;
         ctx.send_line(session, &"-".repeat(40)).await?;
-        ctx.send_line(session, &post.body).await?;
+        ctx.send_line(session, &convert_caret_escape(&post.body)).await?;
         ctx.send_line(session, &"-".repeat(40)).await?;
 
         // Mark this post as read for logged-in users
@@ -942,7 +942,7 @@ impl BoardScreen {
             )
             .await?;
             ctx.send_line(session, &"-".repeat(40)).await?;
-            ctx.send_line(session, &post.body).await?;
+            ctx.send_line(session, &convert_caret_escape(&post.body)).await?;
             ctx.send_line(session, &"-".repeat(40)).await?;
 
             // Mark this post as read (create repo in block to release borrow)
@@ -1107,7 +1107,7 @@ impl BoardScreen {
             )
             .await?;
             ctx.send_line(session, &"-".repeat(40)).await?;
-            ctx.send_line(session, &post.body).await?;
+            ctx.send_line(session, &convert_caret_escape(&post.body)).await?;
             ctx.send_line(session, &"-".repeat(40)).await?;
 
             // Mark this post as read (create repo in block to release borrow)

--- a/src/app/screens/mail.rs
+++ b/src/app/screens/mail.rs
@@ -8,7 +8,7 @@ use crate::db::UserRepository;
 use crate::error::Result;
 use crate::mail::{MailRepository, NewMail};
 use crate::rate_limit::RateLimitResult;
-use crate::server::TelnetSession;
+use crate::server::{convert_caret_escape, TelnetSession};
 
 /// Mail screen handler.
 pub struct MailScreen;
@@ -179,7 +179,7 @@ impl MailScreen {
         )
         .await?;
         ctx.send_line(session, &"-".repeat(40)).await?;
-        ctx.send_line(session, &mail.body).await?;
+        ctx.send_line(session, &convert_caret_escape(&mail.body)).await?;
         ctx.send_line(session, &"-".repeat(40)).await?;
 
         // Options

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,11 +10,11 @@ mod session;
 pub mod telnet;
 
 pub use encoding::{
-    convert_ansi_to_petscii_ctrl, decode_cp437, decode_from_client, decode_from_client_detailed,
-    decode_petscii, decode_shiftjis, decode_shiftjis_strict, encode_cp437, encode_for_client,
-    encode_for_client_detailed, encode_petscii, encode_shiftjis, encode_shiftjis_strict,
-    process_output_mode, strip_ansi_sequences, CharacterEncoding, DecodeResult, EncodeResult,
-    OutputMode,
+    convert_ansi_to_petscii_ctrl, convert_caret_escape, decode_cp437, decode_from_client,
+    decode_from_client_detailed, decode_petscii, decode_shiftjis, decode_shiftjis_strict,
+    encode_cp437, encode_for_client, encode_for_client_detailed, encode_petscii, encode_shiftjis,
+    encode_shiftjis_strict, process_output_mode, strip_ansi_sequences, CharacterEncoding,
+    DecodeResult, EncodeResult, OutputMode,
 };
 pub use input::{EchoMode, InputResult, LineBuffer, MultiLineBuffer};
 pub use listener::{ConnectionPermit, TelnetServer};


### PR DESCRIPTION
## Summary

- パソコン通信時代に一般的だった `^[` 記法をサポート
- 投稿本文で `^[[31m` などと入力すると、表示時にANSIエスケープシーケンスとして変換される

## 変更内容

### 新規追加
- `convert_caret_escape()` 関数を `src/server/encoding.rs` に追加
- 単体テスト5件追加

### 適用箇所
- 掲示板投稿の本文表示（4箇所）
- メール本文表示

## 使用例

```
入力: ^[[1;33mHello^[[0m
表示: Hello（黄色太字）
```

## Test plan
- [x] convert_caret_escape のユニットテスト（5件パス）
- [x] 掲示板に `^[[31mRed^[[0m` を含む投稿を作成し、赤色で表示されることを確認
- [x] メールに `^[[1;32mGreen^[[0m` を含む本文を送信し、緑色太字で表示されることを確認

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)