### PR TITLE
fix: スレッド掲示板のまとめ読みでスレッドタイトルを表示 (Issue #287)

### DIFF
--- a/src/app/screens/board.rs
+++ b/src/app/screens/board.rs
@@ -942,7 +942,17 @@ impl BoardScreen {
                     .unwrap_or_else(|| "Unknown".to_string())
             };
 
-            let title = post.title.as_deref().unwrap_or("(no title)");
+            // Get title: for thread posts, fetch thread title; for flat posts, use post title
+            let title = if let Some(thread_id) = post.thread_id {
+                let thread_repo = ThreadRepository::new(ctx.db.pool());
+                thread_repo
+                    .get_by_id(thread_id)
+                    .await?
+                    .map(|t| t.title)
+                    .unwrap_or_else(|| "(no thread)".to_string())
+            } else {
+                post.title.clone().unwrap_or_else(|| "(no title)".to_string())
+            };
 
             ctx.send_line(
                 session,
@@ -1107,7 +1117,17 @@ impl BoardScreen {
                     .unwrap_or_else(|| "Unknown".to_string())
             };
 
-            let title = post.title.as_deref().unwrap_or("(no title)");
+            // Get title: for thread posts, fetch thread title; for flat posts, use post title
+            let title = if let Some(thread_id) = post.thread_id {
+                let thread_repo = ThreadRepository::new(ctx.db.pool());
+                thread_repo
+                    .get_by_id(thread_id)
+                    .await?
+                    .map(|t| t.title)
+                    .unwrap_or_else(|| "(no thread)".to_string())
+            } else {
+                post.title.clone().unwrap_or_else(|| "(no title)".to_string())
+            };
 
             // Show board name and post info
             ctx.send_line(


### PR DESCRIPTION
## Summary

- スレッド掲示板の未読一括表示（まとめ読み）で、投稿のタイトルが「(no title)」と表示される問題を修正
- スレッド投稿の場合、そのスレッドのタイトルを取得して表示するように変更

Fixes #287

## 変更内容

`src/app/screens/board.rs` の2箇所を修正：

- `run_unread_batch_read()`: 単一掲示板のまとめ読み
- `run_all_unread_batch_read()`: 全掲示板のまとめ読み

### 変更前
```
=== [1/1] [スレッド掲示板] (no title) ===
```

### 変更後
```
=== [1/1] [スレッド掲示板] 今日の出来事 ===
```

## 実装

`post.thread_id` がある場合は `ThreadRepository::get_by_id()` でスレッドのタイトルを取得：

```rust
let title = if let Some(thread_id) = post.thread_id {
    let thread_repo = ThreadRepository::new(ctx.db.pool());
    thread_repo
        .get_by_id(thread_id)
        .await?
        .map(|t| t.title)
        .unwrap_or_else(|| "(no thread)".to_string())
} else {
    post.title.clone().unwrap_or_else(|| "(no title)".to_string())
};
```

## Test plan

- [x] `cargo build` - ビルド成功
- [x] `cargo test --lib board` - 178テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)