### PR TITLE
fix: Docker Composeの開発用資格情報を環境変数化 (Issue #296)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# ============================================================
+# HOBBS Docker Environment Variables
+# ============================================================
+# Copy this file to .env and customize the values.
+# このファイルを.envにコピーして値をカスタマイズしてください。
+#
+# WARNING: Never commit .env to version control!
+# 警告: .envファイルをバージョン管理にコミットしないでください！
+# ============================================================
+
+# PostgreSQL (Development)
+POSTGRES_USER=hobbs
+POSTGRES_PASSWORD=change_me_to_secure_password
+POSTGRES_DB=hobbs
+
+# PostgreSQL (Test)
+POSTGRES_TEST_USER=hobbs
+POSTGRES_TEST_PASSWORD=change_me_to_secure_password
+POSTGRES_TEST_DB=hobbs_test

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ data/
 # Local configuration overrides
 config.local.toml
 
+# Environment variables (Docker, etc.)
+.env
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,19 @@
+# ============================================================
+# WARNING: 開発環境専用 / FOR DEVELOPMENT ONLY
+# ============================================================
+# このdocker-compose.ymlは開発・テスト用です。
+# 本番環境では使用しないでください。
+#
+# This docker-compose.yml is for development and testing only.
+# DO NOT use in production environments.
+#
+# 資格情報を変更する場合は.envファイルを作成してください:
+# To customize credentials, create a .env file:
+#   POSTGRES_USER=your_user
+#   POSTGRES_PASSWORD=your_secure_password
+#   POSTGRES_DB=your_database
+# ============================================================
+
 version: '3.8'
 
 services:
@@ -5,15 +21,16 @@ services:
     image: postgres:16-alpine
     container_name: hobbs-postgres
     environment:
-      POSTGRES_USER: hobbs
-      POSTGRES_PASSWORD: hobbs_password
-      POSTGRES_DB: hobbs
+      POSTGRES_USER: ${POSTGRES_USER:-hobbs}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-hobbs_dev_password}
+      POSTGRES_DB: ${POSTGRES_DB:-hobbs}
     ports:
-      - "5433:5432"
+      # Bind to localhost only to prevent external access
+      - "127.0.0.1:5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U hobbs -d hobbs"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-hobbs} -d ${POSTGRES_DB:-hobbs}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -22,13 +39,14 @@ services:
     image: postgres:16-alpine
     container_name: hobbs-postgres-test
     environment:
-      POSTGRES_USER: hobbs
-      POSTGRES_PASSWORD: hobbs
-      POSTGRES_DB: hobbs_test
+      POSTGRES_USER: ${POSTGRES_TEST_USER:-hobbs}
+      POSTGRES_PASSWORD: ${POSTGRES_TEST_PASSWORD:-hobbs_test_password}
+      POSTGRES_DB: ${POSTGRES_TEST_DB:-hobbs_test}
     ports:
-      - "5434:5432"
+      # Bind to localhost only to prevent external access
+      - "127.0.0.1:5434:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U hobbs -d hobbs_test"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_TEST_USER:-hobbs} -d ${POSTGRES_TEST_DB:-hobbs_test}"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

- Docker Compose設定のセキュリティを強化
- 資格情報の環境変数化とポートバインドの制限

## 変更内容

### docker-compose.yml
- 資格情報を環境変数で上書き可能に（`${VAR:-default}` 形式）
- ポートを `127.0.0.1` にバインド（外部アクセス防止）
- 開発環境専用であることを示す警告コメントを追加（日英両言語）

### 新規ファイル
- `.env.example` - 環境変数の設定例

### .gitignore
- `.env` を追加（資格情報の誤コミット防止）

## 使用方法

```bash
# .envファイルを作成（オプション）
cp .env.example .env
# 必要に応じて.envの値を編集

# Docker Composeを起動
docker-compose up -d
```

## Test plan

- [x] `docker-compose up -d` でPostgreSQLが起動することを確認
- [x] `.env` ファイルで資格情報を上書きできることを確認
- [x] 外部からポート5433/5434にアクセスできないことを確認

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)