### PR TITLE
fix: リフレッシュトークンをハッシュ化して保存 (Issue #294)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "tempfile",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 feed-rs = "2.3"
 url = "2"
 urlencoding = "2"
+sha2 = "0.10"
 # xmodem = "0.4" # Using custom async implementation instead
 
 # Web UI

--- a/migrations/postgres/0024_invalidate_plaintext_tokens.sql
+++ b/migrations/postgres/0024_invalidate_plaintext_tokens.sql
@@ -1,0 +1,7 @@
+-- Invalidate all existing refresh tokens.
+-- This migration is required because we changed from storing plaintext tokens
+-- to storing SHA256 hashes. Existing plaintext tokens won't match the new
+-- hash-based validation, so we need to revoke them all.
+-- Users will need to re-login after this migration.
+
+UPDATE refresh_tokens SET revoked_at = TO_CHAR(NOW(), 'YYYY-MM-DD HH24:MI:SS') WHERE revoked_at IS NULL;

--- a/migrations/sqlite/0024_invalidate_plaintext_tokens.sql
+++ b/migrations/sqlite/0024_invalidate_plaintext_tokens.sql
@@ -1,0 +1,7 @@
+-- Invalidate all existing refresh tokens.
+-- This migration is required because we changed from storing plaintext tokens
+-- to storing SHA256 hashes. Existing plaintext tokens won't match the new
+-- hash-based validation, so we need to revoke them all.
+-- Users will need to re-login after this migration.
+
+UPDATE refresh_tokens SET revoked_at = datetime('now') WHERE revoked_at IS NULL;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -14,7 +14,7 @@ mod repository;
 mod user;
 
 pub use one_time_token::{NewOneTimeToken, OneTimeToken, OneTimeTokenRepository, TokenPurpose};
-pub use refresh_token::{NewRefreshToken, RefreshToken, RefreshTokenRepository};
+pub use refresh_token::{hash_token, NewRefreshToken, RefreshToken, RefreshTokenRepository};
 pub use repository::UserRepository;
 pub use user::{NewUser, Role, User, UserUpdate};
 
@@ -508,7 +508,7 @@ mod tests {
 
         // Check that migrations were applied
         let version = db.schema_version().await.unwrap();
-        assert_eq!(version as usize, 23); // 23 migrations
+        assert_eq!(version as usize, 24); // 24 migrations
     }
 
     #[tokio::test]
@@ -640,7 +640,7 @@ mod tests {
             let db = Database::open(&db_path).await.unwrap();
             assert!(db.table_exists("users").await.unwrap());
             // Migrations should not be reapplied
-            assert_eq!(db.schema_version().await.unwrap(), 23);
+            assert_eq!(db.schema_version().await.unwrap(), 24);
             db.close().await;
         }
 


### PR DESCRIPTION
## Summary

- リフレッシュトークンをSHA256でハッシュ化して保存するように変更
- データベース流出時のトークン再利用を防止

## 変更内容

### 新規追加
- `sha2` クレートを依存関係に追加
- `hash_token()` 関数を追加（SHA256ハッシュ化）
- マイグレーション `0024_invalidate_plaintext_tokens.sql`（既存トークン無効化）

### 変更
- `NewRefreshToken.token` → `NewRefreshToken.token_hash` に名称変更
- リポジトリメソッド (`get_by_token`, `get_valid_token`, `revoke`) で入力トークンを自動ハッシュ化
- auth.rs でトークン保存時に `hash_token()` を使用

## セキュリティ上の利点

- データベースが流出しても、攻撃者はハッシュ値からリフレッシュトークンを復元できない
- SHA256は高速なため検証時のパフォーマンス影響は軽微

## 破壊的変更

- 既存のリフレッシュトークンはマイグレーションで無効化される
- ユーザーは再ログインが必要

## Test plan

- [x] 全テスト通過（1346件）
- [x] `test_hash_token` でハッシュの一貫性と形式を検証
- [x] 実際のログイン・トークンリフレッシュが動作することを確認
- [x] 既存セッションが無効化されることを確認

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)