### PR TITLE
feat: Web UIゲストブラウズ機能

### DIFF
--- a/src/web/dto/response.rs
+++ b/src/web/dto/response.rs
@@ -167,6 +167,8 @@ pub struct ThreadResponse {
     pub author: AuthorInfo,
     /// Number of posts.
     pub post_count: i32,
+    /// Whether user can write to this thread's board.
+    pub can_write: bool,
     /// Creation timestamp.
     pub created_at: String,
     /// Last update timestamp.

--- a/src/web/handlers/board.rs
+++ b/src/web/handlers/board.rs
@@ -162,7 +162,7 @@ pub async fn list_threads(
 
     let (offset, limit) = pagination.to_offset_limit();
 
-    let (_board, threads, total) = {
+    let (board, threads, total) = {
         let board_repo = BoardRepository::new(state.db.pool());
         let thread_repo = ThreadRepository::new(state.db.pool());
 
@@ -227,6 +227,7 @@ pub async fn list_threads(
                 title: t.title,
                 author,
                 post_count: t.post_count,
+                can_write: board.can_write(user_role),
                 created_at: to_rfc3339(&t.created_at),
                 updated_at: to_rfc3339(&t.updated_at),
             });
@@ -351,6 +352,7 @@ pub async fn create_thread(
         title: thread.title,
         author,
         post_count: thread.post_count,
+        can_write: true, // User has write permission (checked above)
         created_at: to_rfc3339(&thread.created_at),
         updated_at: to_rfc3339(&thread.updated_at),
     };
@@ -592,7 +594,7 @@ pub async fn get_thread(
         .map(|c| Role::from_str(&c.role).unwrap_or(Role::Guest))
         .unwrap_or(Role::Guest);
 
-    let (thread, author) = {
+    let (thread, author, can_write) = {
         let thread_repo = ThreadRepository::new(state.db.pool());
         let board_repo = BoardRepository::new(state.db.pool());
         let user_repo = UserRepository::new(state.db.pool());
@@ -620,6 +622,8 @@ pub async fn get_thread(
             return Err(ApiError::forbidden("Access denied"));
         }
 
+        let can_write = board.can_write(user_role);
+
         let author = user_repo
             .get_by_id(thread.author_id)
             .await
@@ -636,7 +640,7 @@ pub async fn get_thread(
                 nickname: "Unknown".to_string(),
             });
 
-        (thread, author)
+        (thread, author, can_write)
     };
 
     let response = ThreadResponse {
@@ -645,6 +649,7 @@ pub async fn get_thread(
         title: thread.title,
         author,
         post_count: thread.post_count,
+        can_write,
         created_at: to_rfc3339(&thread.created_at),
         updated_at: to_rfc3339(&thread.updated_at),
     };
@@ -1063,10 +1068,19 @@ pub async fn update_thread(
             })?
     };
 
-    // Fetch author info
-    let author = {
+    // Fetch author info and board for can_write
+    let (author, can_write) = {
         let user_repo = UserRepository::new(state.db.pool());
-        user_repo.get_by_id(thread.author_id).await.ok().flatten()
+        let board_repo = BoardRepository::new(state.db.pool());
+        let author = user_repo.get_by_id(thread.author_id).await.ok().flatten();
+        let can_write = board_repo
+            .get_by_id(thread.board_id)
+            .await
+            .ok()
+            .flatten()
+            .map(|b| b.can_write(user_role))
+            .unwrap_or(false);
+        (author, can_write)
     };
 
     let response = ThreadResponse {
@@ -1085,6 +1099,7 @@ pub async fn update_thread(
                 nickname: "Unknown".to_string(),
             }),
         post_count: thread.post_count,
+        can_write,
         created_at: to_rfc3339(&thread.created_at),
         updated_at: to_rfc3339(&thread.updated_at),
     };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -90,6 +90,24 @@ const PublicRoute: Component<{ children: any }> = (props) => {
   );
 };
 
+// Guest-allowed route wrapper (accessible without login)
+const GuestAllowedRoute: Component<{ children: any }> = (props) => {
+  const [auth] = useAuth();
+
+  return (
+    <Show
+      when={!auth.isLoading}
+      fallback={<PageLoading />}
+    >
+      <Layout>
+        <Suspense fallback={<PageLoading />}>
+          {props.children}
+        </Suspense>
+      </Layout>
+    </Show>
+  );
+};
+
 const App: Component = () => {
   return (
     <SiteConfigProvider>
@@ -115,19 +133,19 @@ const App: Component = () => {
           </ProtectedRoute>
         )} />
         <Route path="/boards" component={() => (
-          <ProtectedRoute>
+          <GuestAllowedRoute>
             <BoardsPage />
-          </ProtectedRoute>
+          </GuestAllowedRoute>
         )} />
         <Route path="/boards/:id" component={() => (
-          <ProtectedRoute>
+          <GuestAllowedRoute>
             <BoardDetailPage />
-          </ProtectedRoute>
+          </GuestAllowedRoute>
         )} />
         <Route path="/threads/:id" component={() => (
-          <ProtectedRoute>
+          <GuestAllowedRoute>
             <ThreadDetailPage />
-          </ProtectedRoute>
+          </GuestAllowedRoute>
         )} />
         <Route path="/mail" component={() => (
           <ProtectedRoute>
@@ -185,7 +203,14 @@ const App: Component = () => {
         )} />
 
         {/* Fallback */}
-        <Route path="*" component={() => <Navigate href="/" />} />
+        <Route path="*" component={() => {
+          const [auth] = useAuth();
+          return (
+            <Show when={!auth.isLoading}>
+              <Navigate href={auth.isAuthenticated ? "/" : "/boards"} />
+            </Show>
+          );
+        }} />
           </Router>
         </AuthProvider>
       </I18nProvider>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -27,22 +27,22 @@ export const Layout: ParentComponent = (props) => {
         <div class="container mx-auto px-4">
           <div class="flex items-center justify-between h-16">
             {/* Logo */}
-            <A href="/" class="font-display text-2xl font-bold text-neon-cyan text-neon-glow">
+            <A href={auth.isAuthenticated ? "/" : "/boards"} class="font-display text-2xl font-bold text-neon-cyan text-neon-glow">
               {siteConfig.config.name.split(' - ')[0] || siteConfig.config.name}
             </A>
 
             {/* Navigation */}
-            <Show when={auth.isAuthenticated}>
-              <nav class="hidden md:flex items-center space-x-1">
-                <NavLink href="/boards" active={isActive('/boards')}>{t('nav.boards')}</NavLink>
+            <nav class="hidden md:flex items-center space-x-1">
+              <NavLink href="/boards" active={isActive('/boards')}>{t('nav.boards')}</NavLink>
+              <Show when={auth.isAuthenticated}>
                 <NavLink href="/mail" active={isActive('/mail')}>{t('nav.mail')}</NavLink>
                 <NavLink href="/chat" active={isActive('/chat')}>{t('nav.chat')}</NavLink>
                 <NavLink href="/files" active={isActive('/files')}>{t('nav.files')}</NavLink>
                 <Show when={auth.user?.role === 'sysop' || auth.user?.role === 'subop'}>
                   <NavLink href="/admin" active={isActive('/admin')}>{t('nav.admin')}</NavLink>
                 </Show>
-              </nav>
-            </Show>
+              </Show>
+            </nav>
 
             {/* User Info */}
             <div class="flex items-center space-x-4">
@@ -57,9 +57,14 @@ export const Layout: ParentComponent = (props) => {
               <Show
                 when={auth.isAuthenticated}
                 fallback={
-                  <A href="/login" class="btn-primary text-sm">
-                    {t('nav.login')}
-                  </A>
+                  <div class="flex items-center space-x-2">
+                    <A href="/login" class="btn-primary text-sm">
+                      {t('nav.login')}
+                    </A>
+                    <A href="/register" class="text-sm text-gray-400 hover:text-neon-cyan transition-colors">
+                      {t('auth.register')}
+                    </A>
+                  </div>
                 }
               >
                 <div class="flex items-center space-x-3">
@@ -86,17 +91,17 @@ export const Layout: ParentComponent = (props) => {
           </div>
 
           {/* Mobile Navigation */}
-          <Show when={auth.isAuthenticated}>
-            <nav class="md:hidden flex items-center space-x-1 pb-3 overflow-x-auto">
-              <NavLink href="/boards" active={isActive('/boards')}>{t('nav.boards')}</NavLink>
+          <nav class="md:hidden flex items-center space-x-1 pb-3 overflow-x-auto">
+            <NavLink href="/boards" active={isActive('/boards')}>{t('nav.boards')}</NavLink>
+            <Show when={auth.isAuthenticated}>
               <NavLink href="/mail" active={isActive('/mail')}>{t('nav.mail')}</NavLink>
               <NavLink href="/chat" active={isActive('/chat')}>{t('nav.chat')}</NavLink>
               <NavLink href="/files" active={isActive('/files')}>{t('nav.files')}</NavLink>
               <Show when={auth.user?.role === 'sysop' || auth.user?.role === 'subop'}>
                 <NavLink href="/admin" active={isActive('/admin')}>{t('nav.admin')}</NavLink>
               </Show>
-            </nav>
-          </Show>
+            </Show>
+          </nav>
         </div>
       </header>
 

--- a/web/src/components/UserLink.tsx
+++ b/web/src/components/UserLink.tsx
@@ -1,5 +1,6 @@
-import { type Component } from 'solid-js';
+import { type Component, Show } from 'solid-js';
 import { A } from '@solidjs/router';
+import { useAuth } from '../stores/auth';
 
 export interface UserLinkProps {
   /** Username to link to */
@@ -12,18 +13,27 @@ export interface UserLinkProps {
 
 /**
  * UserLink component - Creates a link to a user's profile page.
+ * When the user is not authenticated, displays as plain text instead.
  *
  * @example
  * <UserLink username="john" />
  * <UserLink username="john" displayName="John Doe" />
  */
 export const UserLink: Component<UserLinkProps> = (props) => {
+  const [auth] = useAuth();
+
   return (
-    <A
-      href={`/users/${encodeURIComponent(props.username)}`}
-      class={`text-neon-cyan hover:text-neon-pink transition-colors ${props.class || ''}`}
-    >
-      {props.displayName || props.username}
-    </A>
+    <Show when={auth.isAuthenticated} fallback={
+      <span class={`text-neon-cyan ${props.class || ''}`}>
+        {props.displayName || props.username}
+      </span>
+    }>
+      <A
+        href={`/users/${encodeURIComponent(props.username)}`}
+        class={`text-neon-cyan hover:text-neon-pink transition-colors ${props.class || ''}`}
+      >
+        {props.displayName || props.username}
+      </A>
+    </Show>
   );
 };

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -62,6 +62,7 @@ export const dict = {
     loginHere: 'Login',
     subtitle: 'Powered by HOBBS',
     telnetPasswordWarning: 'Warning: This BBS supports Telnet (plaintext) connections. Your password may be transmitted unencrypted over the network. NEVER use the same password as other services.',
+    guestBrowse: 'Browse as Guest',
   },
 
   // Home
@@ -107,6 +108,7 @@ export const dict = {
     editThreadFailed: 'Failed to edit thread',
     confirmDeleteThread: 'Are you sure you want to delete this thread?',
     deleteThreadFailed: 'Failed to delete thread',
+    loginToReply: 'Please login to post',
   },
 
   // Mail

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -62,6 +62,7 @@ export const dict = {
     loginHere: 'ログイン',
     subtitle: 'Powered by HOBBS',
     telnetPasswordWarning: '警告: このBBSはTelnet（平文）接続に対応しています。パスワードは暗号化されずにネットワーク上を流れる可能性があります。他のサービスと同じパスワードは絶対に使用しないでください。',
+    guestBrowse: 'ゲストとして閲覧',
   },
 
   // Home
@@ -107,6 +108,7 @@ export const dict = {
     editThreadFailed: 'スレッドの編集に失敗しました',
     confirmDeleteThread: 'このスレッドを削除しますか？',
     deleteThreadFailed: 'スレッドの削除に失敗しました',
+    loginToReply: '投稿するにはログインしてください',
   },
 
   // Mail

--- a/web/src/pages/Boards.tsx
+++ b/web/src/pages/Boards.tsx
@@ -75,7 +75,9 @@ export const BoardDetailPage: Component = () => {
     return isAuthor || isAdmin;
   };
 
-  const [board] = createResource(boardId, boardApi.getBoard);
+  const [board] = createResource(boardId, (id) =>
+    boardApi.getBoard(id).catch(() => null)
+  );
 
   // スレッド形式の掲示板用
   const [threads, { refetch: refetchThreads }] = createResource(
@@ -122,7 +124,15 @@ export const BoardDetailPage: Component = () => {
 
   return (
     <div class="space-y-6">
-      <Show when={!board.loading && board()} fallback={<PageLoading />}>
+      <Show when={!board.loading} fallback={<PageLoading />}>
+      <Show when={board()} fallback={
+        <div class="space-y-4">
+          <div class="flex items-center space-x-2 text-sm text-gray-500 mb-2">
+            <A href="/boards" class="hover:text-neon-cyan transition-colors">{t('boards.title')}</A>
+          </div>
+          <Alert type="error">{t('errors.notFound')}</Alert>
+        </div>
+      }>
         {/* Header */}
         <div class="flex items-center justify-between">
           <div>
@@ -325,6 +335,7 @@ export const BoardDetailPage: Component = () => {
           </Show>
         </Modal>
       </Show>
+      </Show>
     </div>
   );
 };
@@ -354,10 +365,12 @@ export const ThreadDetailPage: Component = () => {
     return isAuthor || isAdmin;
   };
 
-  const [thread, { refetch: refetchThread }] = createResource(threadId, boardApi.getThread);
+  const [thread, { refetch: refetchThread }] = createResource(threadId, (id) =>
+    boardApi.getThread(id).catch(() => null)
+  );
 
   const [posts, { refetch }] = createResource(
-    () => ({ threadId: threadId(), page: page() }),
+    () => thread() ? { threadId: threadId(), page: page() } : null,
     ({ threadId, page }) => boardApi.getPosts(threadId, { page, per_page: 50 })
   );
 
@@ -391,7 +404,15 @@ export const ThreadDetailPage: Component = () => {
 
   return (
     <div class="space-y-6">
-      <Show when={!thread.loading && thread()} fallback={<PageLoading />}>
+      <Show when={!thread.loading} fallback={<PageLoading />}>
+      <Show when={thread()} fallback={
+        <div class="space-y-4">
+          <div class="flex items-center space-x-2 text-sm text-gray-500 mb-2">
+            <A href="/boards" class="hover:text-neon-cyan transition-colors">{t('boards.title')}</A>
+          </div>
+          <Alert type="error">{t('errors.notFound')}</Alert>
+        </div>
+      }>
         {/* Header */}
         <div>
           <div class="flex items-center space-x-2 text-sm text-gray-500 mb-2">
@@ -428,13 +449,22 @@ export const ThreadDetailPage: Component = () => {
         {/* Posts */}
         <Show when={!posts.loading} fallback={<PageLoading />}>
           {/* Reply Form */}
-          <div class="card">
-            <h3 class="text-lg font-medium text-neon-cyan mb-4">{t('boards.reply')}</h3>
-            <ReplyForm
-              threadId={threadId()}
-              onSuccess={handlePostCreated}
-            />
-          </div>
+          <Show when={thread()?.can_write} fallback={
+            <Show when={!auth.isAuthenticated}>
+              <div class="card text-center py-4">
+                <p class="text-gray-400 mb-2">{t('boards.loginToReply')}</p>
+                <A href="/login" class="text-neon-cyan hover:text-neon-cyan/80">{t('auth.login')}</A>
+              </div>
+            </Show>
+          }>
+            <div class="card">
+              <h3 class="text-lg font-medium text-neon-cyan mb-4">{t('boards.reply')}</h3>
+              <ReplyForm
+                threadId={threadId()}
+                onSuccess={handlePostCreated}
+              />
+            </div>
+          </Show>
 
           <Show when={posts()}>
             <Pagination
@@ -520,6 +550,7 @@ export const ThreadDetailPage: Component = () => {
             )}
           </Show>
         </Modal>
+      </Show>
       </Show>
     </div>
   );

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -94,6 +94,12 @@ export const LoginPage: Component = () => {
               {t('auth.registerHere')}
             </A>
           </div>
+
+          <div class="mt-4 text-center">
+            <A href="/boards" class="text-sm text-gray-400 hover:text-neon-cyan transition-colors">
+              {t('auth.guestBrowse')}
+            </A>
+          </div>
         </div>
 
         {/* Decorative Element */}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -91,6 +91,7 @@ export interface Thread {
   title: string;
   author: AuthorInfo;
   post_count: number;
+  can_write: boolean;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

- ログインせずに掲示板（一覧・詳細・スレッド）を閲覧できるようにした
- ログインページに「ゲストとして閲覧」リンクを追加
- `ThreadResponse` に `can_write` フィールドを追加し、返信フォームの表示を権限に基づいて制御
- 存在しない掲示板/スレッドURLでのエラー表示を追加（無限ローディング防止）

### バックエンド変更
| ファイル | 変更内容 |
|---------|---------|
| `src/web/dto/response.rs` | `ThreadResponse` に `can_write: bool` 追加 |
| `src/web/handlers/board.rs` | `list_threads`, `create_thread`, `get_thread`, `update_thread` の4箇所で `can_write` を設定 |

### フロントエンド変更
| ファイル | 変更内容 |
|---------|---------|
| `web/src/App.tsx` | `GuestAllowedRoute` 追加、掲示板ルート切り替え、フォールバック条件分岐 |
| `web/src/pages/Login.tsx` | 「ゲストとして閲覧」リンク追加 |
| `web/src/components/Layout.tsx` | ロゴリンク条件分岐、掲示板ナビ常時表示、ゲスト向けログイン/登録ボタン |
| `web/src/pages/Boards.tsx` | 返信フォームを `can_write` で制御、404/403時のエラー表示 |
| `web/src/components/UserLink.tsx` | 未認証時はプレーンテキスト表示 |
| `web/src/locales/ja.ts` / `en.ts` | `guestBrowse`, `loginToReply` 翻訳キー追加 |
| `web/src/types/index.ts` | `Thread` 型に `can_write` 追加 |

## Test plan

- [x] ログインページに「ゲストとして閲覧」リンクが表示される
- [x] 未ログイン状態で `/boards` にアクセス → 掲示板一覧が表示される
- [x] 掲示板詳細・スレッド詳細も未ログインで閲覧可能
- [x] ゲスト状態で「新規スレッド」「新規投稿」ボタンが表示されない
- [x] スレッド詳細で返信フォームの代わりに「投稿するにはログインしてください」が表示される
- [x] ナビバーに「掲示板」リンクが常時表示、「メール」「チャット」等は認証時のみ
- [x] ロゴクリックで未認証時は `/boards`、認証時は `/` に遷移
- [x] 投稿者名がゲスト時はプレーンテキスト、ログイン時はプロフィールリンク
- [x] 存在しないURLにアクセス → 未認証時は `/boards`、認証時は `/` にリダイレクト
- [x] 存在しない掲示板/スレッドURLでエラーメッセージが表示される（無限ローディングにならない）
- [x] ログイン済みユーザーは従来通りすべて利用可能
- [x] `cargo build` / `cargo test --test web_api_board` 通過
- [x] `npm run build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)