### PR TITLE
feat: Telnet有効時にパスワード警告を表示

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -68,6 +68,7 @@ account_disabled = "This account has been disabled."
 
 [register]
 title = "=== Registration ==="
+password_warning = "[WARNING] Telnet transmits passwords unencrypted. NEVER use the same password as other services."
 username = "Username"
 password = "Password"
 confirm_password = "Confirm Password"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -71,6 +71,7 @@ account_disabled = "This account has been disabled."
 
 [register]
 title = "=== 新規登録 ==="
+password_warning = "【警告】Telnet接続ではパスワードは暗号化されません。他のサービスと同じパスワードは絶対に使用しないでください。"
 username = "ユーザーID"
 password = "パスワード"
 confirm_password = "パスワード（確認）"

--- a/src/app/session_handler.rs
+++ b/src/app/session_handler.rs
@@ -574,6 +574,12 @@ Select language / Gengo sentaku:
         self.send_line(session, self.i18n.t("register.title"))
             .await?;
 
+        // Show password warning for Telnet connections
+        self.send_line(session, "").await?;
+        self.send_line(session, self.i18n.t("register.password_warning"))
+            .await?;
+        self.send_line(session, "").await?;
+
         // Get username
         self.send(session, &format!("{}: ", self.i18n.t("register.username")))
             .await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,9 @@ use crate::{HobbsError, Result};
 /// Server configuration.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ServerConfig {
+    /// Whether Telnet server is enabled.
+    #[serde(default = "default_telnet_enabled")]
+    pub enabled: bool,
     /// Host address to bind.
     #[serde(default = "default_host")]
     pub host: String,
@@ -29,6 +32,10 @@ pub struct ServerConfig {
     /// Timezone for displaying dates (e.g., "Asia/Tokyo", "UTC").
     #[serde(default = "default_timezone")]
     pub timezone: String,
+}
+
+fn default_telnet_enabled() -> bool {
+    true
 }
 
 fn default_host() -> String {
@@ -62,6 +69,7 @@ fn default_timezone() -> String {
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
+            enabled: default_telnet_enabled(),
             host: default_host(),
             port: default_port(),
             max_connections: default_max_connections(),
@@ -737,6 +745,7 @@ mod tests {
     fn test_default_config() {
         let config = Config::default();
 
+        assert!(config.server.enabled);
         assert_eq!(config.server.host, "0.0.0.0");
         assert_eq!(config.server.port, 2323);
         assert_eq!(config.server.max_connections, 20);

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,7 @@ async fn run_server(config: Config) -> Result<(), Box<dyn std::error::Error>> {
                     web_db,
                     &config.files,
                     &config.bbs,
+                    config.server.enabled,
                 )
                 .with_chat_manager(web_chat_manager);
                 let web_addr = web_server.addr();

--- a/src/server/listener.rs
+++ b/src/server/listener.rs
@@ -116,6 +116,7 @@ mod tests {
 
     fn test_config(port: u16, max_connections: usize) -> ServerConfig {
         ServerConfig {
+            enabled: true,
             host: "127.0.0.1".to_string(),
             port,
             max_connections,

--- a/src/web/handlers/auth.rs
+++ b/src/web/handlers/auth.rs
@@ -47,6 +47,8 @@ pub struct AppState {
     pub bbs_description: String,
     /// SysOp name (from config).
     pub sysop_name: String,
+    /// Whether Telnet server is enabled.
+    pub telnet_enabled: bool,
 }
 
 impl AppState {
@@ -68,6 +70,7 @@ impl AppState {
             bbs_name: "HOBBS".to_string(),
             bbs_description: "A retro BBS system".to_string(),
             sysop_name: "SysOp".to_string(),
+            telnet_enabled: true, // Default to true
         }
     }
 
@@ -94,6 +97,12 @@ impl AppState {
     /// Set chat room manager.
     pub fn with_chat_manager(mut self, chat_manager: Arc<ChatRoomManager>) -> Self {
         self.chat_manager = Some(chat_manager);
+        self
+    }
+
+    /// Set telnet enabled flag.
+    pub fn with_telnet_enabled(mut self, enabled: bool) -> Self {
+        self.telnet_enabled = enabled;
         self
     }
 

--- a/src/web/handlers/config.rs
+++ b/src/web/handlers/config.rs
@@ -17,6 +17,8 @@ pub struct SiteConfigResponse {
     pub description: String,
     /// SysOp name.
     pub sysop_name: String,
+    /// Whether Telnet server is enabled.
+    pub telnet_enabled: bool,
 }
 
 /// Get public site configuration.
@@ -38,6 +40,7 @@ pub async fn get_public_config(
         name: state.bbs_name.clone(),
         description: state.bbs_description.clone(),
         sysop_name: state.sysop_name.clone(),
+        telnet_enabled: state.telnet_enabled,
     };
     Json(ApiResponse::new(config))
 }
@@ -52,8 +55,10 @@ mod tests {
             name: "Test BBS".to_string(),
             description: "A test BBS".to_string(),
             sysop_name: "Admin".to_string(),
+            telnet_enabled: true,
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("Test BBS"));
+        assert!(json.contains("telnet_enabled"));
     }
 }

--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -38,6 +38,7 @@ impl WebServer {
         db: SharedDatabase,
         files_config: Option<&FilesConfig>,
         bbs_config: Option<&BbsConfig>,
+        telnet_enabled: bool,
     ) -> Self {
         let addr = format!("{}:{}", config.host, config.port)
             .parse()
@@ -48,7 +49,8 @@ impl WebServer {
             &config.jwt_secret,
             config.jwt_access_token_expiry_secs,
             config.jwt_refresh_token_expiry_days,
-        );
+        )
+        .with_telnet_enabled(telnet_enabled);
 
         // Apply BBS config if provided
         if let Some(bbs) = bbs_config {
@@ -90,7 +92,7 @@ impl WebServer {
 
     /// Create a new web server from a raw Database.
     pub fn from_database(config: &WebConfig, db: Database) -> Self {
-        Self::new(config, Arc::new(db), None, None)
+        Self::new(config, Arc::new(db), None, None, true)
     }
 
     /// Create a new web server from a raw Database with files config.
@@ -99,7 +101,7 @@ impl WebServer {
         db: Database,
         files_config: &FilesConfig,
     ) -> Self {
-        Self::new(config, Arc::new(db), Some(files_config), None)
+        Self::new(config, Arc::new(db), Some(files_config), None, true)
     }
 
     /// Create a new web server from a raw Database with files and BBS config.
@@ -108,12 +110,14 @@ impl WebServer {
         db: Database,
         files_config: &FilesConfig,
         bbs_config: &BbsConfig,
+        telnet_enabled: bool,
     ) -> Self {
         Self::new(
             config,
             Arc::new(db),
             Some(files_config),
             Some(bbs_config),
+            telnet_enabled,
         )
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -396,6 +396,7 @@ impl TestServer {
 
         // Bind server to a random port first to get the address
         let server_config = ServerConfig {
+            enabled: true,
             host: "127.0.0.1".to_string(),
             port: 0, // Let OS assign a port
             max_connections: 10,
@@ -531,6 +532,7 @@ impl Drop for TestServer {
 pub fn test_config() -> Config {
     Config {
         server: ServerConfig {
+            enabled: true,
             host: "127.0.0.1".to_string(),
             port: 0,
             max_connections: 10,

--- a/tests/server_integration.rs
+++ b/tests/server_integration.rs
@@ -8,6 +8,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 fn test_config(port: u16, max_connections: usize) -> ServerConfig {
     ServerConfig {
+        enabled: true,
         host: "127.0.0.1".to_string(),
         port,
         max_connections,

--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -4,6 +4,7 @@ export interface SiteConfig {
   name: string;
   description: string;
   sysop_name: string;
+  telnet_enabled: boolean;
 }
 
 /**

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -61,6 +61,7 @@ export const dict = {
     hasAccount: 'Already have an account?',
     loginHere: 'Login',
     subtitle: 'Powered by HOBBS',
+    telnetPasswordWarning: 'Warning: This BBS supports Telnet (plaintext) connections. Your password may be transmitted unencrypted over the network. NEVER use the same password as other services.',
   },
 
   // Home

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -61,6 +61,7 @@ export const dict = {
     hasAccount: 'すでにアカウントをお持ちの方は',
     loginHere: 'ログイン',
     subtitle: 'Powered by HOBBS',
+    telnetPasswordWarning: '警告: このBBSはTelnet（平文）接続に対応しています。パスワードは暗号化されずにネットワーク上を流れる可能性があります。他のサービスと同じパスワードは絶対に使用しないでください。',
   },
 
   // Home

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -65,6 +65,15 @@ export const RegisterPage: Component = () => {
         <div class="card">
           <h2 class="text-xl font-medium text-neon-cyan mb-6">{t('auth.createAccount')}</h2>
 
+          {/* Telnet Password Warning */}
+          {siteConfig.config.telnet_enabled && (
+            <div class="mb-4">
+              <Alert type="warning">
+                {t('auth.telnetPasswordWarning')}
+              </Alert>
+            </div>
+          )}
+
           {error() && (
             <div class="mb-4">
               <Alert type="error" onClose={() => setError('')}>

--- a/web/src/stores/siteConfig.tsx
+++ b/web/src/stores/siteConfig.tsx
@@ -19,6 +19,7 @@ const DEFAULT_CONFIG: SiteConfig = {
   name: 'HOBBS',
   description: 'A retro BBS system',
   sysop_name: 'SysOp',
+  telnet_enabled: true,
 };
 
 export const SiteConfigProvider: ParentComponent = (props) => {


### PR DESCRIPTION
## Summary
- Telnet接続が有効な場合、新規登録時にパスワードセキュリティ警告を表示
- Web UIとTelnet両方の登録フローで警告を表示
- ServerConfigに`enabled`フラグを追加し、telnet_enabledをAPIで公開

## Changes
- `config.rs`: `ServerConfig.enabled` フラグ追加（デフォルト: true）
- `auth.rs`: `AppState.telnet_enabled` フィールド追加
- `config.rs` (handlers): `SiteConfigResponse.telnet_enabled` 追加
- `server.rs`: `telnet_enabled` パラメータをWebServerに追加
- `main.rs`: telnet_enabledをWebServerに渡す
- `session_handler.rs`: Telnet登録時に警告メッセージを表示
- Web UI: Register.tsxで警告バナーを表示
- locales: 日英の警告文を追加

## 警告メッセージ
- 日本語: 「警告: このBBSはTelnet（平文）接続に対応しています。パスワードは暗号化されずにネットワーク上を流れる可能性があります。他のサービスと同じパスワードは絶対に使用しないでください。」
- English: "Warning: This BBS supports Telnet (plaintext) connections. Your password may be transmitted unencrypted over the network. NEVER use the same password as other services."

## Test plan
- [x] `cargo test --lib site_config` - SiteConfigResponse のシリアライズテスト合格
- [x] `cargo check` - ビルド成功
- [x] フロントエンドビルド成功 (`npm run build`)
- [x] Telnet接続で新規登録時に警告が表示されることを確認
- [x] Web UIで新規登録画面に警告バナーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)